### PR TITLE
feat: Put AppMap API key in process env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
       "type": "extensionHost",
       "request": "launch",
       "env": {
-        "TEST_FILE": "sequenceDiagram/compareSequenceDiagrams.test.js",
+        "TEST_FILE": "scanner/performAsAppMapsAreModified.test.js",
         "PROJECT_DIR": "${workspaceFolder}/test/fixtures/workspaces/project-a"
       },
       "args": [

--- a/src/actions/appmapUploader.ts
+++ b/src/actions/appmapUploader.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import extensionSettings from '../configuration/extensionSettings';
 import { AppMap } from '@appland/client';
 import { UploadAppMapResponse } from '@appland/client/dist/src/appMap';
-import { AUTHN_PROVIDER_NAME } from '../authentication';
+import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
 
 export class AppmapUploader {
   public static DIALOG_KEY = 'applandinc.appmap.uploadDialog';
@@ -40,12 +40,8 @@ export class AppmapUploader {
       return undefined;
     }
 
-    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
-      createIfNone: true,
-    });
-    if (!session) {
-      return undefined;
-    }
+    const appmapApiKey = await AppMapServerAuthenticationProvider.getApiKey(true);
+    if (!appmapApiKey) return;
 
     let upload: UploadAppMapResponse;
     try {

--- a/src/actions/appmapUploader.ts
+++ b/src/actions/appmapUploader.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import extensionSettings from '../configuration/extensionSettings';
 import { AppMap } from '@appland/client';
 import { UploadAppMapResponse } from '@appland/client/dist/src/appMap';
-import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
+import { getApiKey } from '../authentication';
 
 export class AppmapUploader {
   public static DIALOG_KEY = 'applandinc.appmap.uploadDialog';
@@ -40,7 +40,7 @@ export class AppmapUploader {
       return undefined;
     }
 
-    const appmapApiKey = await AppMapServerAuthenticationProvider.getApiKey(true);
+    const appmapApiKey = await getApiKey(true);
     if (!appmapApiKey) return;
 
     let upload: UploadAppMapResponse;

--- a/src/actions/signup.ts
+++ b/src/actions/signup.ts
@@ -1,4 +1,4 @@
-import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
+import { getApiKey } from '../authentication';
 import extensionSettings from '../configuration/extensionSettings';
 import AnalysisManager from '../services/analysisManager';
 import { ANALYSIS_CTA_INTERACTION, Telemetry } from '../telemetry';
@@ -10,7 +10,7 @@ export class Signup {
 
     Telemetry.sendEvent(ANALYSIS_CTA_INTERACTION);
 
-    const appmapApiKey = await AppMapServerAuthenticationProvider.getApiKey(true);
+    const appmapApiKey = await getApiKey(true);
     if (!appmapApiKey) return false;
 
     await extensionSettings.enableFindings();

--- a/src/actions/signup.ts
+++ b/src/actions/signup.ts
@@ -1,5 +1,4 @@
-import * as vscode from 'vscode';
-import { AUTHN_PROVIDER_NAME } from '../authentication';
+import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
 import extensionSettings from '../configuration/extensionSettings';
 import AnalysisManager from '../services/analysisManager';
 import { ANALYSIS_CTA_INTERACTION, Telemetry } from '../telemetry';
@@ -11,11 +10,8 @@ export class Signup {
 
     Telemetry.sendEvent(ANALYSIS_CTA_INTERACTION);
 
-    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
-      createIfNone: true,
-    });
-
-    if (!session) return false;
+    const appmapApiKey = await AppMapServerAuthenticationProvider.getApiKey(true);
+    if (!appmapApiKey) return false;
 
     await extensionSettings.enableFindings();
 

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -14,6 +14,7 @@ import {
 } from '../telemetry';
 import ErrorCode from '../telemetry/definitions/errorCodes';
 import { AUTHN_PROVIDER_NAME } from './index';
+import Environment from '../configuration/environment';
 
 const APPMAP_SERVER_SESSION_KEY = 'appmap.server.session';
 
@@ -49,6 +50,8 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
   }
 
   static async getApiKey(createIfNone: boolean): Promise<string | undefined> {
+    if (!createIfNone && Environment.appMapTestApiKey) return Environment.appMapTestApiKey;
+
     const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
       createIfNone,
     });

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -52,10 +52,7 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
       createIfNone,
     });
-    if (!session) {
-      return;
-    }
-    return session.accessToken;
+    return session?.accessToken;
   }
 
   constructor(public context: vscode.ExtensionContext, public uriHandler: UriHandler) {}
@@ -124,7 +121,8 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
         },
         async (_progress, token) => {
           return new Promise((resolve) => {
-            const dispose = (disposables) => disposables.forEach((d) => d.dispose());
+            const dispose = (disposables: vscode.Disposable[]) =>
+              disposables.forEach((d) => d.dispose());
             const disposables = [
               authnHandler.onCreateSession((session) => {
                 dispose(disposables);

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -14,7 +14,6 @@ import {
 } from '../telemetry';
 import ErrorCode from '../telemetry/definitions/errorCodes';
 import { AUTHN_PROVIDER_NAME } from './index';
-import Environment from '../configuration/environment';
 
 const APPMAP_SERVER_SESSION_KEY = 'appmap.server.session';
 
@@ -47,15 +46,6 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     Object.entries(queryParams).forEach(([k, v]) => url.searchParams.set(k, v));
 
     return vscode.Uri.parse(url.toString());
-  }
-
-  static async getApiKey(createIfNone: boolean): Promise<string | undefined> {
-    if (!createIfNone && Environment.appMapTestApiKey) return Environment.appMapTestApiKey;
-
-    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
-      createIfNone,
-    });
-    return session?.accessToken;
   }
 
   constructor(public context: vscode.ExtensionContext, public uriHandler: UriHandler) {}

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { default as ExtensionSettings } from '../configuration/extensionSettings';
 import UriHandler from '../uri/uriHandler';
 import AppMapServerAuthenticationHandler from '../uri/appmapServerAuthenticationHandler';
@@ -47,6 +46,16 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     Object.entries(queryParams).forEach(([k, v]) => url.searchParams.set(k, v));
 
     return vscode.Uri.parse(url.toString());
+  }
+
+  static async getApiKey(createIfNone: boolean): Promise<string | undefined> {
+    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
+      createIfNone,
+    });
+    if (!session) {
+      return;
+    }
+    return session.accessToken;
   }
 
   constructor(public context: vscode.ExtensionContext, public uriHandler: UriHandler) {}

--- a/src/authentication/index.ts
+++ b/src/authentication/index.ts
@@ -1,4 +1,17 @@
 // This was previously exported within `appmapServerAuthenticationProvider.ts`, however by doing so
 // it introduces dependencies which rely on transpiled content (HTML files). This works in the packaged
+
+import * as vscode from 'vscode';
+import Environment from '../configuration/environment';
+
 // extension (because of Webpack), but fails during tests. As a quick fix, this export has been moved out.
 export const AUTHN_PROVIDER_NAME = 'appmap.server';
+
+export async function getApiKey(createIfNone: boolean): Promise<string | undefined> {
+  if (!createIfNone && Environment.appMapTestApiKey) return Environment.appMapTestApiKey;
+
+  const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
+    createIfNone,
+  });
+  return session?.accessToken;
+}

--- a/src/configuration/environment.ts
+++ b/src/configuration/environment.ts
@@ -1,4 +1,7 @@
 export default class Environment {
+  static get appMapTestApiKey(): string | undefined {
+    return process.env.APPMAP_TEST_API_KEY;
+  }
   static get isSystemTest(): boolean {
     return process.env.APPMAP_SYSTEM_TEST !== undefined;
   }

--- a/src/configuration/environment.ts
+++ b/src/configuration/environment.ts
@@ -1,5 +1,5 @@
 export default class Environment {
-  static get isSmokeTest(): boolean {
-    return process.env.APPMAP_TEST !== undefined;
+  static get isSystemTest(): boolean {
+    return process.env.APPMAP_SYSTEM_TEST !== undefined;
   }
 }

--- a/src/configuration/environment.ts
+++ b/src/configuration/environment.ts
@@ -2,6 +2,9 @@ export default class Environment {
   static get appMapTestApiKey(): string | undefined {
     return process.env.APPMAP_TEST_API_KEY;
   }
+  static get isIntegrationTest(): boolean {
+    return process.env.APPMAP_INTEGRATION_TEST !== undefined;
+  }
   static get isSystemTest(): boolean {
     return process.env.APPMAP_SYSTEM_TEST !== undefined;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,7 +265,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     });
 
     // Use this notification to track when the extension is activated.
-    if (Environment.isSmokeTest) {
+    if (Environment.isSystemTest) {
       // It may just be a nightly thing, but showErrorMessage has stopped working when called
       // immediately after the extension is activated. This is a workaround.
       const intervalHandle = setInterval(async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     FindingsOverviewWebview.register(context);
     FindingInfoWebview.register(context);
 
-    const processService = new NodeProcessService(context, projectStates);
+    const processService = new NodeProcessService(context);
     (async function() {
       processService.onReady(activateUptodateService);
       await processService.install();

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -102,7 +102,7 @@ export default class AnalysisManager {
   }
 
   public static async isUserAuthenticated(): Promise<boolean> {
-    if (Environment.isSmokeTest) return true;
+    if (Environment.isSystemTest) return true;
 
     return !!(await AppMapServerAuthenticationProvider.getApiKey(false));
   }

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -65,7 +65,9 @@ export default class AnalysisManager {
       }),
       vscode.authentication.onDidChangeSessions((e) => {
         if (e.provider.id !== AUTHN_PROVIDER_NAME) return;
-        this.updateAnalysisState();
+
+        // The API key won't be available immediately. Wait a tick.
+        setTimeout(this.updateAnalysisState.bind(this), 0);
       })
     );
   }

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { AUTHN_PROVIDER_NAME } from '../authentication';
+import { AUTHN_PROVIDER_NAME, getApiKey } from '../authentication';
 import ExtensionSettings from '../configuration/extensionSettings';
 import FindingsDiagnosticsProvider from '../diagnostics/findingsDiagnosticsProvider';
 import FindingsIndex from './findingsIndex';
@@ -11,7 +11,6 @@ import { ResolvedFinding } from './resolvedFinding';
 import { WorkspaceServices } from './workspaceServices';
 import Environment from '../configuration/environment';
 import { ANALYSIS_DISABLE, ANALYSIS_ENABLE, Telemetry } from '../telemetry';
-import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
 
 export interface AnalysisToggleEvent {
   enabled: boolean;
@@ -104,7 +103,7 @@ export default class AnalysisManager {
   public static async isUserAuthenticated(): Promise<boolean> {
     if (Environment.isSystemTest) return true;
 
-    return !!(await AppMapServerAuthenticationProvider.getApiKey(false));
+    return !!(await getApiKey(false));
   }
 
   private static onAnalysisEnabled(): void {

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -11,6 +11,7 @@ import { ResolvedFinding } from './resolvedFinding';
 import { WorkspaceServices } from './workspaceServices';
 import Environment from '../configuration/environment';
 import { ANALYSIS_DISABLE, ANALYSIS_ENABLE, Telemetry } from '../telemetry';
+import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
 
 export interface AnalysisToggleEvent {
   enabled: boolean;
@@ -101,10 +102,7 @@ export default class AnalysisManager {
   public static async isUserAuthenticated(): Promise<boolean> {
     if (Environment.isSmokeTest) return true;
 
-    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
-      createIfNone: false,
-    });
-    return session !== undefined;
+    return !!(await AppMapServerAuthenticationProvider.getApiKey(false));
   }
 
   private static onAnalysisEnabled(): void {

--- a/src/services/appMapConfigWatcher.ts
+++ b/src/services/appMapConfigWatcher.ts
@@ -3,7 +3,7 @@ import { fileExists } from '../util';
 import { FileChangeEmitter, FileChangeEvent } from './fileChangeEmitter';
 import { WorkspaceService, WorkspaceServiceInstance } from './workspaceService';
 
-class ConfigWatcherInstance implements WorkspaceServiceInstance {
+export class AppMapConfigWatcherInstance implements WorkspaceServiceInstance {
   watcher: vscode.FileSystemWatcher;
   protected disposables: vscode.Disposable[] = [];
   protected configPattern = new vscode.RelativePattern(this.folder, `**/appmap.yml`);
@@ -26,14 +26,14 @@ class ConfigWatcherInstance implements WorkspaceServiceInstance {
     );
   }
 
-  async initialize() {
+  async initialize(): Promise<AppMapConfigWatcherInstance> {
     (await vscode.workspace.findFiles(this.configPattern)).forEach((uri) => {
       this.onCreate.fire({ uri, workspaceFolder: this.folder });
     });
     return this;
   }
 
-  async dispose() {
+  async dispose(): Promise<void> {
     (
       await vscode.workspace.findFiles(
         new vscode.RelativePattern(this.folder, '**/*.appmap.json'),
@@ -48,9 +48,9 @@ class ConfigWatcherInstance implements WorkspaceServiceInstance {
 }
 
 export class AppMapConfigWatcher extends FileChangeEmitter
-  implements WorkspaceService<ConfigWatcherInstance> {
-  async create(folder: vscode.WorkspaceFolder): Promise<ConfigWatcherInstance> {
-    const watcher = new ConfigWatcherInstance(
+  implements WorkspaceService<AppMapConfigWatcherInstance> {
+  async create(folder: vscode.WorkspaceFolder): Promise<AppMapConfigWatcherInstance> {
+    const watcher = new AppMapConfigWatcherInstance(
       folder,
       this._onChange,
       this._onCreate,

--- a/src/services/appmapServerConfiguration.ts
+++ b/src/services/appmapServerConfiguration.ts
@@ -1,7 +1,7 @@
 import { Configuration } from '@appland/client';
 import { setConfiguration } from '@appland/client/dist/src/loadConfiguration';
 import * as vscode from 'vscode';
-import { AUTHN_PROVIDER_NAME } from '../authentication';
+import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
 import ExtensionSettings from '../configuration/extensionSettings';
 
 export default class AppMapServerConfiguration implements vscode.Disposable {
@@ -29,10 +29,8 @@ export default class AppMapServerConfiguration implements vscode.Disposable {
   static async updateAppMapClientConfiguration(): Promise<void> {
     const serverURL = ExtensionSettings.appMapServerURL;
     const configuration: Configuration = { baseURL: serverURL.toString() };
-    const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default']);
-    if (session) {
-      configuration.apiKey = session.accessToken;
-    }
+    const apiKey = await AppMapServerAuthenticationProvider.getApiKey(false);
+    if (apiKey) configuration.apiKey = apiKey;
 
     setConfiguration(configuration);
   }

--- a/src/services/appmapServerConfiguration.ts
+++ b/src/services/appmapServerConfiguration.ts
@@ -1,7 +1,7 @@
 import { Configuration } from '@appland/client';
 import { setConfiguration } from '@appland/client/dist/src/loadConfiguration';
 import * as vscode from 'vscode';
-import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
+import { getApiKey } from '../authentication';
 import ExtensionSettings from '../configuration/extensionSettings';
 
 export default class AppMapServerConfiguration implements vscode.Disposable {
@@ -29,7 +29,7 @@ export default class AppMapServerConfiguration implements vscode.Disposable {
   static async updateAppMapClientConfiguration(): Promise<void> {
     const serverURL = ExtensionSettings.appMapServerURL;
     const configuration: Configuration = { baseURL: serverURL.toString() };
-    const apiKey = await AppMapServerAuthenticationProvider.getApiKey(false);
+    const apiKey = await getApiKey(false);
     if (apiKey) configuration.apiKey = apiKey;
 
     setConfiguration(configuration);

--- a/src/services/indexProcessWatcher.ts
+++ b/src/services/indexProcessWatcher.ts
@@ -1,0 +1,15 @@
+import { NodeProcessService } from './nodeProcessService';
+import { ProcessWatcher } from './processWatcher';
+
+export default class IndexProcessWatcher extends ProcessWatcher {
+  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
+    super({
+      id: 'index',
+      modulePath: modulePath,
+      log: NodeProcessService.outputChannel,
+      args: ['index', '--watch', '--appmap-dir', appmapDir],
+      cwd,
+      env,
+    });
+  }
+}

--- a/src/services/indexProcessWatcher.ts
+++ b/src/services/indexProcessWatcher.ts
@@ -1,9 +1,15 @@
 import { NodeProcessService } from './nodeProcessService';
-import { ProcessWatcher } from './processWatcher';
+import { ConfigFileProvider, ProcessWatcher } from './processWatcher';
 
 export default class IndexProcessWatcher extends ProcessWatcher {
-  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
-    super({
+  constructor(
+    configFileProvider: ConfigFileProvider,
+    modulePath: string,
+    appmapDir: string,
+    cwd: string,
+    env?: NodeJS.ProcessEnv
+  ) {
+    super(configFileProvider, {
       id: 'index',
       modulePath: modulePath,
       log: NodeProcessService.outputChannel,

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -71,7 +71,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       appMapDir = NodeProcessService.DEFAULT_APPMAP_DIR;
     }
 
-    const env = process.env.APPMAP_TEST
+    const env = process.env.APPMAP_SYSTEM_TEST
       ? { ...process.env, APPMAP_WRITE_PIDFILE: 'true' }
       : undefined;
 

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -105,7 +105,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
     }
 
     const instance = new NodeProcessServiceInstance(folder, services, projectState);
-    await instance.initialize();
+    instance.initialize();
 
     return instance;
   }
@@ -205,7 +205,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       // to run `yarn install` to create it. `yarn up` will happilly update an empty lock file.
       await fs.appendFile(path.join(this.globalStorageDir, 'yarn.lock'), '');
 
-      const installProcess = await spawn({
+      const installProcess = spawn({
         modulePath: this.yarnPath,
         args: ['up', '-R', '@appland/appmap', '@appland/scanner'],
         cwd: this.globalStorageDir,

--- a/src/services/scanProcessWatcher.ts
+++ b/src/services/scanProcessWatcher.ts
@@ -1,4 +1,4 @@
-import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
+import { getApiKey } from '../authentication';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
 import { ProcessWatcher } from './processWatcher';
@@ -26,7 +26,7 @@ export default class ScanProcessWatcher extends ProcessWatcher {
   }
 
   async accessToken(): Promise<string | undefined> {
-    return AppMapServerAuthenticationProvider.getApiKey(false);
+    return getApiKey(false);
   }
 
   protected async loadEnvironment(): Promise<NodeJS.ProcessEnv> {

--- a/src/services/scanProcessWatcher.ts
+++ b/src/services/scanProcessWatcher.ts
@@ -1,11 +1,17 @@
 import { getApiKey } from '../authentication';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
-import { ProcessWatcher } from './processWatcher';
+import { ConfigFileProvider, ProcessWatcher } from './processWatcher';
 
 export default class ScanProcessWatcher extends ProcessWatcher {
-  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
-    super({
+  constructor(
+    configFileProvider: ConfigFileProvider,
+    modulePath: string,
+    appmapDir: string,
+    cwd: string,
+    env?: NodeJS.ProcessEnv
+  ) {
+    super(configFileProvider, {
       id: 'analysis',
       modulePath: modulePath,
       log: NodeProcessService.outputChannel,
@@ -16,6 +22,9 @@ export default class ScanProcessWatcher extends ProcessWatcher {
   }
 
   async canStart(): Promise<{ enabled: boolean; reason?: string }> {
+    const result = await super.canStart();
+    if (!result.enabled) return result;
+
     if (!ExtensionSettings.findingsEnabled)
       return { enabled: false, reason: 'appMap.findingsEnabled is false' };
 

--- a/src/services/scanProcessWatcher.ts
+++ b/src/services/scanProcessWatcher.ts
@@ -1,0 +1,34 @@
+import AppMapServerAuthenticationProvider from '../authentication/appmapServerAuthenticationProvider';
+import AnalysisManager from './analysisManager';
+import { NodeProcessService } from './nodeProcessService';
+import { ProcessWatcher } from './processWatcher';
+
+export default class ScanProcessWatcher extends ProcessWatcher {
+  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
+    super({
+      id: 'analysis',
+      modulePath: modulePath,
+      log: NodeProcessService.outputChannel,
+      args: ['scan', '--watch', '--appmap-dir', appmapDir],
+      cwd,
+      env,
+    });
+  }
+
+  async canStart(): Promise<boolean> {
+    return AnalysisManager.isAnalysisEnabled && !!(await this.accessToken());
+  }
+
+  async accessToken(): Promise<string | undefined> {
+    return await AppMapServerAuthenticationProvider.getApiKey(false);
+  }
+
+  protected async loadEnvironment(): Promise<NodeJS.ProcessEnv> {
+    const env = await super.loadEnvironment();
+    const accessToken = await this.accessToken();
+    if (accessToken) {
+      env.APPMAP_API_KEY = accessToken;
+    }
+    return env;
+  }
+}

--- a/test/integration/nodeProcesses/backgroundProcess.test.ts
+++ b/test/integration/nodeProcesses/backgroundProcess.test.ts
@@ -9,16 +9,12 @@ import {
   mkTmpDir,
   ProjectA,
   restoreFile,
-  unsafeCast,
   waitForExtension,
   withAuthenticatedUser,
-  withTmpDir,
 } from '../util';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ProjectStateServiceInstance } from '../../../src/services/projectStateService';
-import Sinon from 'sinon';
 
 async function waitForProcessState(
   processWatchers: ReadonlyArray<ProcessWatcher>,
@@ -176,19 +172,11 @@ describe('Background processes', () => {
         name: path.basename(tmpDir),
         index: -1,
       } as vscode.WorkspaceFolder;
-      service = new NodeProcessService(
-        {
-          globalStorageUri: directoryUri,
-          extensionPath: path.join(__dirname, '..', '..', '..', '..'),
-        } as vscode.ExtensionContext,
-        [
-          unsafeCast<ProjectStateServiceInstance>({
-            folder: workspaceFolder,
-            metadata: {},
-            onStateChange: Sinon.stub(),
-          }),
-        ]
-      );
+      service = new NodeProcessService(({
+        globalStorageUri: directoryUri,
+        extensionPath: path.join(__dirname, '..', '..', '..', '..'),
+        subscriptions: [],
+      } as any) as vscode.ExtensionContext);
       await fs.writeFile(path.join(tmpDir, 'appmap.yml'), `appmap_dir: ${appmapDir}`, 'utf8');
     });
 
@@ -205,9 +193,9 @@ describe('Background processes', () => {
 
     it("creates the AppMap directory if it doesn't already exist", async () => {
       const expectedPath = path.join(tmpDir, appmapDir);
-      assert(!(await fileExists(expectedPath)), 'the appmap_dir provided is expected not to exist');
+      assert(!(await fileExists(expectedPath)), 'the appmap_dir provided should not exist');
       await service.create(workspaceFolder);
-      assert(await fileExists(expectedPath), 'the appmap_dir provided was not created');
+      assert(await fileExists(expectedPath), 'the appmap_dir provided does not exist');
     });
   });
 });

--- a/test/integration/nodeProcesses/nodeProcessService.test.ts
+++ b/test/integration/nodeProcesses/nodeProcessService.test.ts
@@ -15,7 +15,7 @@ describe('NodeProcessService', () => {
           extensionPath: path.join(__dirname, '..', '..', '..', '..'),
         } as vscode.ExtensionContext;
 
-        const service = new NodeProcessService(extensionContext, []);
+        const service = new NodeProcessService(extensionContext);
         await service.install();
         await fs.stat(path.join(tmpDir, 'node_modules'));
         await fs.stat(path.join(tmpDir, 'yarn.lock'));
@@ -39,7 +39,7 @@ describe('NodeProcessService', () => {
             extensionPath: path.join(__dirname, '..', '..', '..', '..'),
           } as vscode.ExtensionContext;
 
-          const service = new NodeProcessService(extensionContext, []);
+          const service = new NodeProcessService(extensionContext);
           service.install();
           await new Promise((resolve) => service.onReady(resolve));
 

--- a/test/integration/sampleCodeObjects/codeObjects.test.ts
+++ b/test/integration/sampleCodeObjects/codeObjects.test.ts
@@ -9,7 +9,7 @@ import {
   withAuthenticatedUser,
 } from '../util';
 
-describe('Sample Code Objects', () => {
+describe('Code Objects', () => {
   withAuthenticatedUser();
 
   beforeEach(initializeWorkspace);

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -131,6 +131,7 @@ async function integrationTest() {
         PROJECT_DIR: workspaceDir, // A hint to resolve relative paths in settings
         TEST_FILE: testFile,
         APPMAP_WRITE_PIDFILE: 'true',
+        APPMAP_INTEGRATION_TEST: 'true',
         YARN_LOCKFILE_NAME: 'bad.lock',
       },
       launchArgs: [

--- a/test/system/src/app.ts
+++ b/test/system/src/app.ts
@@ -64,7 +64,7 @@ export async function launchCode(
     ],
     env: {
       ...process.env,
-      APPMAP_TEST: '1',
+      APPMAP_SYSTEM_TEST: '1',
     },
   });
 

--- a/test/system/src/app.ts
+++ b/test/system/src/app.ts
@@ -64,6 +64,7 @@ export async function launchCode(
     ],
     env: {
       ...process.env,
+      APPMAP_TEST_API_KEY: 'Zm9vQGdtYWlsLmNvbTpmYzYwNTRiNi0xOTAzLTQ0MDEtOTJhNy0wMDAzNWFjOGI2MGMK',
       APPMAP_SYSTEM_TEST: '1',
     },
   });


### PR DESCRIPTION
* Provide the AppMap API key to the scanner process, so that it can enforce its presence if desired.
* Use a simple interval to manage indexer and scanner processes.
* DRY up access to the AppMap API key.
* Remove some dependency on ProjectState, which isn't reliable as the user adds and removes projects.
