### PR TITLE
fix: Wait for `yarn up` before releasing installation lock

### DIFF
--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -213,7 +213,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
 
       installProcess.log.append('Installing dependencies...');
 
-      return new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         installProcess.once('error', (err) => reject(err));
         installProcess.once('exit', async (code, signal) => {
           if (code && code !== 0) {


### PR DESCRIPTION
The lock was being released before dependencies were installed. This may result in either:
- Another process installing simultaneously or
- Background services attempting to launch before they're ready