### PR TITLE
feat: investigate findings shows signup info when findings not enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
       },
       {
         "view": "appmap.views.findings",
-        "contents": "AppMap runtime analysis works right in your code editor, to help you find and fix problems in your code.\n[Learn More](command:appmap.getEarlyAccess?%5B%22sidebar%22%5D)"
+        "contents": "AppMap runtime analysis works right in your code editor, to help you find and fix problems in your code.\n[Learn More](command:appmap.openInstallGuide?%5B%22investigate-findings%22%5D)"
       }
     ],
     "views": {

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -40,10 +40,7 @@ const docsPages: DocPage[] = [
     },
     args: ['open-appmaps'],
   },
-];
-
-if (extensionSettings.findingsEnabled()) {
-  docsPages.push({
+  {
     id: 'WALKTHROUGH_INVESTIGATE_FINDINGS',
     title: 'Investigate findings',
     command: 'appmap.openInstallGuide',
@@ -51,13 +48,17 @@ if (extensionSettings.findingsEnabled()) {
       return Boolean((await projectState.metadata()).investigatedFindings);
     },
     args: ['investigate-findings'],
-  });
-}
+  },
+];
 
 async function getIcon(
   page: DocPage,
   projectState?: ProjectStateServiceInstance
 ): Promise<string | vscode.ThemeIcon> {
+  if (!extensionSettings.findingsEnabled() && page.id === 'WALKTHROUGH_INVESTIGATE_FINDINGS') {
+    return new vscode.ThemeIcon('lock');
+  }
+
   if (!projectState || !page.isComplete) {
     return new vscode.ThemeIcon('circle-large-outline');
   }

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import extensionSettings from '../configuration/extensionSettings';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import { COPY_COMMAND, OPEN_VIEW, Telemetry } from '../telemetry';
 import { getNonce, getWorkspaceFolderFromPath } from '../util';
 import ProjectMetadata from '../workspace/projectMetadata';
 import * as semver from 'semver';
 import ExtensionState from '../configuration/extensionState';
+import extensionSettings from '../configuration/extensionSettings';
 
 type PageMessage = {
   page: string;
@@ -85,19 +85,15 @@ export default class InstallGuideWebView {
           disposables.forEach((disposable) => disposable.dispose());
         });
 
-        const disabledPages = ['openapi'];
-        if (!extensionSettings.findingsEnabled()) {
-          disabledPages.push('investigate-findings');
-        }
-
         panel.webview.onDidReceiveMessage(async (message) => {
           switch (message.command) {
             case 'ready':
               panel.webview.postMessage({
                 type: 'init',
                 projects: await collectProjects(),
-                disabled: disabledPages,
+                disabled: ['openapi'],
                 page: pageIndex,
+                findingsEnabled: extensionSettings.findingsEnabled(),
               });
 
               break;

--- a/web/src/installGuideView.js
+++ b/web/src/installGuideView.js
@@ -7,7 +7,7 @@ export default function mountInstallGuide() {
   const vscode = window.acquireVsCodeApi();
   const messages = new MessagePublisher(vscode);
 
-  messages.on('init', ({ projects: startProjects, page: startPage, disabled }) => {
+  messages.on('init', ({ projects: startProjects, page: startPage, disabled, findingsEnabled }) => {
     let currentPage = startPage;
     let currentProject;
 
@@ -20,6 +20,7 @@ export default function mountInstallGuide() {
             projects: this.projects,
             disabledPages: new Set(disabled),
             editor: 'vscode',
+            findingsEnabled,
           },
         });
       },


### PR DESCRIPTION
Fixes applandinc/board#107

If findings are not enabled, render `Investigate findings` as an info page with a Slack signup button.