### PR TITLE
fix: Override environment yarn configuration

### DIFF
--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -212,7 +212,13 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
         log: NodeProcessService.outputChannel,
         // Fix "The remote archive doesn't match the expected checksum" issue by
         // forcing yarn to fetch from the remote registry if checksums don't match.
-        env: { YARN_CHECKSUM_BEHAVIOR: 'update' },
+        env: {
+          YARN_CHECKSUM_BEHAVIOR: 'update',
+          YARN_ENABLE_TELEMETRY: 'false',
+          YARN_LOCKFILE_NAME: undefined,
+          YARN_RC_FILENAME: undefined,
+          YARN_YARN_PATH: this.yarnPath,
+        },
       });
 
       installProcess.log.append('Installing dependencies...');

--- a/test/integration/nodeProcesses/nodeProcessService.test.ts
+++ b/test/integration/nodeProcesses/nodeProcessService.test.ts
@@ -15,13 +15,15 @@ describe('NodeProcessService', () => {
           extensionPath: path.join(__dirname, '..', '..', '..', '..'),
         } as vscode.ExtensionContext;
 
-        console.log(extensionContext.extensionPath);
         const service = new NodeProcessService(extensionContext, []);
         await service.install();
         await fs.stat(path.join(tmpDir, 'node_modules'));
         await fs.stat(path.join(tmpDir, 'yarn.lock'));
         await fs.stat(path.join(tmpDir, 'yarn.js'));
         await fs.stat(path.join(tmpDir, 'package.json'));
+
+        // This file shouldn't exist. If it does, our process environment was not overridden.
+        await assert.rejects(fs.stat(path.join(tmpDir, 'bad.lock')));
         await assert.rejects(fs.stat(lockFile));
       });
     });

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -131,6 +131,7 @@ async function integrationTest() {
         PROJECT_DIR: workspaceDir, // A hint to resolve relative paths in settings
         TEST_FILE: testFile,
         APPMAP_WRITE_PIDFILE: 'true',
+        YARN_LOCKFILE_NAME: 'bad.lock',
       },
       launchArgs: [
         '--user-data-dir',


### PR DESCRIPTION
Presumably some users have a yarn configuration which interferes with our dependency install. This change scrubs the environment of `YARN` configuration which may conflict.

Fixes #553. Integration tests are now run with `YARN_LOCKFILE_NAME` to make sure the override works. Stubbing `process.env` is not possible from the integration test.