### PR TITLE
fix: `getRecords` now returns nested objects and enforces value type

### DIFF
--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { createHash } from 'crypto';
 import TelemetryDataProvider from '../telemetryDataProvider';
 import LanguageResolver, { UNKNOWN_LANGUAGE } from '../../services/languageResolver';
-import { fileExists } from '../../util';
+import { fileExists, getRecords } from '../../util';
 import ErrorCode from './errorCodes';
 import ProjectMetadata from '../../workspace/projectMetadata';
 import { TerminalConfig } from '../../commands/installAgent';
@@ -98,7 +98,7 @@ export const FILE_SIZE = new TelemetryDataProvider({
 export const FILE_METADATA = new TelemetryDataProvider({
   id: 'appmap.file.metadata',
   async value({ metadata }: { metadata?: Record<string, unknown> }) {
-    return metadata;
+    return getRecords({ ...metadata, git: undefined, fingerprints: undefined }, undefined, String);
   },
 });
 

--- a/test/integration/telemetry/util.test.ts
+++ b/test/integration/telemetry/util.test.ts
@@ -1,0 +1,26 @@
+import { deepStrictEqual } from 'assert';
+import { getRecords } from '../../../src/util';
+
+describe('util', () => {
+  describe('getRecords', () => {
+    it('adds nested properties to the top level', async () => {
+      const result = getRecords({ a: '1', b: { c: '2' } });
+      deepStrictEqual(result, { a: '1', 'b.c': '2' });
+    });
+
+    it('appends a prefix', async () => {
+      const result = getRecords({ a: '1', b: { c: '2' } }, 'example');
+      deepStrictEqual(result, { 'example.a': '1', 'example.b.c': '2' });
+    });
+
+    it('transforms values if a transformer is provided', async () => {
+      const result = getRecords<string>({ a: 1, b: { c: 2 } }, undefined, String);
+      deepStrictEqual(result, { a: '1', 'b.c': '2' });
+    });
+
+    it('does not write undefined or null values', async () => {
+      const result = getRecords<string>({ a: null, b: { c: undefined }, d: 1 }, undefined, String);
+      deepStrictEqual(result, { d: '1' });
+    });
+  });
+});


### PR DESCRIPTION
Nested values are now returned, e.g.:
```
    "appmap.file.metadata.app": "scanner/ruby-fixture",
    "appmap.file.metadata.language.name": "ruby",
    "appmap.file.metadata.language.engine": "ruby",
    "appmap.file.metadata.language.version": "3.0.1",
    "appmap.file.metadata.client.name": "appmap",
    "appmap.file.metadata.client.url": "https://github.com/applandinc/appmap-ruby",
    "appmap.file.metadata.client.version": "0.83.4",
    "appmap.file.metadata.name": "Crypt crypt aes 256 gcm",
    "appmap.file.metadata.source_location": "test/crypt_test.rb:11",
    "appmap.file.metadata.frameworks.0.name": "minitest",
    "appmap.file.metadata.frameworks.0.version": "5.16.2",
    "appmap.file.metadata.recorder.name": "minitest",
    "appmap.file.metadata.test_status": "succeeded",
```

This also fixes an issue where the return value may contains values of various types.