### PR TITLE
Feat: Add Domain Counts to VSCode Project State

### DIFF
--- a/src/appMapService.ts
+++ b/src/appMapService.ts
@@ -5,6 +5,7 @@ import { FindingsService } from './findingsService';
 import { AppMapConfigWatcher } from './services/appMapConfigWatcher';
 import { AppmapUptodateService } from './services/appmapUptodateService';
 import Command from './services/command';
+import ProjectStateService, { ProjectStateServiceInstance } from './services/projectStateService';
 import { SourceFileWatcher } from './services/sourceFileWatcher';
 import { WorkspaceServices } from './services/workspaceServices';
 
@@ -29,4 +30,5 @@ export default interface AppMapService {
   workspaceServices: WorkspaceServices;
   findings?: FindingsService;
   classMap?: ClassMapService;
+  projectState?: ProjectStateService;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       lineInfoIndex: LineInfoIndex | undefined,
       projectStates: ProjectStateServiceInstance[] = [],
       appmapUptodateService: AppmapUptodateService | undefined,
+      projectState: ProjectStateService | undefined,
       sourceFileWatcher: SourceFileWatcher | undefined;
 
     const appmapWatcher = new AppMapWatcher();
@@ -184,7 +185,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     }
 
     {
-      const projectState = new ProjectStateService(
+      projectState = new ProjectStateService(
         extensionState,
         appmapWatcher,
         configWatcher,
@@ -295,6 +296,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       uptodate: appmapUptodateService,
       findings: findingsIndex,
       classMap: classMapIndex,
+      projectState: projectState,
     };
   } catch (exception) {
     Telemetry.sendEvent(DEBUG_EXCEPTION, { exception: exception as Error });

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -6,16 +6,8 @@ import { FileChangeEmitter } from './fileChangeEmitter';
 import FindingsIndex from './findingsIndex';
 import { ResolvedFinding } from './resolvedFinding';
 import { analyze, scoreValue } from '../analyzers';
-import ProjectMetadata from '../workspace/projectMetadata';
+import ProjectMetadata, { DomainCounts } from '../workspace/projectMetadata';
 import AppMapCollection from './appmapCollection';
-
-export interface DomainCounts {
-  total: number;
-  security: number;
-  performance: number;
-  maintainability: number;
-  stability: number;
-}
 
 export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
   protected disposables: vscode.Disposable[] = [];

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -202,6 +202,10 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
       analysisPerformed: this.analysisPerformed,
       appMapOpened: this.hasOpenedAppMap || false,
       numFindings: this.numFindings,
+      numMaintainability: this.domains.maintainability,
+      numPerformance: this.domains.performance,
+      numSecurity: this.domains.security,
+      numStability: this.domains.stability,
       language: {
         name: analysis.features.lang.title,
         score: scoreValue(analysis.features.lang.score) + 1,

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -9,7 +9,7 @@ import { analyze, scoreValue } from '../analyzers';
 import ProjectMetadata from '../workspace/projectMetadata';
 import AppMapCollection from './appmapCollection';
 
-interface DomainCounts {
+export interface DomainCounts {
   total: number;
   security: number;
   performance: number;
@@ -27,13 +27,7 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
 
   public onStateChange = this._onStateChange.event;
 
-  protected domains: DomainCounts = {
-    total: 0,
-    security: 0,
-    performance: 0,
-    maintainability: 0,
-    stability: 0,
-  };
+  protected domains?: DomainCounts;
 
   constructor(
     public readonly folder: vscode.WorkspaceFolder,
@@ -142,13 +136,13 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
     });
 
     // Sets this.domain to corresponding values in uniqueDomainMap
-    this.domains.maintainability = uniqueDomainMap.get('Maintainability')?.size || 0;
-    this.domains.performance = uniqueDomainMap.get('Performance')?.size || 0;
-    this.domains.stability = uniqueDomainMap.get('Stability')?.size || 0;
-    this.domains.security = uniqueDomainMap.get('Security')?.size || 0;
-    this.domains.total = findings.length;
-
-    vscode.window.showInformationMessage(JSON.stringify(this.domains));
+    this.domains = {
+      maintainability: uniqueDomainMap.get('Maintainability')?.size || 0,
+      performance: uniqueDomainMap.get('Performance')?.size || 0,
+      stability: uniqueDomainMap.get('Stability')?.size || 0,
+      security: uniqueDomainMap.get('Security')?.size || 0,
+      total: findings.length,
+    };
   }
 
   onFindingsChanged(findings: ResolvedFinding[]): void {
@@ -202,10 +196,7 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
       analysisPerformed: this.analysisPerformed,
       appMapOpened: this.hasOpenedAppMap || false,
       numFindings: this.numFindings,
-      numMaintainability: this.domains.maintainability,
-      numPerformance: this.domains.performance,
-      numSecurity: this.domains.security,
-      numStability: this.domains.stability,
+      impactDomainCounts: this.domains,
       language: {
         name: analysis.features.lang.title,
         score: scoreValue(analysis.features.lang.score) + 1,

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -1,4 +1,5 @@
 import { AppMapSummary } from '../analyzers';
+import { DomainCounts } from '../services/projectStateService';
 import Feature from './feature';
 
 export default interface ProjectMetadata {
@@ -10,10 +11,7 @@ export default interface ProjectMetadata {
   analysisPerformed?: boolean;
   appMapOpened?: boolean;
   numFindings?: number;
-  numSecurity?: number;
-  numPerformance?: number;
-  numMaintainability?: number;
-  numStability?: number;
+  impactDomainCounts?: DomainCounts;
   language?: Feature;
   testFramework?: Feature;
   webFramework?: Feature;

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -10,6 +10,10 @@ export default interface ProjectMetadata {
   analysisPerformed?: boolean;
   appMapOpened?: boolean;
   numFindings?: number;
+  numSecurity?: number;
+  numPerformance?: number;
+  numMaintainability?: number;
+  numStability?: number;
   language?: Feature;
   testFramework?: Feature;
   webFramework?: Feature;

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -1,6 +1,13 @@
 import { AppMapSummary } from '../analyzers';
-import { DomainCounts } from '../services/projectStateService';
 import Feature from './feature';
+
+export interface DomainCounts {
+  total: number;
+  security: number;
+  performance: number;
+  maintainability: number;
+  stability: number;
+}
 
 export default interface ProjectMetadata {
   name: string;

--- a/test/integration/projectState.test.ts
+++ b/test/integration/projectState.test.ts
@@ -1,0 +1,36 @@
+// @project project-system
+import assert from 'assert';
+import * as vscode from 'vscode';
+import { touch } from '../../src/lib/touch';
+import { ProjectStateServiceInstance } from '../../src/services/projectStateService';
+import { initializeWorkspace, waitForExtension, waitForIndexer } from './util';
+
+describe('ImpactDomain', () => {
+  beforeEach(initializeWorkspace);
+  beforeEach(waitForExtension);
+  beforeEach(waitForIndexer);
+  afterEach(initializeWorkspace);
+
+  it('checks if impact domains are properly calculated ', async () => {
+    const appMapService = await waitForExtension();
+
+    const projectStateService = appMapService.projectState;
+    assert(projectStateService);
+    const serviceInstances = (await waitForExtension()).workspaceServices.getServiceInstances(
+      projectStateService
+    );
+    assert.strictEqual(serviceInstances.length, 1);
+
+    const serviceInstance = serviceInstances[0] as ProjectStateServiceInstance;
+    serviceInstance.metadata().then((metadata) => {
+      const domainCounts = metadata.impactDomainCounts;
+      const sumOfDomainCounts =
+        (domainCounts?.maintainability || 0) +
+        (domainCounts?.performance || 0) +
+        (domainCounts?.security || 0) +
+        (domainCounts?.stability || 0);
+
+      assert.strictEqual(sumOfDomainCounts, 1);
+    });
+  });
+});


### PR DESCRIPTION
### Changes

- Created method countDomainsFromFindings
    - Counts unique hashes for each domain category
    - Saves them in DomainCounts object
    - Domain is undefined if not present in document

### Use-case

- Used by InvestigateFindings Page to show finding domain breakdown