### PR TITLE
Update VS Code for Runtime Analysis Findings Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -499,10 +499,10 @@
   "dependencies": {
     "@appland/appmap": "^3.43.2",
     "@appland/client": "^1.5.0",
-    "@appland/components": "^2.18.3",
+    "@appland/components": "^2.19.0",
     "@appland/diagrams": "^1.5.3",
     "@appland/models": "^1.20.0",
-    "@appland/scanner": "^1.71.5",
+    "@appland/scanner": "^1.74.0",
     "@appland/sequence-diagram": "^1.1.0",
     "bent": "^7.3.12",
     "bootstrap": "^4.5.3",

--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -1,6 +1,4 @@
 import { WorkspaceFolder } from 'vscode';
-import AppMapCollection from '../services/appmapCollection';
-import AppMapLoader from '../services/appmapLoader';
 import LanguageResolver from '../services/languageResolver';
 import { systemNodeVersion, nvmNodeVersion } from '../services/command';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,8 @@ import { FindingsService } from './findingsService';
 import Environment from './configuration/environment';
 import ErrorCode from './telemetry/definitions/errorCodes';
 import promptInstall from './actions/promptInstall';
+import FindingsOverviewWebview from './webviews/findingsWebview';
+import FindingInfoWebview from './webviews/findingInfoWebview';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -208,6 +210,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     InstallGuideWebView.register(context, projectStates, extensionState);
     const openedInstallGuide = InstallGuideWebView.tryOpen(extensionState);
+
+    FindingsOverviewWebview.register(context);
+    FindingInfoWebview.register(context);
 
     const processService = new NodeProcessService(context, projectStates);
     (async function() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,13 +28,7 @@ import { NodeProcessService } from './services/nodeProcessService';
 import ProjectStateService, { ProjectStateServiceInstance } from './services/projectStateService';
 import { SourceFileWatcher } from './services/sourceFileWatcher';
 import { initializeWorkspaceServices } from './services/workspaceServices';
-import {
-  DEBUG_EXCEPTION,
-  PROJECT_OPEN,
-  Telemetry,
-  TELEMETRY_ENABLED,
-  sendAppMapCreateEvent,
-} from './telemetry';
+import { DEBUG_EXCEPTION, Telemetry, TELEMETRY_ENABLED, sendAppMapCreateEvent } from './telemetry';
 import appmapLinkProvider from './terminalLink/appmapLinkProvider';
 import registerTrees from './tree';
 import { ClassMapTreeDataProvider } from './tree/classMapTreeDataProvider';

--- a/src/services/findingsIndex.ts
+++ b/src/services/findingsIndex.ts
@@ -102,6 +102,32 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
     this._onChanged.fire(workspaceFolder);
   }
 
+  findingsByImpactDomain(impactDomain: string): ResolvedFinding[] {
+    return this.findings().filter((finding) => finding.finding.impactDomain === impactDomain);
+  }
+
+  findingsByHashV2(hash: string): ResolvedFinding[] {
+    return this.findings().filter((finding) => finding.finding.hash_v2 === hash);
+  }
+
+  uniqueFindingsByRuleTitle(ruleTitle: string): ResolvedFinding[] {
+    const findingsByRuleTitle = this.findings().filter(
+      (finding) => finding.finding.ruleTitle === ruleTitle
+    );
+
+    const uniqueFindingsByHash = findingsByRuleTitle.reduce((accumulator, finding) => {
+      const hashV2 = finding.finding.hash_v2;
+
+      if (!(hashV2 in accumulator)) {
+        accumulator[hashV2] = finding;
+      }
+
+      return accumulator;
+    }, {});
+
+    return Object.values(uniqueFindingsByHash);
+  }
+
   dispose(): void {
     this._onChanged.dispose();
   }

--- a/src/services/findingsIndex.ts
+++ b/src/services/findingsIndex.ts
@@ -110,7 +110,7 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
     return this.findings().filter((finding) => finding.finding.impactDomain === impactDomain);
   }
 
-  findingsByHashV2(hash: string): ResolvedFinding[] {
+  findingsByHash(hash: string): ResolvedFinding[] {
     return this.findings().filter((finding) => finding.finding.hash_v2 === hash);
   }
 

--- a/src/services/findingsIndex.ts
+++ b/src/services/findingsIndex.ts
@@ -107,16 +107,16 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
   }
 
   findingsByImpactDomain(impactDomain: string): ResolvedFinding[] {
-    return this.findings().filter((finding) => finding.finding.impactDomain === impactDomain);
+    return this.findings().filter(({ finding }) => finding.impactDomain === impactDomain);
   }
 
   findingsByHash(hash: string): ResolvedFinding[] {
-    return this.findings().filter((finding) => finding.finding.hash_v2 === hash);
+    return this.findings().filter(({ finding }) => finding.hash_v2 === hash);
   }
 
   uniqueFindingsByRuleTitle(ruleTitle: string): ResolvedFinding[] {
     const findingsByRuleTitle = this.findings().filter(
-      (finding) => finding.finding.ruleTitle === ruleTitle
+      ({ finding }) => finding.ruleTitle === ruleTitle
     );
 
     const uniqueFindingsByHash = findingsByRuleTitle.reduce((accumulator, finding) => {

--- a/src/services/findingsIndex.ts
+++ b/src/services/findingsIndex.ts
@@ -6,6 +6,7 @@ import { readFile } from 'fs';
 import EventEmitter from 'events';
 import { fileExists } from '../util';
 import uniq from '../lib/uniq';
+import { Check } from '@appland/scanner';
 
 export default class FindingsIndex extends EventEmitter implements vscode.Disposable {
   private _onChanged = new vscode.EventEmitter<vscode.WorkspaceFolder>();
@@ -50,6 +51,7 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
   ): Promise<void> {
     let findingsData: Buffer;
     let findings: Finding[];
+    let checks: Check[];
 
     try {
       findingsData = await promisify(readFile)(sourceUri.fsPath);
@@ -62,7 +64,9 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
     const findingsDataStr = findingsData.toString();
 
     try {
-      findings = JSON.parse(findingsDataStr).findings;
+      const appmapFindings = JSON.parse(findingsDataStr);
+      findings = appmapFindings.findings;
+      checks = appmapFindings.checks || [];
     } catch (e) {
       // Malformed JSON file. This is unexpected because findings files should be written atomically.
       // TODO: Retry in a little while?
@@ -78,7 +82,7 @@ export default class FindingsIndex extends EventEmitter implements vscode.Dispos
     const resolvedFindings = await Promise.all(
       findings.map(
         async (finding: Finding): Promise<ResolvedFinding> => {
-          const resolvedFinding = new ResolvedFinding(sourceUri, finding);
+          const resolvedFinding = new ResolvedFinding(sourceUri, finding, checks);
           await resolvedFinding.initialize();
           return resolvedFinding;
         }

--- a/src/services/resolvedFinding.ts
+++ b/src/services/resolvedFinding.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Finding } from '@appland/scanner';
+import { Check, Finding, Rule } from '@appland/scanner';
 import { resolveFilePath } from '../util';
 import present from '../lib/present';
 import ValueCache from '../lib/ValueCache';
@@ -26,10 +26,11 @@ const groupDetailsCache = new ValueCache<ResolvedFinding, string | undefined>();
 export class ResolvedFinding {
   public appMapUri?: vscode.Uri;
   public problemLocation?: vscode.Location;
+  public rule?: Rule;
 
   stackFrameIndex = new StackFrameIndex();
 
-  constructor(public sourceUri: vscode.Uri, public finding: Finding) {}
+  constructor(public sourceUri: vscode.Uri, public finding: Finding, public checks: Check[]) {}
 
   async initialize(): Promise<void> {
     await Promise.all(
@@ -40,6 +41,8 @@ export class ResolvedFinding {
         if (location) this.stackFrameIndex.put(this.sourceUri, path, location);
       })
     );
+
+    this.rule = this.checks.find((check) => check.id === this.finding.checkId)?.rule;
 
     this.problemLocation = ResolvedFinding.preferredLocation(
       this.stackFrameIndex,

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -120,7 +120,14 @@ export class FindingsTreeDataProvider
 
     return uniqueFindingsByRuleTitle.map((finding) => {
       const hashV2 = finding.finding.hash_v2;
-      const label = finding.locationLabel;
+      const { event } = finding.finding;
+      const req = event['http_server_request'];
+      const label =
+        finding.locationLabel ||
+        event.path ||
+        finding.finding.stack[0] ||
+        (req && `${req?.request_method} ${req?.path_info}`);
+
       const treeItem = new vscode.TreeItem(String(label));
 
       treeItem.command = {

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -1,28 +1,11 @@
 import * as vscode from 'vscode';
 import FindingsIndex from '../services/findingsIndex';
-import { ResolvedFinding } from '../services/resolvedFinding';
 import AnalysisManager from '../services/analysisManager';
-import memoize from '../lib/memoize';
-import uniq from '../lib/uniq';
-import firstLine from '../lib/firstLine';
 
-function tooltip({
-  finding: { ruleTitle },
-  locationLabel,
-  groupDetails,
-}: ResolvedFinding): vscode.MarkdownString {
-  const result = new vscode.MarkdownString(`**${ruleTitle}**`);
-  if (locationLabel) result.appendText('\n').appendMarkdown(`*${locationLabel}*`);
-  if (groupDetails) result.appendCodeblock(`${groupDetails}`);
-  return result;
-}
-
-const sortKey = memoize(({ finding: { ruleTitle }, locationLabel }: ResolvedFinding) =>
-  [ruleTitle, locationLabel].join(', ')
-);
+const IMPACT_DOMAINS = ['Security', 'Performance', 'Stability', 'Maintainability'];
 
 export class FindingsTreeDataProvider
-  implements vscode.TreeDataProvider<ResolvedFinding>, vscode.Disposable {
+  implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable {
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private findingsIndex?: FindingsIndex;
@@ -53,32 +36,104 @@ export class FindingsTreeDataProvider
     this._onDidChangeTreeData.fire(undefined);
   }
 
-  public getTreeItem(finding: ResolvedFinding): vscode.TreeItem {
-    const {
-      finding: { ruleTitle, hash },
-      locationLabel,
-      problemLocation,
-      groupDetails,
-    } = finding;
-    const item = new vscode.TreeItem(ruleTitle);
-    item.description = locationLabel || firstLine(groupDetails);
-    item.tooltip = tooltip(finding);
-    item.id = hash;
-    if (problemLocation) {
-      item.command = {
-        title: 'Open',
-        command: 'appmap.openFinding',
-        arguments: [problemLocation.uri],
-      };
-    }
-    return item;
+  public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
   }
 
-  public getChildren(): ResolvedFinding[] {
+  public getChildren(element?: vscode.TreeItem): vscode.TreeItem[] {
     if (!this.findingsIndex) return [];
 
-    const unique = uniq(this.findingsIndex.findings(), ({ finding: { hash } }) => hash);
-    return unique.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+    if (!element) {
+      return this.getTopLevelTreeItems();
+    }
+
+    const label = String(element.label);
+    if (IMPACT_DOMAINS.includes(label)) {
+      return this.getChildrenForImpactDomain(label);
+    }
+
+    return this.getChildrenForRule(label);
+  }
+
+  getTopLevelTreeItems(): vscode.TreeItem[] {
+    if (!this.findingsIndex) return [];
+
+    const topLevelTreeLabels = this.findingsIndex
+      .findings()
+      .reduce((impactDomains, finding) => {
+        const impactDomain = finding.finding.impactDomain;
+
+        if (impactDomain && !impactDomains.includes(impactDomain)) {
+          impactDomains.push(impactDomain);
+        }
+
+        return impactDomains;
+      }, [] as string[])
+      .sort((labelA, labelB) => IMPACT_DOMAINS.indexOf(labelA) - IMPACT_DOMAINS.indexOf(labelB));
+
+    const overviewTreeItem = new vscode.TreeItem('Overview');
+    overviewTreeItem.command = {
+      command: 'appmap.openFindingsOverview',
+      title: `Open in AppMap`,
+    };
+
+    return topLevelTreeLabels.reduce(
+      (treeItems, impactDomain) => {
+        const treeItem = new vscode.TreeItem(
+          impactDomain,
+          vscode.TreeItemCollapsibleState.Expanded
+        );
+
+        treeItems.push(treeItem);
+        return treeItems;
+      },
+      [overviewTreeItem]
+    );
+  }
+
+  getChildrenForImpactDomain(impactDomain: string): vscode.TreeItem[] {
+    if (!this.findingsIndex) return [];
+
+    const findingsInImpactDomain = this.findingsIndex.findingsByImpactDomain(impactDomain);
+
+    const ruleTitles = findingsInImpactDomain.reduce((titles, finding) => {
+      const ruleTitle = finding.finding.ruleTitle;
+
+      if (!titles.includes(ruleTitle)) {
+        titles.push(ruleTitle);
+      }
+
+      return titles;
+    }, [] as string[]);
+
+    return ruleTitles
+      .sort((ruleA, ruleB) => (ruleA < ruleB ? -1 : 1))
+      .map((title) => {
+        return new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.Expanded);
+      });
+  }
+
+  getChildrenForRule(ruleTitle: string): vscode.TreeItem[] {
+    if (!this.findingsIndex) return [];
+
+    const uniqueFindingsByRuleTitle = this.findingsIndex.uniqueFindingsByRuleTitle(ruleTitle);
+
+    return uniqueFindingsByRuleTitle.map((finding) => {
+      const hashV2 = finding.finding.hash_v2;
+      const label = finding.locationLabel;
+      const treeItem = new vscode.TreeItem(String(label));
+
+      treeItem.command = {
+        command: 'appmap.openFindingInfo',
+        title: `Finding Info`,
+        arguments: [hashV2],
+      };
+
+      treeItem.tooltip = finding.finding.message;
+      treeItem.id = hashV2;
+
+      return treeItem;
+    });
   }
 
   dispose(): void {

--- a/src/webviews/findingInfoWebview.ts
+++ b/src/webviews/findingInfoWebview.ts
@@ -187,6 +187,11 @@ export default class FindingInfoWebview {
                 vscode.commands.executeCommand('vscode.open', uri);
               }
               break;
+            case 'open-findings-overview':
+              {
+                vscode.commands.executeCommand('appmap.openFindingsOverview');
+              }
+              break;
           }
         });
       })

--- a/src/webviews/findingInfoWebview.ts
+++ b/src/webviews/findingInfoWebview.ts
@@ -1,0 +1,220 @@
+import path, { join } from 'path';
+import * as vscode from 'vscode';
+import fs from 'fs';
+import AnalysisManager from '../services/analysisManager';
+import { ResolvedFinding } from '../services/resolvedFinding';
+import { getNonce } from '../util';
+import { parse } from 'yaml';
+import { Finding } from '@appland/scanner';
+
+type FindingData = {
+  finding: Finding;
+  appMapUri?: vscode.Uri;
+  problemLocation?: vscode.Location;
+  stackLocations: StackLocation[];
+  ruleInfo?: RuleInfo;
+  appMapName: string;
+};
+
+type LocationInfo = {
+  uri: {
+    path: string;
+    scheme: string;
+    fsPath: string;
+  };
+  range: Array<{
+    line: number;
+    character: number;
+  }>;
+};
+
+type RuleFrontMatter = {
+  rule: string;
+  name: string;
+  title: string;
+  references?: Array<{ reference: string }>;
+  impactDomain: string;
+  labels?: Array<string>;
+  scope?: string;
+};
+
+type RuleInfo = {
+  frontMatter?: RuleFrontMatter;
+  description: string;
+};
+
+type StackLocation = vscode.Location & {
+  truncatedPath: string;
+};
+
+type WebPanelHolder = {
+  [hash: string]: vscode.WebviewPanel;
+};
+
+const STACK_TRACE_CHARACTER_LIMIT = 50;
+
+// Attribution: https://github.com/shahata/dasherize
+// MIT License
+function dasherize(str: string): string {
+  return str
+    .replace(/[A-Z0-9](?:(?=[^A-Z0-9])|[A-Z0-9]*(?=[A-Z0-9][^A-Z0-9]|$))/g, function(s, i) {
+      return (i > 0 ? '-' : '') + s.toLowerCase();
+    })
+    .replace(/--+/g, '-');
+}
+
+function openInSource(location: LocationInfo): void {
+  const { uri, range } = location;
+  const [start, end] = range;
+  const selection = new vscode.Range(start.line, start.character, end.line, end.character);
+  vscode.window.showTextDocument(vscode.Uri.file(uri.path), { selection });
+}
+
+function getStackLocations(finding: ResolvedFinding): StackLocation[] {
+  const stackFrameIndex = finding.stackFrameIndex;
+  return Array.from(stackFrameIndex.locationByFrame.values()).map((location) => {
+    let truncatedPath = location.uri.path;
+    const splitPath = location.uri.path.split(path.sep);
+
+    while (truncatedPath.length > STACK_TRACE_CHARACTER_LIMIT) {
+      splitPath.shift();
+      truncatedPath = splitPath.join(path.sep);
+    }
+    truncatedPath = `...${path.sep}${truncatedPath}`;
+
+    return { ...location, truncatedPath };
+  });
+}
+
+function parseRule(id: string): RuleInfo | undefined {
+  const docPath = join(__dirname, `../node_modules/@appland/scanner/doc/rules/${dasherize(id)}.md`);
+
+  if (!fs.existsSync(docPath)) return;
+
+  // replace any carriage return with a newline
+  const content = fs.readFileSync(docPath, 'utf-8').replace(/\r\n/g, '\n');
+  const propertiesContent = content.match(/---\n((?:.*\n)+)---\n((?:.*\n)+?)##?#?/);
+
+  if (!propertiesContent) {
+    // This is probably a new doc that doesn't have front matter yet.
+    // It's all description.
+    return { description: content };
+  }
+
+  const frontMatter = parse(propertiesContent[1]);
+  const description = propertiesContent[2].replace(/\n/g, ' ').trim();
+
+  return {
+    frontMatter,
+    description,
+  };
+}
+
+function filterFinding(resolvedFinding: ResolvedFinding): FindingData {
+  const ruleInfo = parseRule(resolvedFinding.finding.ruleId);
+  const stackLocations = getStackLocations(resolvedFinding);
+  const appMapName = path.basename(resolvedFinding.finding.appMapFile).split('.')[0];
+  const { finding, appMapUri, problemLocation } = resolvedFinding;
+  return { ruleInfo, stackLocations, finding, appMapUri, problemLocation, appMapName };
+}
+
+export default class FindingInfoWebview {
+  private static existingPanels = {} as WebPanelHolder;
+  private static findingsIndex = AnalysisManager.findingsIndex;
+
+  public static register(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+      vscode.commands.registerCommand('appmap.openFindingInfo', async (hash: string) => {
+        if (!this.findingsIndex) {
+          this.findingsIndex = AnalysisManager.findingsIndex;
+        }
+        const findings = this.findingsIndex?.findingsByHashV2(hash).map(filterFinding);
+
+        // Attempt to re-use an existing webview for this project if one exists
+        if (this.existingPanels && this.existingPanels[hash]) {
+          this.existingPanels[hash].reveal(vscode.ViewColumn.One);
+          this.existingPanels[hash].webview.postMessage({
+            type: 'open-new-finding',
+            findings,
+          });
+          return;
+        }
+
+        const panelTitle = (findings && findings[0]?.finding.ruleTitle) || 'Finding Info';
+
+        const panel = vscode.window.createWebviewPanel(
+          'findingInfo',
+          panelTitle,
+          vscode.ViewColumn.One,
+          {
+            enableScripts: true,
+            retainContextWhenHidden: true,
+          }
+        );
+
+        this.existingPanels[hash] = panel;
+        panel.webview.html = getWebviewContent(panel.webview, context);
+
+        panel.onDidDispose(() => {
+          delete this.existingPanels[hash];
+        });
+
+        panel.webview.onDidReceiveMessage(async (message) => {
+          switch (message.command) {
+            case 'findingsInfoReady':
+              panel.webview.postMessage({
+                type: 'initFindingsInfo',
+                findings,
+              });
+
+              break;
+            case 'open-in-source-code':
+              {
+                const location = message.data;
+                openInSource(location);
+              }
+              break;
+            case 'open-map':
+              {
+                let uri: vscode.Uri;
+
+                if (message.data.uri) {
+                  uri = vscode.Uri.from(message.data.uri);
+                } else {
+                  uri = vscode.Uri.file(message.data.mapFile);
+                }
+
+                vscode.commands.executeCommand('vscode.open', uri);
+              }
+              break;
+          }
+        });
+      })
+    );
+  }
+}
+
+function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionContext): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.file(path.join(context.extensionPath, 'out', 'app.js'))
+  );
+  const nonce = getNonce();
+
+  return ` <!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>AppLand Scenario</title>
+  </head>
+  <body>
+    <div id="app">
+    </div>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+    <script type="text/javascript" nonce="${nonce}">
+      AppLandWeb.mountFindingInfoView();
+    </script>
+  </body>
+  </html>`;
+}

--- a/src/webviews/findingInfoWebview.ts
+++ b/src/webviews/findingInfoWebview.ts
@@ -103,7 +103,7 @@ export default class FindingInfoWebview {
         if (!this.findingsIndex) {
           this.findingsIndex = AnalysisManager.findingsIndex;
         }
-        const findings = this.findingsIndex?.findingsByHashV2(hash).map(filterFinding);
+        const findings = this.findingsIndex?.findingsByHash(hash).map(filterFinding);
 
         // Attempt to re-use an existing webview for this project if one exists
         if (this.existingPanels && this.existingPanels[hash]) {

--- a/src/webviews/findingsWebview.ts
+++ b/src/webviews/findingsWebview.ts
@@ -1,0 +1,103 @@
+import path from 'path';
+import * as vscode from 'vscode';
+import AnalysisManager from '../services/analysisManager';
+import { getNonce } from '../util';
+
+export default class FindingsOverviewWebview {
+  private static existingPanel?: vscode.WebviewPanel;
+  private static findingsIndex = AnalysisManager.findingsIndex;
+
+  public static register(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+      vscode.commands.registerCommand('appmap.openFindingsOverview', async () => {
+        if (!this.findingsIndex) {
+          this.findingsIndex = AnalysisManager.findingsIndex;
+        }
+
+        // Attempt to re-use an existing webview for this project if one exists
+        if (this.existingPanel) {
+          this.existingPanel.reveal(vscode.ViewColumn.One);
+          return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+          'findingsOverview',
+          'Findings Overview',
+          vscode.ViewColumn.One,
+          {
+            enableScripts: true,
+            retainContextWhenHidden: true,
+          }
+        );
+
+        this.existingPanel = panel;
+        panel.webview.html = getWebviewContent(panel.webview, context);
+
+        this.findingsIndex?.on('added', () => {
+          this.existingPanel?.webview.postMessage({
+            type: 'findings',
+            findings: this.findingsIndex?.findings(),
+          });
+        });
+        this.findingsIndex?.on('removed', () => {
+          this.existingPanel?.webview.postMessage({
+            type: 'findings',
+            findings: this.findingsIndex?.findings(),
+          });
+        });
+
+        panel.onDidDispose(() => {
+          this.existingPanel = undefined;
+        });
+
+        panel.webview.onDidReceiveMessage(async (message) => {
+          switch (message.command) {
+            case 'findings-overview-ready':
+              panel.webview.postMessage({
+                type: 'initFindings',
+                findings: this.findingsIndex?.findings(),
+              });
+
+              break;
+            case 'open-finding-info':
+              {
+                const hash = message.data;
+                vscode.commands.executeCommand('appmap.openFindingInfo', hash);
+              }
+              break;
+            case 'open-problems-tab':
+              {
+                vscode.commands.executeCommand('workbench.panel.markers.view.focus');
+              }
+              break;
+          }
+        });
+      })
+    );
+  }
+}
+
+function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionContext): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.file(path.join(context.extensionPath, 'out', 'app.js'))
+  );
+  const nonce = getNonce();
+
+  return ` <!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>AppLand Scenario</title>
+  </head>
+  <body>
+    <div id="app">
+    </div>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+    <script type="text/javascript" nonce="${nonce}">
+      AppLandWeb.mountFindingsView();
+    </script>
+  </body>
+  </html>`;
+}

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -213,7 +213,7 @@ function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionCon
     <script nonce="${nonce}" src="${scriptUri}"></script>
     <script type="text/javascript" nonce="${nonce}">
       AppLandWeb.mountInstallGuide();
-    </script>1
+    </script>
   </body>
   </html>`;
 }

--- a/test/system/src/appMap.ts
+++ b/test/system/src/appMap.ts
@@ -1,4 +1,6 @@
 import { Locator, Page } from '@playwright/test';
+import FindingDetailsWebview from './findingDetailsWebview';
+import FindingsOverviewWebview from './findingsOverviewWebview';
 import InstructionsWebview from './instructionsWebview';
 
 export enum InstructionStep {
@@ -18,7 +20,9 @@ export enum InstructionStepStatus {
 export default class AppMap {
   constructor(
     protected readonly page: Page,
-    protected readonly instructionsWebview: InstructionsWebview
+    protected readonly instructionsWebview: InstructionsWebview,
+    protected readonly findingsOverviewWebview: FindingsOverviewWebview,
+    protected readonly findingDetailsWebview: FindingDetailsWebview
   ) {}
 
   get actionPanelButton(): Locator {
@@ -49,6 +53,10 @@ export default class AppMap {
     return this.findingsTree.locator('.pane-body >> [role="treeitem"]').nth(nth || 0);
   }
 
+  public finding(nth?: number): Locator {
+    return this.findingsTree.locator('[role="treeitem"][aria-level="3"]').nth(nth || 0);
+  }
+
   public appMapTreeItem(): Locator {
     return this.appMapTree.locator('.pane-body >> [role="treeitem"]:not([aria-expanded])').first();
   }
@@ -57,6 +65,14 @@ export default class AppMap {
     if (await this.findingsTree.locator('.pane-body').isHidden()) {
       await this.findingsTree.click();
     }
+  }
+
+  public async openFindingsOverview(): Promise<void> {
+    this.findingsTreeItem(0).click();
+  }
+
+  public openNthFinding(nth: number): void {
+    this.finding(nth).click();
   }
 
   public async openActionPanel(): Promise<void> {

--- a/test/system/src/driver.ts
+++ b/test/system/src/driver.ts
@@ -1,6 +1,8 @@
 import { BrowserContext, ElectronApplication, Locator, Page } from '@playwright/test';
 import { glob } from 'glob';
 import AppMap from './appMap';
+import FindingDetailsWebview from './findingDetailsWebview';
+import FindingsOverviewWebview from './findingsOverviewWebview';
 import InstructionsWebview from './instructionsWebview';
 import Panel from './panel';
 import { getOsShortcut } from './util';
@@ -15,7 +17,14 @@ async function tryClick(elem: Locator, timeout = 5000) {
 
 export default class Driver {
   public readonly instructionsWebview = new InstructionsWebview(this.page);
-  public readonly appMap = new AppMap(this.page, this.instructionsWebview);
+  public readonly findingsOverviewWebview = new FindingsOverviewWebview(this.page);
+  public readonly findingDetailsWebview = new FindingDetailsWebview(this.page);
+  public readonly appMap = new AppMap(
+    this.page,
+    this.instructionsWebview,
+    this.findingsOverviewWebview,
+    this.findingDetailsWebview
+  );
   public readonly panel = new Panel(this.page);
 
   constructor(

--- a/test/system/src/findingDetailsWebview.ts
+++ b/test/system/src/findingDetailsWebview.ts
@@ -1,0 +1,31 @@
+import { FrameLocator, Page } from '@playwright/test';
+import { strictEqual } from 'assert';
+import { waitFor } from '../../waitFor';
+
+export default class FindingDetailsWebview {
+  constructor(protected readonly page: Page) {}
+
+  private frameSelector = 'iframe.webview.ready';
+  private frame?: FrameLocator;
+  private initializeErrorMsg = 'No frame found. Call initialize() first';
+
+  public async assertTitleRenders(expectedTitle: string): Promise<void> {
+    if (!this.frame) throw Error(this.initializeErrorMsg);
+
+    const title = this.frame.locator('[data-cy="title"]');
+    strictEqual(await title.count(), 1, 'Expected one title element');
+    strictEqual(await title.innerText(), expectedTitle);
+  }
+
+  public async initialize(expectedFrames: number): Promise<void> {
+    const checkForIFrames = async () => {
+      const iframes = await this.page.locator(this.frameSelector).count();
+      return iframes === expectedFrames;
+    };
+
+    await waitFor('waiting for second iframe', checkForIFrames.bind(this));
+    const outerFrame = this.page.frameLocator(this.frameSelector).last();
+    await outerFrame.locator('iframe#active-frame').waitFor();
+    this.frame = outerFrame.frameLocator('#active-frame');
+  }
+}

--- a/test/system/src/findingDetailsWebview.ts
+++ b/test/system/src/findingDetailsWebview.ts
@@ -24,6 +24,7 @@ export default class FindingDetailsWebview {
     };
 
     await waitFor('waiting for second iframe', checkForIFrames.bind(this));
+    // this assumes that the last iframe is the finding details page
     const outerFrame = this.page.frameLocator(this.frameSelector).last();
     await outerFrame.locator('iframe#active-frame').waitFor();
     this.frame = outerFrame.frameLocator('#active-frame');

--- a/test/system/src/findingsOverviewWebview.ts
+++ b/test/system/src/findingsOverviewWebview.ts
@@ -1,0 +1,49 @@
+import { FrameLocator, Page } from '@playwright/test';
+import { strictEqual } from 'assert';
+import { waitFor } from '../../waitFor';
+
+export default class FindingsOverviewWebview {
+  constructor(protected readonly page: Page) {}
+
+  private title = 'Runtime Analysis';
+  private frameSelector = 'iframe.webview.ready';
+  private frame?: FrameLocator;
+  private initializeErrorMsg = 'No frame found. Call initialize() first';
+
+  public async assertNumberOfFindingsInOverview(expected: number): Promise<void> {
+    if (!this.frame) throw Error(this.initializeErrorMsg);
+
+    const count = await this.frame.locator('[data-cy="finding"]').count();
+    strictEqual(count, expected, `Expected number of findings to be ${expected}`);
+  }
+
+  public async assertTitleRenders(): Promise<void> {
+    if (!this.frame) throw Error(this.initializeErrorMsg);
+
+    const title = this.frame.locator('[data-cy="title"]');
+    strictEqual(await title.count(), 1, 'Expected one title element');
+    strictEqual(await title.innerText(), this.title);
+  }
+
+  public async openFirstFindingDetail(): Promise<void> {
+    if (!this.frame) throw Error(this.initializeErrorMsg);
+
+    this.frame
+      .locator('[data-cy="finding"]')
+      .first()
+      .locator('ul')
+      .click();
+  }
+
+  public async initialize(expectedFrames: number): Promise<void> {
+    const checkForIFrames = async () => {
+      const iframes = await this.page.locator(this.frameSelector).count();
+      return iframes === expectedFrames;
+    };
+
+    await waitFor('waiting for second iframe', checkForIFrames.bind(this));
+    const outerFrame = this.page.frameLocator(this.frameSelector).last();
+    await outerFrame.locator('iframe#active-frame').waitFor();
+    this.frame = outerFrame.frameLocator('#active-frame');
+  }
+}

--- a/test/system/src/findingsOverviewWebview.ts
+++ b/test/system/src/findingsOverviewWebview.ts
@@ -42,6 +42,7 @@ export default class FindingsOverviewWebview {
     };
 
     await waitFor('waiting for second iframe', checkForIFrames.bind(this));
+    // this assumes that the last iframe is the findings page
     const outerFrame = this.page.frameLocator(this.frameSelector).last();
     await outerFrame.locator('iframe#active-frame').waitFor();
     this.frame = outerFrame.frameLocator('#active-frame');

--- a/test/system/src/instructionsWebview.ts
+++ b/test/system/src/instructionsWebview.ts
@@ -6,10 +6,13 @@ export default class InstructionsWebview {
   private frameSelector = 'iframe.webview.ready';
 
   private get frame(): FrameLocator {
-    return this.page
-      .frameLocator(this.frameSelector)
-      .first()
-      .frameLocator('#active-frame');
+    return (
+      this.page
+        .frameLocator(this.frameSelector)
+        // this assumes that the first iframe is the instructions page
+        .first()
+        .frameLocator('#active-frame')
+    );
   }
 
   public get currentPage(): Locator {

--- a/test/system/tests/findings.test.ts
+++ b/test/system/tests/findings.test.ts
@@ -1,3 +1,4 @@
+import { strictEqual } from 'assert';
 import * as path from 'path';
 
 describe('Findings and scanning', function() {
@@ -19,9 +20,88 @@ describe('Findings and scanning', function() {
     await driver.appMap.openActionPanel();
     await driver.appMap.expandFindings();
     await driver.appMap.findingsTree.click();
-    await driver.appMap.findingsTreeItem().waitFor({ state: 'hidden' });
+    await driver.appMap.findingsTreeItem().waitFor();
     await project.restoreFiles('**/*.appmap.json');
     await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
-    await driver.appMap.findingsTreeItem().waitFor({ state: 'visible' });
+    await driver.appMap.findingsTreeItem(1).waitFor();
+  });
+
+  it('shows the findings overview page', async function() {
+    const { driver, project } = this;
+
+    await driver.appMap.openActionPanel();
+    await driver.appMap.expandFindings();
+    await driver.appMap.openFindingsOverview();
+    const expectedFrames = 2;
+    await driver.appMap.findingsOverviewWebview.initialize(expectedFrames);
+    await driver.appMap.findingsOverviewWebview.assertTitleRenders();
+    await driver.appMap.findingsOverviewWebview.assertNumberOfFindingsInOverview(0);
+    await project.restoreFiles('**/*.appmap.json');
+    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
+    await driver.appMap.findingsTreeItem(1).waitFor();
+    await driver.appMap.findingsOverviewWebview.assertNumberOfFindingsInOverview(3);
+  });
+
+  it('opens the findings details page from the findings overview page', async function() {
+    const { driver, project } = this;
+
+    await driver.appMap.openActionPanel();
+    await driver.appMap.expandFindings();
+    await driver.appMap.openFindingsOverview();
+
+    let expectedFrames = 2;
+    await driver.appMap.findingsOverviewWebview.initialize(expectedFrames);
+    await driver.appMap.findingsOverviewWebview.assertTitleRenders();
+    await project.restoreFiles('**/*.appmap.json');
+    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
+    await driver.appMap.findingsTreeItem(1).waitFor();
+    await driver.appMap.findingsOverviewWebview.openFirstFindingDetail();
+
+    expectedFrames = 3;
+    await driver.appMap.findingDetailsWebview.initialize(expectedFrames);
+
+    const expectedTitle = 'N plus 1 SQL query';
+    await driver.appMap.findingDetailsWebview.assertTitleRenders(expectedTitle);
+  });
+
+  it('opens the findings details page from the runtime analysis tree view', async function() {
+    const { driver, project } = this;
+
+    await driver.appMap.openActionPanel();
+    await driver.appMap.expandFindings();
+
+    await project.restoreFiles('**/*.appmap.json');
+    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
+    await driver.appMap.findingsTreeItem(1).waitFor();
+
+    await driver.appMap.openNthFinding(2);
+    const expectedFrames = 2;
+    await driver.appMap.findingDetailsWebview.initialize(expectedFrames);
+
+    const expectedTitle = 'N plus 1 SQL query';
+    await driver.appMap.findingDetailsWebview.assertTitleRenders(expectedTitle);
+  });
+
+  it('reuses the finding details webview', async function() {
+    const { driver, project } = this;
+
+    await driver.appMap.openActionPanel();
+    await driver.appMap.expandFindings();
+    await driver.appMap.openFindingsOverview();
+    let expectedFrames = 2;
+    await driver.appMap.findingsOverviewWebview.initialize(expectedFrames);
+
+    await project.restoreFiles('**/*.appmap.json');
+    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
+    await driver.appMap.findingsTreeItem(1).waitFor();
+
+    await driver.appMap.findingsOverviewWebview.openFirstFindingDetail();
+    expectedFrames = 3;
+    await driver.appMap.findingDetailsWebview.initialize(expectedFrames);
+    await driver.appMap.openNthFinding(2);
+    await driver.appMap.findingDetailsWebview.initialize(expectedFrames);
+
+    const numTabs = await driver.tabCount();
+    strictEqual(numTabs, expectedFrames);
   });
 });

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -3,5 +3,7 @@ import plugin from '@appland/components';
 
 export { default as mountApp } from './appmapView';
 export { default as mountInstallGuide } from './installGuideView';
+export { default as mountFindingsView } from './findingsView';
+export { default as mountFindingInfoView } from './findingsInfo';
 
 Vue.use(plugin);

--- a/web/src/appmapView.js
+++ b/web/src/appmapView.js
@@ -10,8 +10,7 @@ export default function mountApp() {
 
   const app = new Vue({
     el: '#app',
-    // eslint-disable-next-line arrow-body-style
-    render: (h) => {
+    render(h) {
       return h(VVsCodeExtension, {
         ref: 'ui',
         props: {

--- a/web/src/findingsInfo.js
+++ b/web/src/findingsInfo.js
@@ -47,6 +47,10 @@ export default function mountFindingInfoView() {
     app.$on('open-map', (mapFile, uri) => {
       messages.rpc('open-map', { mapFile, uri });
     });
+
+    app.$on('open-findings-overview', () => {
+      messages.rpc('open-findings-overview');
+    });
   });
 
   vscode.postMessage({ command: 'findingsInfoReady' });

--- a/web/src/findingsInfo.js
+++ b/web/src/findingsInfo.js
@@ -1,0 +1,53 @@
+import Vue from 'vue';
+import { VFindingDetails } from '@appland/components'; // eslint-disable-line import/no-named-default
+import '@appland/diagrams/dist/style.css';
+import MessagePublisher from './messagePublisher';
+
+export default function mountFindingInfoView() {
+  const vscode = window.acquireVsCodeApi();
+  const messages = new MessagePublisher(vscode);
+
+  messages.on('initFindingsInfo', (initialData) => {
+    const app = new Vue({
+      el: '#app',
+      render(h) {
+        return h(VFindingDetails, {
+          ref: 'ui',
+          props: {
+            findings: this.findings,
+          },
+        });
+      },
+      data() {
+        return {
+          findings: initialData.findings,
+        };
+      },
+    });
+
+    window.addEventListener('error', (event) => {
+      vscode.postMessage({
+        command: 'reportError',
+        error: {
+          message: event.error.message,
+          stack: event.error.stack,
+        },
+      });
+    });
+
+    messages.on('open-new-finding', ({ findings }) => {
+      app.findings = findings;
+      app.$forceUpdate();
+    });
+
+    app.$on('open-in-source-code', (location) => {
+      messages.rpc('open-in-source-code', location);
+    });
+
+    app.$on('open-map', (mapFile, uri) => {
+      messages.rpc('open-map', { mapFile, uri });
+    });
+  });
+
+  vscode.postMessage({ command: 'findingsInfoReady' });
+}

--- a/web/src/findingsView.js
+++ b/web/src/findingsView.js
@@ -1,0 +1,53 @@
+import Vue from 'vue';
+import { VAnalysisFindings } from '@appland/components'; // eslint-disable-line import/no-named-default
+import '@appland/diagrams/dist/style.css';
+import MessagePublisher from './messagePublisher';
+
+export default function mountFindingsView() {
+  const vscode = window.acquireVsCodeApi();
+  const messages = new MessagePublisher(vscode);
+
+  messages.on('initFindings', (initialData) => {
+    const app = new Vue({
+      el: '#app',
+      render(h) {
+        return h(VAnalysisFindings, {
+          ref: 'ui',
+          props: {
+            findings: this.findings,
+          },
+        });
+      },
+      data() {
+        return {
+          findings: initialData.findings,
+        };
+      },
+    });
+
+    window.addEventListener('error', (event) => {
+      vscode.postMessage({
+        command: 'reportError',
+        error: {
+          message: event.error.message,
+          stack: event.error.stack,
+        },
+      });
+    });
+
+    messages.on('findings', (message) => {
+      app.findings = message.findings;
+      app.$forceUpdate();
+    });
+
+    app.$on('open-finding-info', (hash) => {
+      messages.rpc('open-finding-info', hash);
+    });
+
+    app.$on('open-problems-tab', () => {
+      messages.rpc('open-problems-tab');
+    });
+  });
+
+  vscode.postMessage({ command: 'findings-overview-ready' });
+}

--- a/web/src/installGuideView.js
+++ b/web/src/installGuideView.js
@@ -80,20 +80,12 @@ export default function mountInstallGuide() {
       vscode.postMessage({ command: 'open-file', file });
     });
 
-    app.$on('perform-install', (path, language) => {
-      vscode.postMessage({ command: 'perform-install', path, language });
-    });
-
     app.$on('open-instruction', (pageId) => {
       app.$refs.ui.jumpTo(pageId);
     });
 
     app.$on('perform-install', (path, language) => {
       vscode.postMessage({ command: 'perform-install', path, language });
-    });
-
-    app.$on('open-instruction', (pageId) => {
-      app.$refs.ui.jumpTo(pageId);
     });
 
     app.$on('generate-openapi', (projectPath) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/client@npm:^1.3.0, @appland/client@npm:^1.5.0":
+"@appland/client@npm:^1.5.0":
   version: 1.5.0
   resolution: "@appland/client@npm:1.5.0"
   dependencies:
@@ -119,7 +119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:2.18.3, @appland/components@npm:^2.18.3":
+"@appland/components@npm:2.18.3":
   version: 2.18.3
   resolution: "@appland/components@npm:2.18.3"
   dependencies:
@@ -131,6 +131,21 @@ __metadata:
     vue: ^2.6.11
     vuex: ^3.6.0
   checksum: 8ccd067f0b2d1a4c94d18682992ddf27071b8684a4e3bab27be9661288939fe948611bb260bd57f0a17f155d4f796d54f22a3ab18b91d0a7e6f8f9a68b836f86
+  languageName: node
+  linkType: hard
+
+"@appland/components@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "@appland/components@npm:2.19.0"
+  dependencies:
+    "@appland/diagrams": ^1.5.1
+    "@appland/models": ^1.9.0
+    buffer: ^6.0.3
+    highlight.js: ^10.7.2
+    sql-formatter: ^4.0.2
+    vue: ^2.6.11
+    vuex: ^3.6.0
+  checksum: 0ee4ea8d777e72f13780281c5adf01feeb42585ce23495352ea26ea5060418b17966d2cb3d16b7694d0baf57124bb39fc8afa271c78e75069b69c932996f6e38
   languageName: node
   linkType: hard
 
@@ -169,6 +184,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@appland/models@npm:1.22.0":
+  version: 1.22.0
+  resolution: "@appland/models@npm:1.22.0"
+  dependencies:
+    "@appland/sql-parser": ^1.5.0
+    crypto-js: ^4.0.0
+  checksum: 9627cc5143a93114a94bac4f9d967e126fa7fc6c63bdabdb0665dc49c5993aa776b485f78ab725414b18987935806af107a84075f50890acff89e4152c6a8c34
+  languageName: node
+  linkType: hard
+
 "@appland/openapi@npm:1.1.0":
   version: 1.1.0
   resolution: "@appland/openapi@npm:1.1.0"
@@ -179,13 +204,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/scanner@npm:^1.71.5":
-  version: 1.72.0
-  resolution: "@appland/scanner@npm:1.72.0"
+"@appland/openapi@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@appland/openapi@npm:1.2.0"
   dependencies:
-    "@appland/client": ^1.3.0
+    "@appland/models": 1.22.0
+    js-yaml: ^4.1.0
+  checksum: 113ad14837a22ada4cbf43a93430b0bfdfac6cb3194a9b6d60323f6d63d06cc99e8097a74e8c4938b107f6d62af97d835c2ed4a1d24ccb3df095eeedc202708c
+  languageName: node
+  linkType: hard
+
+"@appland/scanner@npm:^1.74.0":
+  version: 1.74.0
+  resolution: "@appland/scanner@npm:1.74.0"
+  dependencies:
+    "@appland/client": ^1.5.0
     "@appland/models": ^1.18.1
-    "@appland/openapi": 1.1.0
+    "@appland/openapi": 1.2.0
     "@appland/sql-parser": ^1.5.0
     "@types/cli-progress": ^3.9.2
     ajv: ^8.8.2
@@ -212,7 +247,7 @@ __metadata:
     yargs: ^17.1.1
   bin:
     scanner: built/cli.js
-  checksum: 0a03a4558d4369013aea20d2861207855bd1c01e795c27b86f502d8cda68a7aafa65cff71ee96b253e9681fc40e1e3ae9e8f840fc115b81c90f8ee0c635c3fc7
+  checksum: dcfd412de5015e015daf1b60478e98c530fd3af6e6c6a661609e74cb7420dfdb9c4bb8200db30b051260f9f43762bec0555a21c4b2030e3154b60a176c60ec1b
   languageName: node
   linkType: hard
 
@@ -3663,10 +3698,10 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.43.2
     "@appland/client": ^1.5.0
-    "@appland/components": ^2.18.3
+    "@appland/components": ^2.19.0
     "@appland/diagrams": ^1.5.3
     "@appland/models": ^1.20.0
-    "@appland/scanner": ^1.71.5
+    "@appland/scanner": ^1.74.0
     "@appland/sequence-diagram": ^1.1.0
     "@babel/core": ^7.19.3
     "@babel/preset-env": ^7.14.2


### PR DESCRIPTION
Fixes #520
This PR uses webviews that are available from [this PR](https://github.com/getappmap/appmap-js/pull/838)

## **Overview**
This PR adds webviews to the VS Code extension that provide information about findings. There are three main changes:
1. The `Runtime Analysis` tree view is now organized:

![image](https://user-images.githubusercontent.com/45714532/202808749-afaf4002-5c4b-4430-98d2-08015789085b.png)

2. There is a `Findings Overview` page:

![image](https://user-images.githubusercontent.com/45714532/202808870-43cc64eb-d713-4204-9ba7-5fefa031b901.png)

3. There is a `Finding Details` page for each finding:

![image](https://user-images.githubusercontent.com/45714532/202808935-4daafcc4-df1b-4c51-a540-dcd9c6f6250f.png)

## **Developing Locally**

1. Build [this branch](https://github.com/getappmap/appmap-js/tree/analysis-findings) of `appmap-js` locally.
a. `git clone https://github.com/getappmap/appmap-js.git`.
b. `cd appmap-js`.
c. `git checkout analysis-findings`.
d. `yarn`.
e. `yarn build`.
5. Checkout this branch of `vscode-appland`.
6. Add this to the bottom of you `package.json` file in `vscode-appland`, replacing `YOUR_PATH` with the path to `appmap-js` on your machine::
```
"resolutions": {
    "@appland/components": "portal:<YOUR_PATH>/appmap-js/packages/components",
    "@appland/diagrams": "portal:<YOUR_PATH>/appmap-js/packages/diagrams",
    "@appland/models": "portal:<YOUR_PATH>/appmap-js/packages/models",
    "@appland/openapi": "portal:<YOUR_PATH>/appmap-js/packages/openapi",
    "@appland/scanner": "portal:<YOUR_PATH>/appmap-js/packages/scanner"
  }
```
5. Run `yarn` from the root of `vscode-appland`.
7. Run `yarn watch` from the root of `vscode-appland`.
8. Open `vscode-appland` in VS Code and launch the debugger extension host (press `F5` or click the `Run` menu and then click `Start Debugging`).