### PR TITLE
fix: Don't fail when checking if the project root is ignored

### DIFF
--- a/src/telemetry/properties/versionControlGit.ts
+++ b/src/telemetry/properties/versionControlGit.ts
@@ -38,6 +38,8 @@ export default class GitProperties implements VersionControlProperties {
       if (!filePath.startsWith(ignore.dir)) return false;
 
       const relativePath = filePath.slice(ignore.dir.length + 1).replace(/^[/\\]+/, '');
+      if (!relativePath) return false;
+
       return ignore.ignore.ignores(relativePath);
     });
   }

--- a/test/integration/gitProperties.test.ts
+++ b/test/integration/gitProperties.test.ts
@@ -35,6 +35,7 @@ describe('GitProperties', () => {
       assert(!gitProperties.isIgnored(`${absoluteProjectPath}/filename`));
       assert(!gitProperties.isIgnored(`${absoluteProjectPath}//filename`));
       assert(!gitProperties.isIgnored(`/filename`));
+      assert(!gitProperties.isIgnored(absoluteProjectPath));
     });
 
     it('returns ignored paths', () => {


### PR DESCRIPTION
The `ignore` library will raise an exception if it receives an empty string. This could happen when checking if the root of a project is ignored. Instead of allowing this to happen, we'll now always return false. 