### PR TITLE
fix: Set YARN_CHECKSUM_BEHAVIOR=update when 'yarn up' is called

### DIFF
--- a/src/services/nodeDependencyProcess.ts
+++ b/src/services/nodeDependencyProcess.ts
@@ -23,6 +23,9 @@ export type SpawnOptions = {
   // Command line args given to `node` or the `bin` script specified
   args?: string[];
 
+  // Additional environment variables given to `node` or the `bin` script specified
+  env?: Record<string, string>;
+
   // If specified, write log messages to the given output channel
   log?: vscode.OutputChannel;
 

--- a/src/services/nodeDependencyProcess.ts
+++ b/src/services/nodeDependencyProcess.ts
@@ -23,9 +23,6 @@ export type SpawnOptions = {
   // Command line args given to `node` or the `bin` script specified
   args?: string[];
 
-  // Additional environment variables given to `node` or the `bin` script specified
-  env?: Record<string, string>;
-
   // If specified, write log messages to the given output channel
   log?: vscode.OutputChannel;
 

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -209,6 +209,9 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
         args: [this.yarnPath, 'up'],
         cwd: this.globalStorageDir,
         log: NodeProcessService.outputChannel,
+        // Fix "The remote archive doesn't match the expected checksum" issue by
+        // forcing yarn to fetch from the remote registry if checksums don't match.
+        env: { YARN_CHECKSUM_BEHAVIOR: 'update' },
       });
 
       installProcess.log.append('Installing dependencies...');


### PR DESCRIPTION
Attempt to fix the following type of error we often see in the logs
```
➤ YN0018: │ d3-path@npm:1.0.9: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-selection@npm:1.4.2: The remote archive doesn't match the expected checksum
➤ YN0018: │ crypto-js@npm:4.1.1: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-drag@npm:1.2.5: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-shape@npm:1.3.7: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-timer@npm:1.0.10: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-transition@npm:1.3.2: The remote archive doesn't match the expected checksum
➤ YN0018: │ d3-zoom@npm:1.8.3: The remote archive doesn't match the expected checksum
➤ YN0018: │ dashdash@npm:1.14.1: The remote archive doesn't match the expected checksum
➤ YN0018: │ data-urls@npm:2.0.0: The remote archive doesn't match the expected checksum
➤ YN0018: │ debounce-fn@npm:4.0.0: The remote archive doesn't match the expected checksum
➤ YN0018: │ debug@npm:4.3.4: The remote archive doesn't match the expected checksum
➤ YN0018: │ decompress-response@npm:4.2.1: The remote archive doesn't match the expected checksum
➤ YN0018: │ dagre@npm:0.8.5: The remote archive doesn't match the expected checksum
➤ YN0000: └ Completed in 0s 583ms
```

When an archive checksum in `yarn.lock` is incorrect and `YARN_CHECKSUM_BEHAVIOR=update yarn` is called instead of only `yarn`, the archive is [fetched again](https://github.com/getappmap/vscode-appland/issues/547#issuecomment-1355195226) and doesn't produce this error.

Addresses https://github.com/getappmap/vscode-appland/issues/547 but it's uncertain if it will fix it.  It's uncertain if archive checksums were calculated incorrectly due to [bugs in yarn](https://github.com/getappmap/vscode-appland/issues/547#issuecomment-1357909202) when the archive was created or if there's some other error, like something weird going on with the network.

--

To test this I created a vsix file and installed it with logging in [`nodeDependencyProcess.ts:spawn`](https://github.com/getappmap/vscode-appland/blob/master/src/services/nodeDependencyProcess.ts#L140) that showed `YARN_CHECKSUM_BEHAVIOR` was set
![vscode_yarn_checksum_behavior_small](https://user-images.githubusercontent.com/111290954/208525806-df46fcb8-d423-42a5-9b4c-123fdc6dfbeb.png)
