### PR TITLE
fix: Drop the immediate sign-in prompt

### DIFF
--- a/src/actions/signup.ts
+++ b/src/actions/signup.ts
@@ -4,12 +4,12 @@ import extensionSettings from '../configuration/extensionSettings';
 import AnalysisManager from '../services/analysisManager';
 import { ANALYSIS_CTA_INTERACTION, Telemetry } from '../telemetry';
 export class Signup {
-  public static async forAnalysis(skipTelemetry?: boolean): Promise<boolean> {
+  public static async forAnalysis(): Promise<boolean> {
     if (AnalysisManager.isAnalysisEnabled) {
       return true;
     }
 
-    if (!skipTelemetry) Telemetry.sendEvent(ANALYSIS_CTA_INTERACTION);
+    Telemetry.sendEvent(ANALYSIS_CTA_INTERACTION);
 
     const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
       createIfNone: true,

--- a/src/commands/compareSequenceDiagram.ts
+++ b/src/commands/compareSequenceDiagram.ts
@@ -6,7 +6,14 @@ import { AppMap, buildAppMap } from '@appland/models';
 
 import { verifyCommandOutput } from '../services/nodeDependencyProcess';
 import AppMapCollection from '../services/appmapCollection';
-import { plantUMLJarPath, promptForAppMap, promptForSpecification } from '../lib/sequenceDiagram';
+import {
+  NUM_ACTIONS,
+  NUM_ACTORS,
+  NUM_CHANGES,
+  plantUMLJarPath,
+  promptForAppMap,
+  promptForSpecification,
+} from '../lib/sequenceDiagram';
 import { tmpName } from 'tmp';
 import { promisify } from 'util';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
@@ -19,6 +26,13 @@ import {
   FormatType,
   Specification,
 } from '@appland/sequence-diagram';
+import Event from '../telemetry/event';
+import { Telemetry } from '../telemetry';
+
+const SEQUENCE_DIAGRAM_DIFF_EVENT = new Event({
+  name: 'sequence_diagram:generate_diff',
+  metrics: [NUM_ACTORS, NUM_ACTIONS, NUM_CHANGES],
+});
 
 export default async function compareSequenceDiagrams(
   context: vscode.ExtensionContext,
@@ -82,6 +96,8 @@ export default async function compareSequenceDiagrams(
             );
             return;
           }
+
+          Telemetry.sendEvent(SEQUENCE_DIAGRAM_DIFF_EVENT, { diagram: diffDiagram });
 
           const svgFile = [diagramFile, 'svg'].join('.');
           vscode.env.openExternal(vscode.Uri.file(svgFile));

--- a/src/commands/sequenceDiagram.ts
+++ b/src/commands/sequenceDiagram.ts
@@ -7,9 +7,22 @@ import { verifyCommandOutput } from '../services/nodeDependencyProcess';
 import { writeFile } from 'fs/promises';
 import { readFile } from 'fs/promises';
 import AppMapCollection from '../services/appmapCollection';
-import { plantUMLJarPath, promptForAppMap, promptForSpecification } from '../lib/sequenceDiagram';
+import {
+  NUM_ACTIONS,
+  NUM_ACTORS,
+  plantUMLJarPath,
+  promptForAppMap,
+  promptForSpecification,
+} from '../lib/sequenceDiagram';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import assert from 'assert';
+import { Telemetry } from '../telemetry';
+import Event from '../telemetry/event';
+
+const SEQUENCE_DIAGRAM_EVENT = new Event({
+  name: 'sequence_diagram:generate',
+  metrics: [NUM_ACTORS, NUM_ACTIONS],
+});
 
 export default async function sequenceDiagram(
   context: vscode.ExtensionContext,
@@ -52,6 +65,8 @@ export default async function sequenceDiagram(
             );
             return;
           }
+
+          Telemetry.sendEvent(SEQUENCE_DIAGRAM_EVENT, { diagram });
 
           const tokens = diagramFile.split('.');
           vscode.env.openExternal(

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -148,10 +148,8 @@ export const INSTALL_BUTTON_ERROR = new Event({
   ],
 });
 
-export const AUTHENTICATION_PROMPT = new Event({ name: 'authentication:view_prompt' });
 export const AUTHENTICATION_SIGN_OUT = new Event({ name: 'authentication:sign_out' });
 export const AUTHENTICATION_SUCCESS = new Event({ name: 'authentication:success' });
-export const AUTHENTICATION_SKIP = new Event({ name: 'authentication:skip' });
 export const AUTHENTICATION_FAILED = new Event({ name: 'authentication:failed' });
 export const ANALYSIS_ENABLE = new Event({ name: 'analysis:enable' });
 export const ANALYSIS_DISABLE = new Event({ name: 'analysis:disable' });

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -3,13 +3,7 @@ import * as vscode from 'vscode';
 import { GenerateOpenApi } from '../commands/generateOpenApi';
 import { InstallAgent } from '../commands/installAgent';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
-import {
-  AUTHENTICATION_PROMPT,
-  AUTHENTICATION_SKIP,
-  COPY_COMMAND,
-  OPEN_VIEW,
-  Telemetry,
-} from '../telemetry';
+import { COPY_COMMAND, OPEN_VIEW, Telemetry } from '../telemetry';
 import { getNonce, getWorkspaceFolderFromPath } from '../util';
 import ProjectMetadata from '../workspace/projectMetadata';
 import * as semver from 'semver';
@@ -194,18 +188,9 @@ export default class InstallGuideWebView {
               break;
 
             case 'perform-auth': {
-              const { promptSignIn } = message as { promptSignIn?: boolean };
-              Signup.forAnalysis(!promptSignIn);
+              Signup.forAnalysis();
               break;
             }
-
-            case 'skip-sign-in':
-              Telemetry.sendEvent(AUTHENTICATION_SKIP);
-              break;
-
-            case 'view-sign-in':
-              Telemetry.sendEvent(AUTHENTICATION_PROMPT);
-              break;
 
             default:
               break;


### PR DESCRIPTION
When opening the instructions view and not logged out, the user will no longer see a sign up prompt.