### PR TITLE
Prompt users to install if the project is supported

### DIFF
--- a/src/actions/promptInstall.ts
+++ b/src/actions/promptInstall.ts
@@ -1,4 +1,4 @@
-import ProjectStateService from '../services/projectStateService';
+import ProjectStateService, { ProjectStateServiceInstance } from '../services/projectStateService';
 import { WorkspaceServices } from '../services/workspaceServices';
 import * as vscode from 'vscode';
 import { INSTALL_PROMPT, Telemetry } from '../telemetry';
@@ -22,6 +22,12 @@ const promptResponses: ReadonlyArray<vscode.MessageItem> = [
   { title: ButtonText.DontShowAgain },
 ];
 
+const meetsPromptCriteria = (project: ProjectStateServiceInstance): boolean =>
+  project.installable &&
+  !project.metadata.agentInstalled &&
+  project.metadata.language?.name === 'Ruby' &&
+  project.metadata.webFramework?.name === 'Rails';
+
 export default async function promptInstall(
   services: WorkspaceServices,
   extensionState: ExtensionState
@@ -35,9 +41,7 @@ export default async function promptInstall(
     undefined;
   if (silencePrompt) return;
 
-  const numInstallable = projectInstances.filter(
-    (project) => project.installable && !project.metadata.agentInstalled
-  ).length;
+  const numInstallable = projectInstances.filter(meetsPromptCriteria).length;
   if (!numInstallable) return;
 
   const numProjects = projectInstances.length;

--- a/src/actions/promptInstall.ts
+++ b/src/actions/promptInstall.ts
@@ -1,0 +1,71 @@
+import ProjectStateService from '../services/projectStateService';
+import { WorkspaceServices } from '../services/workspaceServices';
+import * as vscode from 'vscode';
+import { INSTALL_PROMPT, Telemetry } from '../telemetry';
+import ExtensionState from '../configuration/extensionState';
+
+export enum ButtonText {
+  Confirm = 'Open instructions',
+  Deny = 'Later',
+  DontShowAgain = "Don't show again",
+}
+
+function getKey(val: string): keyof typeof ButtonText {
+  const entry = Object.entries(ButtonText).find(([, v]) => v === val);
+  if (!entry) return 'Deny';
+  return entry[0] as keyof typeof ButtonText;
+}
+
+const promptResponses: ReadonlyArray<vscode.MessageItem> = [
+  { title: ButtonText.Confirm },
+  { title: ButtonText.Deny, isCloseAffordance: true },
+  { title: ButtonText.DontShowAgain },
+];
+
+export default async function promptInstall(
+  services: WorkspaceServices,
+  extensionState: ExtensionState
+): Promise<void> {
+  const projectService = services.getService(ProjectStateService);
+  if (!projectService) return;
+
+  const projectInstances = services.getServiceInstances(projectService);
+  const silencePrompt =
+    projectInstances.find(({ folder }) => extensionState.getHideInstallPrompt(folder)) !==
+    undefined;
+  if (silencePrompt) return;
+
+  const numInstallable = projectInstances.filter(
+    (project) => project.installable && !project.metadata.agentInstalled
+  ).length;
+  if (!numInstallable) return;
+
+  const numProjects = projectInstances.length;
+
+  const msg: Array<string> = [];
+  if (numProjects === 1) {
+    msg.push('AppMap is ready to map and analyze this project.');
+  } else {
+    // Must be greater than one, otherwise we'd already have returned
+    if (numProjects === numInstallable) {
+      msg.push('AppMap is ready to map and analyze every project within this workspace.');
+    } else {
+      msg.push(`AppMap is ready to map and analyze ${numInstallable} projects in this workspace.`);
+    }
+  }
+  msg.push('Open the setup instructions?');
+
+  const response = await vscode.window.showInformationMessage(msg.join(' '), ...promptResponses);
+  Telemetry.sendEvent(INSTALL_PROMPT, { result: getKey(response?.title || ButtonText.Deny) });
+
+  if (response?.title === ButtonText.Confirm) {
+    /*
+    This should execute `InstallGuideWebView.command` but requiring this file ends up importing an SVG. Our `tsc`
+    compiled tests have no way of reading this file, so it'll result in a panic at runtime. For now, reference the
+    command directly.
+    */
+    await vscode.commands.executeCommand('appmap.openInstallGuide', 'project-picker');
+  } else if (response?.title === ButtonText.DontShowAgain) {
+    projectInstances.forEach(({ folder }) => extensionState.setHideInstallPrompt(folder, true));
+  }
+}

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -14,6 +14,7 @@ export const Keys = {
     OPENED_APPMAP: 'appmap.applandinc.workspaces_opened_appmap',
     FINDINGS_INVESTIGATED: 'appmap.applandinc.findingsInvestigated',
     GENERATED_OPENAPI: 'appmap.applandinc.generatedOpenApi',
+    HIDE_INSTALL_PROMPT: 'appmap.applandinc.hideInstallPrompt',
   },
 };
 
@@ -159,6 +160,14 @@ export default class ExtensionState {
 
   setWorkspaceGeneratedOpenApi(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
     this.setWorkspaceFlag(Keys.Workspace.GENERATED_OPENAPI, value, workspaceFolder);
+  }
+
+  setHideInstallPrompt(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.setWorkspaceFlag(Keys.Workspace.HIDE_INSTALL_PROMPT, value, workspaceFolder);
+  }
+
+  getHideInstallPrompt(workspaceFolder: vscode.WorkspaceFolder): boolean {
+    return this.getWorkspaceFlag(Keys.Workspace.HIDE_INSTALL_PROMPT, workspaceFolder.uri.fsPath);
   }
 
   resetState(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,7 +207,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     tryDisplayEarlyAccessWelcome(context);
 
     InstallGuideWebView.register(context, projectStates, extensionState);
-    InstallGuideWebView.tryOpen(extensionState);
+    const openedInstallGuide = InstallGuideWebView.tryOpen(extensionState);
 
     const processService = new NodeProcessService(context, projectStates);
     (async function() {
@@ -254,7 +254,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     registerUtilityCommands(context, extensionState);
 
-    promptInstall(workspaceServices, extensionState);
+    if (!openedInstallGuide) promptInstall(workspaceServices, extensionState);
 
     vscode.env.onDidChangeTelemetryEnabled((enabled: boolean) => {
       Telemetry.sendEvent(TELEMETRY_ENABLED, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,7 @@ import AnalysisManager from './services/analysisManager';
 import { FindingsService } from './findingsService';
 import Environment from './configuration/environment';
 import ErrorCode from './telemetry/definitions/errorCodes';
+import promptInstall from './actions/promptInstall';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -252,6 +253,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     );
 
     registerUtilityCommands(context, extensionState);
+
+    promptInstall(workspaceServices, extensionState);
 
     vscode.env.onDidChangeTelemetryEnabled((enabled: boolean) => {
       Telemetry.sendEvent(TELEMETRY_ENABLED, {

--- a/src/services/workspaceServices.ts
+++ b/src/services/workspaceServices.ts
@@ -90,7 +90,8 @@ export class WorkspaceServices implements vscode.Disposable {
   getService<
     ServiceInstanceType extends WorkspaceServiceInstance,
     ServiceType extends WorkspaceService<ServiceInstanceType>
-  >(c: { new (): ServiceType }): ServiceType | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  >(c: { new (...args: any[]): ServiceType }): ServiceType | undefined {
     return this.workspaceServices.find((service) => service.constructor === c) as ServiceType;
   }
 
@@ -108,14 +109,16 @@ export class WorkspaceServices implements vscode.Disposable {
   /**
    * Gets all instances of a given service, with an optional folder name.
    */
-  getServiceInstances(
-    service: WorkspaceService<WorkspaceServiceInstance>,
+  getServiceInstances<ServiceInstanceType extends WorkspaceServiceInstance>(
+    service: WorkspaceService<ServiceInstanceType>,
     folder?: vscode.WorkspaceFolder
-  ): WorkspaceServiceInstance[] {
+  ): ServiceInstanceType[] {
     const serviceInstances = folder
       ? this.workspaceServiceInstances.get(folder) || []
       : Array(...this.workspaceServiceInstances.values()).flat();
-    return serviceInstances.filter((instance) => this.instanceServices.get(instance) === service);
+    return serviceInstances.filter(
+      (instance) => this.instanceServices.get(instance) === service
+    ) as ServiceInstanceType[];
   }
 
   private enrollServiceInstance(

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -154,3 +154,8 @@ export const AUTHENTICATION_FAILED = new Event({ name: 'authentication:failed' }
 export const ANALYSIS_ENABLE = new Event({ name: 'analysis:enable' });
 export const ANALYSIS_DISABLE = new Event({ name: 'analysis:disable' });
 export const ANALYSIS_CTA_INTERACTION = new Event({ name: 'analysis:cta_interaction' });
+
+export const INSTALL_PROMPT = new Event({
+  name: 'install_prompt',
+  properties: [Properties.RESULT],
+});

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -38,6 +38,13 @@ export const TEXT = new TelemetryDataProvider({
   },
 });
 
+export const RESULT = new TelemetryDataProvider({
+  id: 'appmap.result',
+  async value({ result }: { result: string }): Promise<string> {
+    return result;
+  },
+});
+
 export const CTA_ID = new TelemetryDataProvider({
   id: 'appmap.cta.id',
   async value({ id }: { id: string }): Promise<string> {

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -35,7 +35,7 @@ export default class InstallGuideWebView {
   public static readonly command = 'appmap.openInstallGuide';
   private static existingPanel?: vscode.WebviewPanel;
 
-  public static tryOpen(extensionState: ExtensionState): Thenable<void | undefined> | undefined {
+  public static tryOpen(extensionState: ExtensionState): boolean {
     const firstVersionInstalled = semver.coerce(extensionState.firstVersionInstalled);
     if (firstVersionInstalled && semver.gte(firstVersionInstalled, '0.15.0')) {
       // Logic within this block will only be executed if the extension was installed after we began tracking the
@@ -44,9 +44,11 @@ export default class InstallGuideWebView {
 
       if (!extensionState.hasViewedInstallGuide) {
         extensionState.hasViewedInstallGuide = true;
-        return vscode.commands.executeCommand(InstallGuideWebView.command, 'project-picker');
+        vscode.commands.executeCommand(InstallGuideWebView.command, 'project-picker');
+        return true;
       }
     }
+    return false;
   }
 
   public static register(

--- a/test/disabled/installGuide.test.ts
+++ b/test/disabled/installGuide.test.ts
@@ -41,7 +41,7 @@ describe('Install guide', () => {
       mockSingleProjectWorkspace(sinon);
 
       assert(properties.hasViewedInstallGuide === false);
-      await InstallGuideWebView.tryOpen(properties);
+      InstallGuideWebView.tryOpen(properties);
       assert(executeCommand.calledWith('appmap.openWorkspaceOverview'));
       assert(properties.hasViewedInstallGuide);
     });
@@ -53,7 +53,7 @@ describe('Install guide', () => {
       mockSingleProjectWorkspace(sinon);
 
       assert(properties.hasViewedInstallGuide === false);
-      await InstallGuideWebView.tryOpen(properties);
+      InstallGuideWebView.tryOpen(properties);
       assert(executeCommand.calledWith('appmap.openWorkspaceOverview') === false);
       assert(properties.hasViewedInstallGuide === false);
     });
@@ -65,7 +65,7 @@ describe('Install guide', () => {
       mockSingleProjectWorkspace(sinon);
 
       assert(properties.hasViewedInstallGuide === false);
-      await InstallGuideWebView.tryOpen(properties);
+      InstallGuideWebView.tryOpen(properties);
 
       assert(executeCommand.calledWith('appmap.openWorkspaceOverview') === shouldOpen);
       assert(properties.hasViewedInstallGuide === shouldOpen);

--- a/test/integration/actions/promptInstall.test.ts
+++ b/test/integration/actions/promptInstall.test.ts
@@ -9,14 +9,18 @@ import { ProjectStateServiceInstance } from '../../../src/services/projectStateS
 import { ProjectA } from '../util';
 
 const unsafeCast = <T>(val: unknown): T => val as T;
-const stubWorkspaceServices = (installable = true) =>
+const stubWorkspaceServices = (installable = true, language = 'Ruby', webFramework = 'Rails') =>
   unsafeCast<WorkspaceServices>({
     getService: () => sinon.stub(),
     getServiceInstances: () =>
       unsafeCast<Array<ProjectStateServiceInstance>>([
         {
           folder: { name: path.basename(ProjectA), uri: vscode.Uri.parse(ProjectA), index: -1 },
-          metadata: { agentInstalled: false },
+          metadata: {
+            agentInstalled: false,
+            language: { name: language },
+            webFramework: { name: webFramework },
+          },
           installable,
         },
       ]),
@@ -91,6 +95,17 @@ describe('promptInstall', () => {
 
   context('when in an uninstallable project', () => {
     const workspaceServices = stubWorkspaceServices(false);
+    const extensionState = unsafeCast<ExtensionState>({ getHideInstallPrompt: () => false });
+
+    it('does not prompt', async () => {
+      const showInformationMessage = sinon.stub(vscode.window, 'showInformationMessage');
+      await promptInstall(workspaceServices, extensionState);
+      assert(!showInformationMessage.called);
+    });
+  });
+
+  context('when in an installable java project', () => {
+    const workspaceServices = stubWorkspaceServices(true, 'Java', 'Spring');
     const extensionState = unsafeCast<ExtensionState>({ getHideInstallPrompt: () => false });
 
     it('does not prompt', async () => {


### PR DESCRIPTION
Users who open a project which is supported by AppMap, but contains no `appmap.yml` will receive a notification prompting them to install.

![image](https://user-images.githubusercontent.com/8737782/201430483-c9eb6103-9a73-4979-9908-cea80f9e00b2.png)

This popup will not open for new users immediately after installation as we're already opening the instructions automatically. Maybe it's worth revisiting this?

Clicking `Open instructions` will open the instructions view to the project picker.
Clicking `Later` will simply close the notification. It will appear again the next time the project is opened.
Clicking `Don't show again` will silence the notification, but only for the currently opened project.
