### PR TITLE
fix: Prevent semver comparison with 'latest'

### DIFF
--- a/src/analyzers/javascript.ts
+++ b/src/analyzers/javascript.ts
@@ -41,7 +41,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
     }
 
     if (pkg.devDependencies?.mocha) {
-      if (semverIntersects('>=8', pkg.devDependencies.mocha)) {
+      const { mocha: mochaVersion } = pkg.devDependencies;
+      if (mochaVersion === 'latest' || semverIntersects('>=8', mochaVersion)) {
         features.test = {
           title: 'mocha',
           score: 'ok',

--- a/test/integration/projectAnalyzers/javascript.test.ts
+++ b/test/integration/projectAnalyzers/javascript.test.ts
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import jsAnalyzer from '../../../src/analyzers/javascript';
+import { withTmpDir } from '../util';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+describe('JavaScript project analyzer', () => {
+  describe('dependency identification', () => {
+    it('identifies the latest version of mocha', async () => {
+      await withTmpDir(async (tmpDir) => {
+        const packageJson = {
+          devDependencies: {
+            mocha: 'latest',
+          },
+        };
+
+        await fs.writeFile(path.join(tmpDir, 'package.json'), JSON.stringify(packageJson), 'utf-8');
+
+        const workspaceFolder: vscode.WorkspaceFolder = {
+          name: path.basename(tmpDir),
+          uri: vscode.Uri.parse(tmpDir),
+          index: -1,
+        };
+        const result = await jsAnalyzer(workspaceFolder);
+
+        assert(result);
+        assert(result.features.test);
+        assert(result.features.test.score == 'ok');
+      });
+    });
+  });
+});


### PR DESCRIPTION
If a user specifies their mocha version as `latest`, we will fail when checking the version for compatibility because we're expecting a semver style version constraint. If it's `latest`, we'll always pass the check.