### PR TITLE
fix: Don't fully analyze the project on every change update

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "appmap",
   "displayName": "AppMap",
   "description": "Interactive maps of runtime code behavior",
-  "version": "0.47.0",
+  "version": "0.47.1-dev2",
   "repository": {
     "type": "git",
     "url": "https://github.com/getappmap/vscode-appland"
@@ -420,7 +420,7 @@
   "dependencies": {
     "@appland/appmap": "^3.43.2",
     "@appland/client": "^1.5.0",
-    "@appland/components": "^2.16.0",
+    "@appland/components": "^2.17.0",
     "@appland/diagrams": "^1.5.3",
     "@appland/models": "^1.20.0",
     "@appland/scanner": "^1.71.2",

--- a/src/analyzers/python.ts
+++ b/src/analyzers/python.ts
@@ -14,6 +14,7 @@ async function pipDependencies(folder: WorkspaceFolder): Promise<DependencyFinde
 }
 
 const pyprojectDependencies = fileWordScanner('pyproject.toml');
+const pipfileDependencies = fileWordScanner('Pipfile');
 
 async function grepFiles(pattern: string, folder: WorkspaceFolder) {
   async function grepFile(file: PromiseLike<Uint8Array>) {
@@ -40,7 +41,11 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
   };
 
   try {
-    const dependency = await Promise.any([pipDependencies(folder), pyprojectDependencies(folder)]);
+    const dependency = await Promise.any([
+      pipDependencies(folder),
+      pipfileDependencies(folder),
+      pyprojectDependencies(folder),
+    ]);
     features.lang.depFile = dependency.filename;
     if (dependency('django')) {
       features.web = {

--- a/src/analyzers/python.ts
+++ b/src/analyzers/python.ts
@@ -13,8 +13,8 @@ async function pipDependencies(folder: WorkspaceFolder): Promise<DependencyFinde
   return finder;
 }
 
-const pyprojectDependencies = fileWordScanner('pyproject.toml');
 const pipfileDependencies = fileWordScanner('Pipfile');
+const poetryDependencies = fileWordScanner('poetry.lock');
 
 async function grepFiles(pattern: string, folder: WorkspaceFolder) {
   async function grepFile(file: PromiseLike<Uint8Array>) {
@@ -44,7 +44,7 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
     const dependency = await Promise.any([
       pipDependencies(folder),
       pipfileDependencies(folder),
-      pyprojectDependencies(folder),
+      poetryDependencies(folder),
     ]);
     features.lang.depFile = dependency.filename;
     if (dependency('django')) {

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -65,17 +65,21 @@ export default class ExtensionState {
   ): void {
     const { fsPath } = workspaceFolder.uri;
     const workspaces = new Set<string>(this.context.globalState.get(key, []));
+    let changed = true;
 
     if (value) {
       if (!workspaces.has(fsPath)) {
         workspaces.add(fsPath);
-        this._onWorkspaceFlag.fire({ workspaceFolder, key, value });
+      } else {
+        changed = false;
       }
     } else {
       workspaces.delete(fsPath);
     }
 
     this.context.globalState.update(key, [...workspaces]);
+
+    if (changed) this._onWorkspaceFlag.fire({ workspaceFolder, key, value });
   }
 
   /** Returns whether or not the workspace folder at the given path exists in the set.

--- a/src/services/nodeProcessServiceInstance.ts
+++ b/src/services/nodeProcessServiceInstance.ts
@@ -36,8 +36,8 @@ export default class NodeProcessServiceInstance implements WorkspaceServiceInsta
       : this.stop(undefined, 'appmap.yml has been deleted or moved');
   }
 
-  async initialize(): Promise<void> {
-    const metadata = await this.projectState.metadata();
+  initialize(): void {
+    const metadata = this.projectState.metadata;
     this.onReceiveProjectMetadata(metadata);
     this.disposables.push(
       this.projectState.onStateChange((metadata) => this.onReceiveProjectMetadata(metadata)),

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -87,8 +87,8 @@ export class InstructionsTreeDataProvider implements vscode.TreeDataProvider<Doc
     }
   }
 
-  public async getChildren(): Promise<DocPage[]> {
-    const metadata = await this.projectState?.metadata();
+  public getChildren(): DocPage[] {
+    const metadata = this.projectState?.metadata;
 
     if (!metadata) this.completion.clear();
     else

--- a/src/util.ts
+++ b/src/util.ts
@@ -261,19 +261,11 @@ export function hasPreviouslyInstalledExtension(extensionPath: string): boolean 
   return false;
 }
 
-export async function getWorkspaceFolderFromPath(
+export function getWorkspaceFolderFromPath(
   projectStates: ReadonlyArray<ProjectStateServiceInstance>,
   path: string
-): Promise<vscode.WorkspaceFolder | undefined> {
-  // generate an array of promises that resolve to a project path
-  const promises = projectStates.map(async (projectState) => {
-    const metadata = await projectState.metadata();
-    return metadata?.path;
-  });
-
-  // convert the array of promises to an array of project paths
-  const projectPaths = await Promise.all(promises);
-
+): vscode.WorkspaceFolder | undefined {
+  const projectPaths = projectStates.map((projectState) => projectState.metadata.path);
   const projectIndex = projectPaths.findIndex((projectPath) => {
     return path.includes(projectPath);
   });

--- a/src/workspace/installationStatus.ts
+++ b/src/workspace/installationStatus.ts
@@ -7,14 +7,14 @@ export default class InstallationStatusBadge {
 
   constructor(private readonly viewId: string) {}
 
-  async initialize(projectStates: ProjectStateServiceInstance[]): Promise<void> {
+  initialize(projectStates: ProjectStateServiceInstance[]): void {
     if (projectStates.length === 0) {
       return this.markAsComplete();
     }
 
     const installableProjects: ProjectStateServiceInstance[] = [];
     for (const projectState of projectStates) {
-      if (await projectState.installable()) {
+      if (projectState.installable) {
         installableProjects.push(projectState);
       }
     }

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -7,7 +7,7 @@ export default interface ProjectMetadata {
   name: string;
   path: string;
   score?: number;
-  hasNode: boolean;
+  hasNode?: boolean;
   agentInstalled?: boolean;
   appMapsRecorded?: boolean;
   analysisPerformed?: boolean;

--- a/test/fixtures/workspaces/project-system/appmap-findings.json
+++ b/test/fixtures/workspaces/project-system/appmap-findings.json
@@ -50,7 +50,8 @@
             "server_version": "3.38.2"
           }
         }
-      ]
+      ],
+      "impactDomain": "Performance"
     }
   ]
 }

--- a/test/integration/findingsImpactDomains/noFindings.test.ts
+++ b/test/integration/findingsImpactDomains/noFindings.test.ts
@@ -19,10 +19,8 @@ describe('Findings impact domains (several findings)', () => {
   });
 
   it('has the expected domain counts', async () => {
-    const domainCounts = await Promise.all(
-      serviceInstances.map(async (serviceInstance) => {
-        return (await serviceInstance.metadata()).findingsDomainCounts;
-      })
+    const domainCounts = serviceInstances.map(
+      (serviceInstance) => serviceInstance.metadata.findingsDomainCounts
     );
 
     assert.strictEqual(domainCounts.length, 1, 'there is one workspace in the project');

--- a/test/integration/findingsImpactDomains/oneFinding.test.ts
+++ b/test/integration/findingsImpactDomains/oneFinding.test.ts
@@ -18,11 +18,9 @@ describe('Findings impact domains (one finding)', () => {
     ) as ProjectStateServiceInstance[];
   });
 
-  it('has the expected domain counts', async () => {
-    const domainCounts = await Promise.all(
-      serviceInstances.map(async (serviceInstance) => {
-        return (await serviceInstance.metadata()).findingsDomainCounts;
-      })
+  it('has the expected domain counts', () => {
+    const domainCounts = serviceInstances.map(
+      (serviceInstance) => serviceInstance.metadata.findingsDomainCounts
     );
 
     assert.strictEqual(domainCounts.length, 1, 'there is one workspace in the project');

--- a/test/integration/findingsImpactDomains/severalFindings.test.ts
+++ b/test/integration/findingsImpactDomains/severalFindings.test.ts
@@ -19,10 +19,8 @@ describe('Findings impact domains (several findings)', () => {
   });
 
   it('has the expected domain counts', async () => {
-    const domainCounts = await Promise.all(
-      serviceInstances.map(async (serviceInstance) => {
-        return (await serviceInstance.metadata()).findingsDomainCounts;
-      })
+    const domainCounts = serviceInstances.map(
+      (serviceInstance) => serviceInstance.metadata.findingsDomainCounts
     );
 
     assert.strictEqual(domainCounts.length, 1, 'there is one workspace in the project');

--- a/test/integration/sampleCodeObjects/codeObjects.test.ts
+++ b/test/integration/sampleCodeObjects/codeObjects.test.ts
@@ -34,7 +34,7 @@ describe('Sample Code Objects', () => {
     const serviceInstance = extension.workspaceServices.getServiceInstances(
       extension.projectState
     )[0] as ProjectStateServiceInstance;
-    const sampleCodeObjects = (await serviceInstance.metadata()).sampleCodeObjects;
+    const sampleCodeObjects = serviceInstance.metadata.sampleCodeObjects;
 
     assert.notStrictEqual(sampleCodeObjects, undefined, 'not undefined');
     assert.strictEqual(sampleCodeObjects?.httpRequests.length, 5, 'five HTTP requests');

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@ __metadata:
   linkType: hard
 
 "@appland/appmap@npm:^3.43.2":
-  version: 3.44.4
-  resolution: "@appland/appmap@npm:3.44.4"
+  version: 3.45.0
+  resolution: "@appland/appmap@npm:3.45.0"
   dependencies:
-    "@appland/components": 2.15.0
+    "@appland/components": 2.16.0
     "@appland/diagrams": 1.5.3
     "@appland/models": 1.20.0
     "@appland/openapi": 1.0.2
@@ -101,7 +101,7 @@ __metadata:
     yargs: ^17.1.1
   bin:
     appmap: built/cli.js
-  checksum: e731a7183ba6524d7d83e319f2f16deeae3c0cf292ba99c60235e54e3926a1b39c0be190d79189897e21bd9a2108c6e55b3c31f80265095ae45d39e55c06365a
+  checksum: 66b788a3a5b8fa24bfcea5438f94336b3fef820a8896f046fc866b12372bc840d88dfb9c1c190d6a911f734f398e986f8404d0cc4d562d70594fccfdf65a205d
   languageName: node
   linkType: hard
 
@@ -117,22 +117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:2.15.0":
-  version: 2.15.0
-  resolution: "@appland/components@npm:2.15.0"
-  dependencies:
-    "@appland/diagrams": ^1.5.1
-    "@appland/models": ^1.9.0
-    buffer: ^6.0.3
-    highlight.js: ^10.7.2
-    sql-formatter: ^4.0.2
-    vue: ^2.6.11
-    vuex: ^3.6.0
-  checksum: 263735069f298ab2e93ef7a138df5f0520754d3c2adfc3813f84d462db4f810ae2277689c18279a273274b989541389c93fc51c52bf033120f0fd928dddf3837
-  languageName: node
-  linkType: hard
-
-"@appland/components@npm:^2.16.0":
+"@appland/components@npm:2.16.0":
   version: 2.16.0
   resolution: "@appland/components@npm:2.16.0"
   dependencies:
@@ -144,6 +129,21 @@ __metadata:
     vue: ^2.6.11
     vuex: ^3.6.0
   checksum: 605de2415f62c945cdae13e92e7a59c4b1ff30dd0306fd8e80b234ab3e5208b7c18314a51247dc2eb7eead6bc839eea5150c04b37629d016ffb2119498846ab9
+  languageName: node
+  linkType: hard
+
+"@appland/components@npm:^2.17.0":
+  version: 2.17.0
+  resolution: "@appland/components@npm:2.17.0"
+  dependencies:
+    "@appland/diagrams": ^1.5.1
+    "@appland/models": ^1.9.0
+    buffer: ^6.0.3
+    highlight.js: ^10.7.2
+    sql-formatter: ^4.0.2
+    vue: ^2.6.11
+    vuex: ^3.6.0
+  checksum: ed2557f7732c1d050e59c76cb1299500d6821b5e339ad6cfaeef619155246fa4f3f999ef0786fabdd03ebd07dca83a74369f0b627a7fd2fee5009fe931fc4446
   languageName: node
   linkType: hard
 
@@ -192,13 +192,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@appland/openapi@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@appland/openapi@npm:1.0.3"
+  dependencies:
+    "@appland/models": 1.20.0
+    js-yaml: ^4.1.0
+  checksum: 87dbd5dbebd24bbf8b99995d1c08fcc83253e727061637dfc1998dd6116210421d08809418ae0a4a543667583f01a55c31ed6b558ecabc2c7007681f75f0d123
+  languageName: node
+  linkType: hard
+
 "@appland/scanner@npm:^1.71.2":
-  version: 1.71.4
-  resolution: "@appland/scanner@npm:1.71.4"
+  version: 1.71.6
+  resolution: "@appland/scanner@npm:1.71.6"
   dependencies:
     "@appland/client": ^1.3.0
     "@appland/models": ^1.18.1
-    "@appland/openapi": 1.0.2
+    "@appland/openapi": 1.0.3
     "@appland/sql-parser": ^1.5.0
     "@types/cli-progress": ^3.9.2
     ajv: ^8.8.2
@@ -225,7 +235,7 @@ __metadata:
     yargs: ^17.1.1
   bin:
     scanner: built/cli.js
-  checksum: 348edec320dc677018e409b78fe432608d22705154ba8ab3de1278bf1c1375fb169d0239e36a7024060966067999c122cdf99c5471daf45ac5c05fca014cece3
+  checksum: 795d49a164f5a33f1ed166095855b846d7d60de244e90154b1794ba8920bb7a9a4647e74c39dde9ac5c6bb78051ec4a010f03b2806a16b379697f728ff8ccb32
   languageName: node
   linkType: hard
 
@@ -3604,7 +3614,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.43.2
     "@appland/client": ^1.5.0
-    "@appland/components": ^2.16.0
+    "@appland/components": ^2.17.0
     "@appland/diagrams": ^1.5.3
     "@appland/models": ^1.20.0
     "@appland/scanner": ^1.71.2


### PR DESCRIPTION
A ton of excess work was being performed on any minor update (new finding, new AppMap, state change).

I've broken the logic up so it'll only update relevant metadata depending on what changed, and project analysis will only occur once.

This PR also adds Pipenv support for Python projects. I originally added this in a separate PR but it ultimately ended up not working without the rest of the fixes in this PR.
![image](https://user-images.githubusercontent.com/8737782/196336892-28c5d9ef-1b2f-4eb4-9f6e-b46d93a5d7c5.png)
