### PR TITLE
fix: Update @appland/appmap and @appland/scanner properly

### DIFF
--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -207,7 +207,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
 
       const installProcess = await spawn({
         modulePath: this.yarnPath,
-        args: ['up'],
+        args: ['up', '-R', '@appland/appmap', '@appland/scanner'],
         cwd: this.globalStorageDir,
         log: NodeProcessService.outputChannel,
         // Fix "The remote archive doesn't match the expected checksum" issue by


### PR DESCRIPTION
Previously, `yarn up` was not giving the desired outcomes. Some users were not receiving updates. This command ensures both packages are updated while not affecting the version constraints defined in `package.json`.

To see this in action, check the version of `@appland/appmap` or `@appland/scanner` in `yarn.lock`.

On Linux:
```sh
$ cat ~/.config/Code/User/globalStorage/appland.appmap/yarn.lock | grep -A1 '@appland/appmap@npm:^3'
"@appland/appmap@npm:^3":
  version: 3.53.0
```

On Darwin:
```sh
$ cat ~/Library/ApplicationSupport/Code/User/globalStorage/appland.appmap/yarn.lock | grep -A1 '@appland/appmap@npm:^3'
"@appland/appmap@npm:^3":
  version: 3.53.0
```

Run the extension. The `AppMap: Services` tab in `Output` should indicate success installing dependencies. Checking the version again should yield an updated version:

```sh
$ cat ~/.config/Code/User/globalStorage/appland.appmap/yarn.lock | grep -A1 '@appland/appmap@npm:^3'
"@appland/appmap@npm:^3":
  version: 3.60.1
```

Fixes #590 
