### PR TITLE
Emit `appmap:create`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,10 +78,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     const appmapWatcher = new AppMapWatcher();
     context.subscriptions.push(
-      appmapWatcher.onCreate(({ uri }) => appmapCollectionFile.onCreate(uri)),
-      appmapWatcher.onCreate(({ uri, workspaceFolder }) =>
-        sendAppMapCreateEvent(uri, workspaceFolder)
-      ),
+      appmapWatcher.onCreate(({ uri, workspaceFolder, initializing }) => {
+        appmapCollectionFile.onCreate(uri);
+        if (!initializing) sendAppMapCreateEvent(uri, workspaceFolder);
+      }),
       appmapWatcher.onDelete(({ uri }) => appmapCollectionFile.onDelete(uri)),
       appmapWatcher.onChange(({ uri }) => appmapCollectionFile.onChange(uri))
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ import { Signup } from './actions/signup';
 import AnalysisManager from './services/analysisManager';
 import { FindingsService } from './findingsService';
 import Environment from './configuration/environment';
+import ErrorCode from './telemetry/definitions/errorCodes';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -291,7 +292,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       },
     };
   } catch (exception) {
-    Telemetry.sendEvent(DEBUG_EXCEPTION, { exception: exception as Error });
+    Telemetry.sendEvent(DEBUG_EXCEPTION, {
+      exception: exception as Error,
+      errorCode: ErrorCode.InitializationFailure,
+    });
     throw exception;
   }
 }

--- a/src/services/appmapWatcher.ts
+++ b/src/services/appmapWatcher.ts
@@ -25,7 +25,7 @@ class AppMapWatcherInstance implements WorkspaceServiceInstance {
         new vscode.RelativePattern(this.folder, '**/*.appmap.json'),
         '**/node_modules/**'
       )
-    ).map((uri) => this.handler.onCreate(uri, this.folder));
+    ).map((uri) => this.handler.onCreate(uri, this.folder, true));
     return this;
   }
 
@@ -49,8 +49,8 @@ export class AppMapWatcher extends FileChangeEmitter
       onChange: (uri, workspaceFolder) => {
         this._onChange.fire({ uri, workspaceFolder });
       },
-      onCreate: (uri, workspaceFolder) => {
-        this._onCreate.fire({ uri, workspaceFolder });
+      onCreate: (uri, workspaceFolder, initializing) => {
+        this._onCreate.fire({ uri, workspaceFolder, initializing });
       },
       onDelete: (uri, workspaceFolder) => {
         this._onDelete.fire({ uri, workspaceFolder });

--- a/src/services/fileChangeEmitter.ts
+++ b/src/services/fileChangeEmitter.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 export interface FileChangeHandler {
   onChange(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder): void;
-  onCreate(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder): void;
+  onCreate(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder, initializing?: boolean): void;
   onDelete(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder): void;
 }
 
@@ -11,8 +11,12 @@ export interface FileChangeEvent {
   workspaceFolder: vscode.WorkspaceFolder;
 }
 
+export interface FileInitEvent {
+  initializing?: boolean;
+}
+
 export class FileChangeEmitter {
-  protected _onCreate = new vscode.EventEmitter<FileChangeEvent>();
+  protected _onCreate = new vscode.EventEmitter<FileChangeEvent & FileInitEvent>();
   protected _onChange = new vscode.EventEmitter<FileChangeEvent>();
   protected _onDelete = new vscode.EventEmitter<FileChangeEvent>();
   public onCreate = this._onCreate.event;

--- a/src/telemetry/definitions/errorCodes.ts
+++ b/src/telemetry/definitions/errorCodes.ts
@@ -4,6 +4,7 @@ enum ErrorCode {
   DependencyPathNotResolved,
   ProcessFailure,
   AuthenticationFailure,
+  InitializationFailure,
 }
 
 export default ErrorCode;

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -74,7 +74,7 @@ export const FILE_SHA_256 = new TelemetryDataProvider({
 export const FILE_SIZE = new TelemetryDataProvider({
   id: 'appmap.file.size',
   async value({ uri }: { uri: Uri }) {
-    return (await fs.stat(uri.fsPath)).size;
+    return (await fs.stat(uri.fsPath)).size.toString();
   },
 });
 


### PR DESCRIPTION
This PR contains some additional changes that I discovered while investigating #495 :

- Pre-existing AppMaps will not emit an `appmap:create` event upon initialization
- `appmap:create` will now be sent properly
- Errors which occur during initialization will receive an error code to reflect the failed initialization

Resolves #495 