### PR TITLE
feat: Emit telemetry for sequence diagrams

### DIFF
--- a/src/commands/compareSequenceDiagram.ts
+++ b/src/commands/compareSequenceDiagram.ts
@@ -6,7 +6,14 @@ import { AppMap, buildAppMap } from '@appland/models';
 
 import { verifyCommandOutput } from '../services/nodeDependencyProcess';
 import AppMapCollection from '../services/appmapCollection';
-import { plantUMLJarPath, promptForAppMap, promptForSpecification } from '../lib/sequenceDiagram';
+import {
+  NUM_ACTIONS,
+  NUM_ACTORS,
+  NUM_CHANGES,
+  plantUMLJarPath,
+  promptForAppMap,
+  promptForSpecification,
+} from '../lib/sequenceDiagram';
 import { tmpName } from 'tmp';
 import { promisify } from 'util';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
@@ -19,6 +26,13 @@ import {
   FormatType,
   Specification,
 } from '@appland/sequence-diagram';
+import Event from '../telemetry/event';
+import { Telemetry } from '../telemetry';
+
+const SEQUENCE_DIAGRAM_DIFF_EVENT = new Event({
+  name: 'sequence_diagram:generate_diff',
+  metrics: [NUM_ACTORS, NUM_ACTIONS, NUM_CHANGES],
+});
 
 export default async function compareSequenceDiagrams(
   context: vscode.ExtensionContext,
@@ -82,6 +96,8 @@ export default async function compareSequenceDiagrams(
             );
             return;
           }
+
+          Telemetry.sendEvent(SEQUENCE_DIAGRAM_DIFF_EVENT, { diagram: diffDiagram });
 
           const svgFile = [diagramFile, 'svg'].join('.');
           vscode.env.openExternal(vscode.Uri.file(svgFile));

--- a/src/commands/sequenceDiagram.ts
+++ b/src/commands/sequenceDiagram.ts
@@ -7,9 +7,22 @@ import { verifyCommandOutput } from '../services/nodeDependencyProcess';
 import { writeFile } from 'fs/promises';
 import { readFile } from 'fs/promises';
 import AppMapCollection from '../services/appmapCollection';
-import { plantUMLJarPath, promptForAppMap, promptForSpecification } from '../lib/sequenceDiagram';
+import {
+  NUM_ACTIONS,
+  NUM_ACTORS,
+  plantUMLJarPath,
+  promptForAppMap,
+  promptForSpecification,
+} from '../lib/sequenceDiagram';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import assert from 'assert';
+import { Telemetry } from '../telemetry';
+import Event from '../telemetry/event';
+
+const SEQUENCE_DIAGRAM_EVENT = new Event({
+  name: 'sequence_diagram:generate',
+  metrics: [NUM_ACTORS, NUM_ACTIONS],
+});
 
 export default async function sequenceDiagram(
   context: vscode.ExtensionContext,
@@ -52,6 +65,8 @@ export default async function sequenceDiagram(
             );
             return;
           }
+
+          Telemetry.sendEvent(SEQUENCE_DIAGRAM_EVENT, { diagram });
 
           const tokens = diagramFile.split('.');
           vscode.env.openExternal(


### PR DESCRIPTION
## `sequence_diagram:generate`

```json
{
  "event": "appland.appmap/sequence_diagram:generate",
  "metrics": {
    "sequence_diagram.num_actors": 6,
    "sequence_diagram.num_actions": 50
  }
}
```

## `sequence_diagram:generate_diff`

```json
{
  "event": "appland.appmap/sequence_diagram:generate_diff",
  "metrics": {
    "sequence_diagram.num_actors": 6,
    "sequence_diagram.num_actions": 50,
    "sequence_diagram.num_changes": 7
  }
}
```

