### PR TITLE
AppMap CLI and scanner specify `--appmap-dir` parameters

### DIFF
--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -11,6 +11,7 @@ import { getBinPath, ProgramName, spawn } from './nodeDependencyProcess';
 import { ProjectStateServiceInstance } from './projectStateService';
 import { downloadFile, getLatestVersionInfo } from '../util';
 import AnalysisManager from './analysisManager';
+import { lookupAppMapDir } from '../lib/appmapDir';
 
 const YARN_JS = 'yarn.js';
 
@@ -50,6 +51,8 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       throw new Error(`failed to resolve a project state for ${folder.name}`);
     }
 
+    const appMapDir = (await lookupAppMapDir(folder.uri.fsPath)) || '.';
+
     try {
       const env = process.env.APPMAP_TEST
         ? { ...process.env, APPMAP_WRITE_PIDFILE: 'true' }
@@ -62,7 +65,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
             globalStoragePath: this.globalStorageDir,
           }),
           log: NodeProcessService.outputChannel,
-          args: ['index', '--watch'],
+          args: ['index', '--watch', '--appmap-dir', appMapDir],
           cwd: folder.uri.fsPath,
           env,
         }),
@@ -74,7 +77,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
             globalStoragePath: this.globalStorageDir,
           }),
           log: NodeProcessService.outputChannel,
-          args: ['scan', '--watch'],
+          args: ['scan', '--watch', '--appmap-dir', appMapDir],
           cwd: folder.uri.fsPath,
         })
       );

--- a/test/integration/actions/promptInstall.test.ts
+++ b/test/integration/actions/promptInstall.test.ts
@@ -6,9 +6,8 @@ import { WorkspaceServices } from '../../../src/services/workspaceServices';
 import promptInstall, { ButtonText } from '../../../src/actions/promptInstall';
 import ExtensionState from '../../../src/configuration/extensionState';
 import { ProjectStateServiceInstance } from '../../../src/services/projectStateService';
-import { ProjectA } from '../util';
+import { ProjectA, unsafeCast } from '../util';
 
-const unsafeCast = <T>(val: unknown): T => val as T;
 const stubWorkspaceServices = (installable = true, language = 'Ruby', webFramework = 'Rails') =>
   unsafeCast<WorkspaceServices>({
     getService: () => sinon.stub(),

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -42,6 +42,30 @@ export async function withTmpDir(fn: (tmpDir: string) => void | Promise<void>): 
   if (createdByUs) await fs.rmdir(tmpDir);
 }
 
+export type TempDirectory = {
+  path: string;
+  cleanup: () => Promise<void>;
+};
+
+export async function mkTmpDir(): Promise<TempDirectory> {
+  const tmpDir = await promisify(tmp.dir)();
+  let createdByUs = false;
+
+  try {
+    await fs.access(tmpDir);
+  } catch (e) {
+    await fs.mkdir(tmpDir);
+    createdByUs = true;
+  }
+
+  return {
+    path: tmpDir,
+    async cleanup() {
+      if (createdByUs) await fs.rmdir(tmpDir);
+    },
+  };
+}
+
 export const ExampleAppMap = join(
   ProjectA,
   'tmp/appmap/minitest/Microposts_controller_can_get_microposts_as_JSON.appmap.json'

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -141,7 +141,7 @@ export async function waitForAppMapServices(touchFile: string): Promise<AppMapSe
   const workspaceFolder = vscode.workspace.workspaceFolders[0];
   const wsPath = workspaceFolder.uri.fsPath;
   console.log('[waitForAppMapServices] wsPath: ', wsPath);
-  const pidPath = join(wsPath, 'tmp', 'appmap', 'index.pid');
+  const pidPath = join(wsPath, 'index.pid');
   console.log('[waitForAppMapServices] pidPath: ', pidPath);
   // Make sure the indexer is all the way up before we ask it to do anything.
   try {

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -270,3 +270,7 @@ export function withAuthenticatedUser(): void {
 
   afterEach(sinon.restore);
 }
+
+export function unsafeCast<T>(val: unknown): T {
+  return val as T;
+}


### PR DESCRIPTION
This is fully tested by automation.
- If `appmap_dir` is set within `appmap.yml` the processes will use it.
- If it's unset, `--appmap-dir .` will be used, effectively falling back to the project directory. 

These changes can be observed in the `Output` -> `AppMap: Services` log.

```
917952 [Stdout] spawned /opt/vscode/code --ms-enable-electron-run-as-node --ms-enable-electron-run-as-node /home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js index --watch --appmap-dir . with options {"retryTimes":3,"retryThreshold":180000,"id":"index","binPath":"/home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js","log":{"name":"AppMap: Services"},"args":["index","--watch","--appmap-dir","."],"cwd":"/home/db/dev/applandinc/appmap-server"}
```