### PR TITLE
feat: Send a telemetry event for AppMap creation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,13 @@ import { ResolvedFinding } from './services/resolvedFinding';
 import { RuntimeAnalysisCtaService } from './services/runtimeAnalysisCtaService';
 import { SourceFileWatcher } from './services/sourceFileWatcher';
 import { initializeWorkspaceServices } from './services/workspaceServices';
-import { DEBUG_EXCEPTION, PROJECT_OPEN, Telemetry, TELEMETRY_ENABLED } from './telemetry';
+import {
+  DEBUG_EXCEPTION,
+  PROJECT_OPEN,
+  Telemetry,
+  TELEMETRY_ENABLED,
+  sendAppMapCreateEvent,
+} from './telemetry';
 import appmapLinkProvider from './terminalLink/appmapLinkProvider';
 import registerTrees from './tree';
 import { ClassMapTreeDataProvider } from './tree/classMapTreeDataProvider';
@@ -70,6 +76,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     const appmapWatcher = new AppMapWatcher();
     context.subscriptions.push(
       appmapWatcher.onCreate(({ uri }) => appmapCollectionFile.onCreate(uri)),
+      appmapWatcher.onCreate(({ uri, workspaceFolder }) =>
+        sendAppMapCreateEvent(uri, workspaceFolder)
+      ),
       appmapWatcher.onDelete(({ uri }) => appmapCollectionFile.onDelete(uri)),
       appmapWatcher.onChange(({ uri }) => appmapCollectionFile.onChange(uri))
     );

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -70,6 +70,17 @@ export const APPMAP_UPLOAD = new Event({
   metrics: [Metrics.APPMAP_JSON],
 });
 
+export const APPMAP_CREATE = new Event({
+  name: 'appmap:create',
+  properties: [
+    Properties.FILE_PATH,
+    Properties.FILE_SHA_256,
+    Properties.FILE_SIZE,
+    Properties.FILE_METADATA,
+    Properties.PROJECT_LANGUAGE,
+  ],
+});
+
 export const RECORDING_START = new Event({
   name: 'remote_recording:start',
   properties: [Properties.RECORDING_ENDPOINT_URL, Properties.RECORDING_STATUS_CODE],

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -5,6 +5,7 @@ import { UnionToIntersection } from '../util';
 import TelemetryResolver from './telemetryResolver';
 import TelemetryDataProvider from './telemetryDataProvider';
 import Event from './event';
+export * from './sendAppMapCreateEvent';
 
 const EXTENSION_ID = `${publisher}.${name}`;
 const EXTENSION_VERSION = `${version}`;

--- a/src/telemetry/sendAppMapCreateEvent.ts
+++ b/src/telemetry/sendAppMapCreateEvent.ts
@@ -1,0 +1,14 @@
+import { Uri, WorkspaceFolder } from 'vscode';
+import { APPMAP_CREATE, Telemetry } from '.';
+
+let alreadySent = false;
+
+export function sendAppMapCreateEvent(uri: Uri, workspaceFolder: WorkspaceFolder): void {
+  if (alreadySent) return; // only send one event per session
+
+  Telemetry.sendEvent(APPMAP_CREATE, {
+    rootDirectory: workspaceFolder.uri.fsPath,
+    uri: uri,
+  });
+  alreadySent = true;
+}


### PR DESCRIPTION
This event is only sent for the first AppMap seen in a session. It will help us make sure our users are successful in making use of the extension and AppMap agents.

Fixes #458