### PR TITLE
fix: Use `child_process.fork` for launching sub-processes

### DIFF
--- a/src/commands/generateOpenApi.ts
+++ b/src/commands/generateOpenApi.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import ExtensionState from '../configuration/extensionState';
 import chooseWorkspace from '../lib/chooseWorkspace';
 import {
-  getBinPath,
+  getModulePath,
   OutputStream,
   ProgramName,
   spawn,
@@ -32,12 +32,12 @@ export default async function generateOpenApi(
         async () => {
           assert(workspaceFolder);
 
-          const binPath = await getBinPath({
+          const modulePath = await getModulePath({
             dependency: ProgramName.Appmap,
             globalStoragePath: context.globalStorageUri.fsPath,
           });
           const openApiCmd = spawn({
-            binPath,
+            modulePath,
             args: ['openapi', '--appmap-dir', workspaceFolder.uri.fsPath],
             saveOutput: true,
           });

--- a/src/services/appmapUptodateService.ts
+++ b/src/services/appmapUptodateService.ts
@@ -5,7 +5,7 @@ import {
   OutputStream,
   ProcessLogItem,
   spawn,
-  getBinPath,
+  getModulePath,
 } from './nodeDependencyProcess';
 import EventEmitter from 'events';
 import { readFile } from 'fs';
@@ -18,7 +18,7 @@ import { workspaceServices } from './workspaceServices';
 
 export default class AppmapUptodateServiceInstance extends EventEmitter
   implements WorkspaceServiceInstance {
-  binPath: string | undefined;
+  modulePath: string | undefined;
   interval?: NodeJS.Timeout;
   process?: ChildProcess;
   updatedAt?: number;
@@ -52,8 +52,8 @@ export default class AppmapUptodateServiceInstance extends EventEmitter
   }
 
   async update(): Promise<void> {
-    if (!this.binPath) {
-      this.binPath = await getBinPath({
+    if (!this.modulePath) {
+      this.modulePath = await getModulePath({
         dependency: ProgramName.Appmap,
         globalStoragePath: this.globalStoragePath,
       });
@@ -85,9 +85,9 @@ export default class AppmapUptodateServiceInstance extends EventEmitter
     // we began our update request.
     if (this.updatedAt && this.updatedAt > updateRequestedAt) return;
 
-    assert(this.binPath, `binPath is not initialized`);
+    assert(this.modulePath, `modulePath is not initialized`);
     this.process = spawn({
-      binPath: this.binPath,
+      modulePath: this.modulePath,
       args: this.commandArgs,
       cwd: this.folder.uri.fsPath,
       saveOutput: true,

--- a/src/services/nodeDependencyProcess.ts
+++ b/src/services/nodeDependencyProcess.ts
@@ -16,9 +16,8 @@ export type WithLogCache = {
 export type ChildProcess = childProcess.ChildProcessWithoutNullStreams & WithLogCache;
 
 export type SpawnOptions = {
-  // Path to a bin script installed via yarn. If specified, it will be shifted into the command args
-  // to be run via `node`
-  binPath: string;
+  // Path to a node module script to be executed
+  modulePath: string;
 
   // Command line args given to `node` or the `bin` script specified
   args?: string[];
@@ -111,7 +110,7 @@ export class ProcessLog extends Array<ProcessLogItem> {
   }
 }
 
-export async function getBinPath(options: ProgramOptions): Promise<string> {
+export async function getModulePath(options: ProgramOptions): Promise<string> {
   const localToolsPath = ExtensionSettings.appMapCommandLineToolsPath;
   if (localToolsPath) {
     let packageName: string;
@@ -139,7 +138,7 @@ export async function getBinPath(options: ProgramOptions): Promise<string> {
 
 export function spawn(options: SpawnOptions): ChildProcess {
   const env = { ...process.env, ...(options.env || {}) };
-  const newProcess = childProcess.fork(options.binPath, options.args || [], {
+  const newProcess = childProcess.fork(options.modulePath, options.args || [], {
     ...options,
     env,
     execArgv: [],

--- a/src/services/nodeDependencyProcess.ts
+++ b/src/services/nodeDependencyProcess.ts
@@ -142,6 +142,7 @@ export function spawn(options: SpawnOptions): ChildProcess {
   const newProcess = childProcess.fork(options.binPath, options.args || [], {
     ...options,
     env,
+    execArgv: [],
     stdio: 'pipe',
   });
   const loggedProcess = ProcessLog.appendLogger(

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -7,7 +7,7 @@ import { WorkspaceService } from './workspaceService';
 import NodeProcessServiceInstance from './nodeProcessServiceInstance';
 import { ProcessWatcher } from './processWatcher';
 import ErrorCode from '../telemetry/definitions/errorCodes';
-import { getBinPath, ProgramName, spawn } from './nodeDependencyProcess';
+import { getModulePath, ProgramName, spawn } from './nodeDependencyProcess';
 import { ProjectStateServiceInstance } from './projectStateService';
 import { downloadFile, getLatestVersionInfo } from '../util';
 import AnalysisManager from './analysisManager';
@@ -76,7 +76,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       services.push(
         new ProcessWatcher({
           id: 'index',
-          binPath: await getBinPath({
+          modulePath: await getModulePath({
             dependency: ProgramName.Appmap,
             globalStoragePath: this.globalStorageDir,
           }),
@@ -88,7 +88,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
         new ProcessWatcher({
           id: 'analysis',
           startCondition: () => AnalysisManager.isAnalysisEnabled,
-          binPath: await getBinPath({
+          modulePath: await getModulePath({
             dependency: ProgramName.Scanner,
             globalStoragePath: this.globalStorageDir,
           }),
@@ -206,7 +206,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       await fs.appendFile(path.join(this.globalStorageDir, 'yarn.lock'), '');
 
       const installProcess = await spawn({
-        binPath: this.yarnPath,
+        modulePath: this.yarnPath,
         args: ['up'],
         cwd: this.globalStorageDir,
         log: NodeProcessService.outputChannel,

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -206,7 +206,8 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       await fs.appendFile(path.join(this.globalStorageDir, 'yarn.lock'), '');
 
       const installProcess = await spawn({
-        args: [this.yarnPath, 'up'],
+        binPath: this.yarnPath,
+        args: ['up'],
         cwd: this.globalStorageDir,
         log: NodeProcessService.outputChannel,
       });


### PR DESCRIPTION
This means we don't need to specify `--ms-enable-electron-run-as-node` or `ELECTRON_RUN_AS_NODE`. It also normalizes logic between remote environments.

Resolves #546 