### PR TITLE
Notify whether a project is installable and contains a devcontainer 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,10 +222,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       appmapUptodateService
     );
 
-    (vscode.workspace.workspaceFolders || []).forEach((workspaceFolder) => {
-      Telemetry.sendEvent(PROJECT_OPEN, { rootDirectory: workspaceFolder.uri.fsPath });
-    });
-
     appmapLinkProvider();
     const editorProvider = AppMapEditorProvider.register(context, extensionState);
     RemoteRecording.register(context);

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -16,6 +16,7 @@ import glob from 'glob';
 import { promisify } from 'util';
 import AnalysisManager from './analysisManager';
 import AppMapLoader from './appmapLoader';
+import { PROJECT_OPEN, Telemetry } from '../telemetry';
 
 type SimpleCodeObject = {
   name: string;
@@ -104,6 +105,10 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
 
   public async initialize(): Promise<void> {
     await Promise.all([this.analyzeProject(), this.onAppMapCreated()]);
+    Telemetry.sendEvent(PROJECT_OPEN, {
+      rootDirectory: this.folder.uri.fsPath,
+      project: this.metadata,
+    });
   }
 
   public setFindingsIndex(findingsIndex?: FindingsIndex): void {

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -18,6 +18,7 @@ export const PROJECT_OPEN = new Event({
     Properties.SCANNER_CONFIG_PRESENT,
     Properties.PROJECT_LANGUAGE,
     Properties.PROJECT_LANGUAGE_DISTRIBUTION,
+    Properties.IS_INSTALLABLE,
   ],
   metrics: [Metrics.NUM_WORKSPACE_FOLDERS],
 });

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -19,6 +19,7 @@ export const PROJECT_OPEN = new Event({
     Properties.PROJECT_LANGUAGE,
     Properties.PROJECT_LANGUAGE_DISTRIBUTION,
     Properties.IS_INSTALLABLE,
+    Properties.HAS_DEVCONTAINER,
   ],
   metrics: [Metrics.NUM_WORKSPACE_FOLDERS],
 });

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -8,6 +8,7 @@ import { fileExists } from '../../util';
 import ErrorCode from './errorCodes';
 import ProjectMetadata from '../../workspace/projectMetadata';
 import { TerminalConfig } from '../../commands/installAgent';
+import * as vscode from 'vscode';
 
 export const DEBUG_EXCEPTION = new TelemetryDataProvider({
   id: 'appmap.debug.exception',
@@ -174,5 +175,22 @@ export const DEFAULT_TERMINALS = new TelemetryDataProvider({
   cache: true,
   async value({ defaultTerminals }: { defaultTerminals: TerminalConfig }) {
     return JSON.stringify(defaultTerminals);
+  },
+});
+
+export const HAS_DEVCONTAINER = new TelemetryDataProvider({
+  id: 'appmap.project.has_devcontainer',
+  async value({ rootDirectory }: { rootDirectory: string }) {
+    const devContainerPattern = new vscode.RelativePattern(
+      rootDirectory,
+      '{devcontainer,.devcontainer}.json'
+    );
+    const devContainerJson = await vscode.workspace.findFiles(
+      devContainerPattern,
+      '**/node_modules/**',
+      1
+    );
+    const hasDevContainer = devContainerJson.length !== 0;
+    return String(hasDevContainer);
   },
 });

--- a/test/integration/telemetry/properties.test.ts
+++ b/test/integration/telemetry/properties.test.ts
@@ -1,0 +1,30 @@
+import { deepStrictEqual } from 'assert';
+import { withTmpDir } from '../util';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { HAS_DEVCONTAINER } from '../../../src/telemetry/definitions/properties';
+
+describe('JavaScript project analyzer', () => {
+  describe('appmap.project.has_devcontainer', () => {
+    it('identifies the presence of a devcontainer.json or .devcontainer.json', async () => {
+      await withTmpDir(async (tmpDir) => {
+        for (const fileName of ['devcontainer.json', '.devcontainer.json']) {
+          const fullPath = path.join(tmpDir, fileName);
+          await fs.writeFile(fullPath, '{}', 'utf-8');
+          deepStrictEqual(
+            await HAS_DEVCONTAINER.getValue({ rootDirectory: tmpDir }),
+            'true',
+            `Expected to find ${fileName}`
+          );
+          await fs.rm(fullPath);
+        }
+      });
+    });
+
+    it('identifies the non-presence of a devcontainer configuration', async () => {
+      await withTmpDir(async (tmpDir) => {
+        deepStrictEqual(await HAS_DEVCONTAINER.getValue({ rootDirectory: tmpDir }), 'false');
+      });
+    });
+  });
+});


### PR DESCRIPTION
`project:open` is now emit after the project has been analyzed, notifying on it's installable status and whether or not it contains a `devcontainer.json`/`.devcontainer.json`.