### PR TITLE
fix: Strip paths of any extra leading path separators

### DIFF
--- a/src/telemetry/properties/versionControlGit.ts
+++ b/src/telemetry/properties/versionControlGit.ts
@@ -30,7 +30,7 @@ export default class GitProperties implements VersionControlProperties {
     return !!this.ignores.find((ignore) => {
       if (!filePath.startsWith(ignore.dir)) return false;
 
-      const relativePath = filePath.slice(ignore.dir.length + 1);
+      const relativePath = filePath.slice(ignore.dir.length + 1).replace(/^[/\\]+/, '');
       return ignore.ignore.ignores(relativePath);
     });
   }

--- a/src/telemetry/properties/versionControlGit.ts
+++ b/src/telemetry/properties/versionControlGit.ts
@@ -9,9 +9,16 @@ type DirIgnore = {
   dir: string;
 };
 
-async function buildIgnore(ignoreFileName: string): Promise<Ignore> {
+export async function buildIgnore(ignoreFileName: string): Promise<Ignore> {
   const wsIgnore = ignore();
-  wsIgnore.add(await fs.readFile(ignoreFileName, 'utf-8'));
+  const buffer = await fs.readFile(ignoreFileName, 'utf-8');
+  const ignoreLines = buffer
+    .toString()
+    .split(/\r?\n/gm)
+    .map((line) => line.replace(/\\+$/, ''));
+
+  ignoreLines.forEach((line) => wsIgnore.add(line));
+
   return wsIgnore;
 }
 

--- a/test/integration/gitProperties.test.ts
+++ b/test/integration/gitProperties.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import GitProperties from '../../src/telemetry/properties/versionControlGit';
+import { ProjectA } from './util';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+describe('GitProperties', () => {
+  describe('isIgnored', () => {
+    let gitProperties: GitProperties;
+    const absoluteProjectPath = path.resolve(ProjectA);
+
+    beforeEach(async () => {
+      gitProperties = new GitProperties();
+      await gitProperties.initialize(absoluteProjectPath);
+    });
+
+    it('accepts various paths', () => {
+      assert(!gitProperties.isIgnored(`file://${absoluteProjectPath}/filename`));
+      assert(!gitProperties.isIgnored(`${absoluteProjectPath}/filename`));
+      assert(!gitProperties.isIgnored(`${absoluteProjectPath}//filename`));
+      assert(!gitProperties.isIgnored(`/filename`));
+    });
+
+    it('returns ignored paths', () => {
+      assert(gitProperties.isIgnored(`${absoluteProjectPath}/node_modules`));
+      assert(gitProperties.isIgnored(`${absoluteProjectPath}/node_modules/@appland`));
+      assert(!gitProperties.isIgnored(`${absoluteProjectPath}/package.json`));
+    });
+  });
+});

--- a/test/integration/gitProperties.test.ts
+++ b/test/integration/gitProperties.test.ts
@@ -1,10 +1,26 @@
 import assert from 'assert';
-import GitProperties from '../../src/telemetry/properties/versionControlGit';
-import { ProjectA } from './util';
+import GitProperties, { buildIgnore } from '../../src/telemetry/properties/versionControlGit';
+import { ProjectA, withTmpDir } from './util';
+import { promises as fs } from 'fs';
 import * as path from 'path';
-import * as vscode from 'vscode';
 
 describe('GitProperties', () => {
+  describe('buildIgnore', () => {
+    it('accepts trailing Windows path separators', async () => {
+      await withTmpDir(async (tmpDir) => {
+        const gitIgnorePath = path.join(tmpDir, '.gitignore');
+        const gitIgnoreContents = ['# comment', 'trailing\\', 'node_modules'].join('\n');
+        await fs.writeFile(gitIgnorePath, gitIgnoreContents, 'utf-8');
+
+        const ignore = await buildIgnore(gitIgnorePath);
+        assert(!ignore.ignores('# comment'));
+        assert(ignore.ignores('trailing'));
+        assert(ignore.ignores('trailing/file'));
+        assert(ignore.ignores('node_modules'));
+      });
+    });
+  });
+
   describe('isIgnored', () => {
     let gitProperties: GitProperties;
     const absoluteProjectPath = path.resolve(ProjectA);


### PR DESCRIPTION
I'm not sure how this is possible, but some user's report an error similar to:
```
RangeError: path should be a `path.relative()`d string, but got "/yarn.lock"
```

This occurs regardless of the OS, sometimes using Windows path separators (e.g. `\yarn.lock`).

These paths must have double separators? I'm not sure how it's occurring, but this should fix it.