### PR TITLE
Change last two places with references to appland

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dynamic security analysis (**DAST**).
 - [GitHub](https://github.com/applandinc)
 - [Blog](https://appmap.io/blog/)
 - [1:1 support with our dev team on Slack](https://appmap.io/slack)
-- Email support: [support@app.land](mailto:support@appmap.io)
+- Email support: [support@appmap.io](mailto:support@appmap.io)
 
 ## Twitter
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/applandinc/vscode-appland"
   },
-  "qna": "https://appland.com/docs/faq.html",
+  "qna": "https://appmap.io/docs/faq.html",
   "engines": {
     "vscode": "^1.55.0"
   },


### PR DESCRIPTION
Missed two last references to app.land and appland.com - both updated here. 