### PR TITLE
Add appmap to recommended extensions

### DIFF
--- a/src/appMapService.ts
+++ b/src/appMapService.ts
@@ -7,6 +7,7 @@ import ExtensionState from './configuration/extensionState';
 import AppMapEditorProvider from './editor/appmapEditorProvider';
 import { FindingsService } from './findingsService';
 import { AppMapConfigWatcher } from './services/appMapConfigWatcher';
+import { AppMapRecommenderService } from './services/appmapRecommenderService';
 import { AppmapUptodateService } from './services/appmapUptodateService';
 import Command from './services/command';
 import { NodeProcessService } from './services/nodeProcessService';
@@ -44,4 +45,5 @@ export default interface AppMapService {
   projectState: ProjectStateService;
   trees: AppMapTreeDataProviders;
   appmapServerAuthenticationProvider: AppMapServerAuthenticationProvider;
+  recommender: AppMapRecommenderService;
 }

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -15,6 +15,7 @@ export const Keys = {
     FINDINGS_INVESTIGATED: 'appmap.applandinc.findingsInvestigated',
     GENERATED_OPENAPI: 'appmap.applandinc.generatedOpenApi',
     HIDE_INSTALL_PROMPT: 'appmap.applandinc.hideInstallPrompt',
+    CLOSED_APPMAP: 'appmap.applandinc.closedAppMap',
   },
 };
 
@@ -168,6 +169,14 @@ export default class ExtensionState {
 
   getHideInstallPrompt(workspaceFolder: vscode.WorkspaceFolder): boolean {
     return this.getWorkspaceFlag(Keys.Workspace.HIDE_INSTALL_PROMPT, workspaceFolder.uri.fsPath);
+  }
+
+  getClosedAppMap(workspaceFolder: vscode.WorkspaceFolder): boolean {
+    return this.getWorkspaceFlag(Keys.Workspace.CLOSED_APPMAP, workspaceFolder.uri.fsPath);
+  }
+
+  setClosedAppMap(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.setWorkspaceFlag(Keys.Workspace.CLOSED_APPMAP, value, workspaceFolder);
   }
 
   resetState(): void {

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -246,6 +246,8 @@ export default class AppMapEditorProvider
     webviewPanel.onDidDispose(() => {
       this.currentWebView = undefined;
       removeOne(this.documents, document);
+      if (document.workspaceFolder)
+        this.extensionState.setClosedAppMap(document.workspaceFolder, true);
     });
 
     function openFile(uri: vscode.Uri, lineNumber: number) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ import ErrorCode from './telemetry/definitions/errorCodes';
 import promptInstall from './actions/promptInstall';
 import FindingsOverviewWebview from './webviews/findingsWebview';
 import FindingInfoWebview from './webviews/findingInfoWebview';
+import { AppMapRecommenderService } from './services/appmapRecommenderService';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -69,6 +70,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     if (extensionState.isNewInstall) {
       Telemetry.reportAction('plugin:install');
     }
+    const recommender = new AppMapRecommenderService(extensionState);
+    await workspaceServices.enroll(recommender);
 
     AppMapServerConfiguration.enroll(context);
 
@@ -289,6 +292,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       get findings(): FindingsService | undefined {
         return AnalysisManager.findingsIndex;
       },
+      recommender,
     };
   } catch (exception) {
     Telemetry.sendEvent(DEBUG_EXCEPTION, {

--- a/src/services/appmapRecommenderService.ts
+++ b/src/services/appmapRecommenderService.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 import { promisify } from 'util';
 import ExtensionState, { Keys } from '../configuration/extensionState';
 import { WorkspaceService, WorkspaceServiceInstance } from './workspaceService';
+import { ADD_RECOMMENDATION, Telemetry } from '../telemetry';
 
 type ExtensionsJson = {
   recommendations?: Array<string>;
@@ -18,6 +19,7 @@ export class AppMapRecommenderServiceInstance implements WorkspaceServiceInstanc
     extensionState.onWorkspaceFlag(async (event) => {
       if (event.workspaceFolder === folder && event.key === Keys.Workspace.CLOSED_APPMAP) {
         const response = await this.askUser();
+        Telemetry.sendEvent(ADD_RECOMMENDATION, { result: response === 'Yes' ? 'true' : 'false' });
         if (response === 'Yes') await this.recommendAppMap();
       }
     });

--- a/src/services/appmapRecommenderService.ts
+++ b/src/services/appmapRecommenderService.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+import { existsSync, mkdirSync, readFile, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { promisify } from 'util';
+import ExtensionState, { Keys } from '../configuration/extensionState';
+import { WorkspaceService, WorkspaceServiceInstance } from './workspaceService';
+
+type ExtensionsJson = {
+  recommendations?: Array<string>;
+  unwantedRecommendations?: Array<string>;
+};
+
+export class AppMapRecommenderServiceInstance implements WorkspaceServiceInstance {
+  constructor(
+    public readonly folder: vscode.WorkspaceFolder,
+    protected readonly extensionState: ExtensionState
+  ) {
+    extensionState.onWorkspaceFlag(async (event) => {
+      if (event.workspaceFolder === folder && event.key === Keys.Workspace.CLOSED_APPMAP) {
+        const response = await this.askUser();
+        if (response === 'Yes') await this.recommendAppMap();
+      }
+    });
+  }
+
+  async askUser(): Promise<string | undefined> {
+    return await vscode.window.showInformationMessage(
+      'Add AppMap as a recommended extension for this project?',
+      'Yes',
+      'No'
+    );
+  }
+
+  async recommendAppMap(): Promise<void> {
+    const workspacePath = this.folder.uri.fsPath;
+    const vscodeFolderPath = resolve(workspacePath, '.vscode');
+
+    if (!existsSync(vscodeFolderPath)) {
+      mkdirSync(resolve(workspacePath, '.vscode'));
+    }
+
+    const vscodeExtensionsPath = resolve(this.folder.uri.fsPath, '.vscode', 'extensions.json');
+    let content = {} as ExtensionsJson;
+
+    if (existsSync(vscodeExtensionsPath)) {
+      const rawContent = await promisify(readFile)(vscodeExtensionsPath, 'utf8');
+      try {
+        content = JSON.parse(rawContent);
+      } catch (e) {
+        // don't do anything if an error is raised when parsing extensions.json
+        vscode.window.showInformationMessage('ERROR: The extensions.json file could not be read.');
+        return;
+      }
+    }
+
+    if (content.recommendations && Array.isArray(content.recommendations)) {
+      if (!content.recommendations.includes('appland.appmap'))
+        content.recommendations.push('appland.appmap');
+    } else if (!content.recommendations) {
+      content.recommendations = ['appland.appmap'];
+    }
+
+    writeFileSync(vscodeExtensionsPath, JSON.stringify(content, null, 2));
+    const extensionsJson = await vscode.workspace.openTextDocument(vscodeExtensionsPath);
+    await vscode.window.showTextDocument(extensionsJson);
+  }
+
+  dispose(): void {
+    return;
+  }
+}
+
+export class AppMapRecommenderService
+  implements WorkspaceService<AppMapRecommenderServiceInstance> {
+  constructor(protected extensionState: ExtensionState) {}
+
+  async create(folder: vscode.WorkspaceFolder): Promise<AppMapRecommenderServiceInstance> {
+    return new AppMapRecommenderServiceInstance(folder, this.extensionState);
+  }
+}

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -170,3 +170,8 @@ export const INSTALL_PROMPT = new Event({
   name: 'install_prompt',
   properties: [Properties.RESULT],
 });
+
+export const ADD_RECOMMENDATION = new Event({
+  name: 'recommend_extension:prompt',
+  properties: [Properties.RESULT],
+});

--- a/test/integration/appmapRecommender/recommender.test.ts
+++ b/test/integration/appmapRecommender/recommender.test.ts
@@ -1,0 +1,95 @@
+// @project project-a
+import assert, { strictEqual } from 'assert';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import AppMapService from '../../../src/appMapService';
+import {
+  AppMapRecommenderService,
+  AppMapRecommenderServiceInstance,
+} from '../../../src/services/appmapRecommenderService';
+import { WorkspaceServiceInstance } from '../../../src/services/workspaceService';
+import { retry } from '../../../src/util';
+import { waitForExtension } from '../util';
+
+describe('AppMap recommender', async () => {
+  let extension: AppMapService;
+  let recommender: AppMapRecommenderService;
+  let recommenderInstance: AppMapRecommenderServiceInstance;
+  let projectDirectory: string;
+
+  beforeEach(async () => {
+    extension = await waitForExtension();
+    recommender = extension.recommender;
+    assert.ok(recommender, 'the service exists');
+
+    let serviceInstances: WorkspaceServiceInstance[] = [];
+
+    await retry(
+      () => {
+        serviceInstances = extension.workspaceServices.getServiceInstances(recommender);
+        if (serviceInstances.length === 0) {
+          throw new Error(`Waiting for service instance creation`);
+        }
+      },
+      5,
+      1000
+    );
+
+    assert.strictEqual(serviceInstances.length, 1, 'a single service instance exists');
+
+    recommenderInstance = serviceInstances[0] as AppMapRecommenderServiceInstance;
+    projectDirectory = recommenderInstance.folder.uri.fsPath;
+  });
+
+  afterEach(() => {
+    unlinkSync(resolve(projectDirectory, '.vscode', 'extensions.json'));
+  });
+
+  it('creates extensions.json and adds appmap to recommended extensions', async () => {
+    assert(existsSync(projectDirectory));
+    assert(existsSync(resolve(projectDirectory, '.vscode')));
+    assert(!existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+
+    await recommenderInstance.recommendAppMap();
+
+    assert(existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+    const content = readFileSync(resolve(projectDirectory, '.vscode', 'extensions.json'), 'utf-8');
+    const expected = '{\n  "recommendations": [\n    "appland.appmap"\n  ]\n}';
+    strictEqual(content, expected);
+  });
+
+  it('adds appmap to recommended extensions if extensions.json already exists without recommendations', async () => {
+    assert(existsSync(projectDirectory));
+    assert(existsSync(resolve(projectDirectory, '.vscode')));
+    assert(!existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+
+    const initialContent = '{}';
+    writeFileSync(resolve(projectDirectory, '.vscode', 'extensions.json'), initialContent);
+
+    assert(existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+
+    await recommenderInstance.recommendAppMap();
+
+    const content = readFileSync(resolve(projectDirectory, '.vscode', 'extensions.json'), 'utf-8');
+    const expected = '{\n  "recommendations": [\n    "appland.appmap"\n  ]\n}';
+    strictEqual(content, expected);
+  });
+
+  it('adds appmap to recommended extensions if extensions.json already exists with recommendations', async () => {
+    assert(existsSync(projectDirectory));
+    assert(existsSync(resolve(projectDirectory, '.vscode')));
+    assert(!existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+
+    const initialContent = '{\n  "recommendations": [\n    "fake.recommendation"\n  ]\n}';
+    writeFileSync(resolve(projectDirectory, '.vscode', 'extensions.json'), initialContent);
+
+    assert(existsSync(resolve(projectDirectory, '.vscode', 'extensions.json')));
+
+    await recommenderInstance.recommendAppMap();
+
+    const content = readFileSync(resolve(projectDirectory, '.vscode', 'extensions.json'), 'utf-8');
+    const expected =
+      '{\n  "recommendations": [\n    "fake.recommendation",\n    "appland.appmap"\n  ]\n}';
+    strictEqual(content, expected);
+  });
+});


### PR DESCRIPTION
Fixes #537

The first time that a user closes a map, prompt the user to add the AppMap extension to the list of recommended extensions for the current project in extensions.json in the .vscode folder.

![image](https://user-images.githubusercontent.com/45714532/211921100-7a687aa4-86cc-4cf5-8899-e4c20815de8b.png)

If they click `Yes`, then the `extensions.json` file is opened in the editor:

![image](https://user-images.githubusercontent.com/45714532/211921268-00749404-071e-410c-8930-44dc8a6c84c2.png)
