### PR TITLE
fix: Use best fit path when opening source of a code object

### DIFF
--- a/src/commands/openAppMap.ts
+++ b/src/commands/openAppMap.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import AppMapEditorProvider from '../editor/appmapEditorProvider';
+
+export default async function appMapOpen(context: vscode.ExtensionContext): Promise<void> {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'appmap.open',
+      async (appMapUri, state?: string | Record<string, unknown>) => {
+        vscode.commands.executeCommand('vscode.open', appMapUri);
+        const ready = await AppMapEditorProvider.webviewReady(appMapUri);
+        if (ready && state) AppMapEditorProvider.setState(appMapUri, state);
+      }
+    )
+  );
+}

--- a/src/commands/openCodeObjectInAppMap.ts
+++ b/src/commands/openCodeObjectInAppMap.ts
@@ -64,10 +64,10 @@ export default async function openCodeObjectInAppMap(
     const state = {
       currentView: 'viewComponent',
       selectedObject: codeObject.fqid,
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const uri = vscode.Uri.parse(`file://${appMapFileName}#${JSON.stringify(state)}`);
+    };
+    const uri = vscode.Uri.file(appMapFileName);
     Telemetry.sendEvent(CLICK_CODE_OBJECT);
-    vscode.commands.executeCommand('vscode.open', uri);
+    vscode.commands.executeCommand('appmap.open', uri, state);
   });
   context.subscriptions.push(command);
 }

--- a/src/commands/openCodeObjectInSource.ts
+++ b/src/commands/openCodeObjectInSource.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { bestFilePath } from '../lib/bestFilePath';
 import { CLICK_CODE_OBJECT, Telemetry } from '../telemetry';
 
 export default async function openCodeObjectInSource(
@@ -6,9 +7,16 @@ export default async function openCodeObjectInSource(
 ): Promise<void> {
   const command = vscode.commands.registerCommand(
     'appmap.openCodeObjectInSource',
-    async (uri, showOptions) => {
+    async (
+      path: string,
+      folder?: vscode.WorkspaceFolder,
+      showOptions?: vscode.TextDocumentShowOptions,
+      prompt?: string
+    ) => {
       Telemetry.sendEvent(CLICK_CODE_OBJECT);
-      await vscode.commands.executeCommand('vscode.open', uri, showOptions);
+      const bestPath = await bestFilePath(path, folder, prompt);
+      if (!bestPath) return;
+      await vscode.commands.executeCommand('vscode.open', bestPath, showOptions);
     }
   );
   context.subscriptions.push(command);

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -61,17 +61,6 @@ export default class AppMapEditorProvider
       })
     );
 
-    context.subscriptions.push(
-      vscode.commands.registerCommand('appmap.setAppmapStateNoPrompt', async (state) => {
-        if (provider.currentWebView) {
-          provider.currentWebView.webview.postMessage({
-            type: 'setAppmapState',
-            state: state,
-          });
-        }
-      })
-    );
-
     return provider;
   }
 
@@ -79,8 +68,8 @@ export default class AppMapEditorProvider
   private static readonly INSTRUCTIONS_VIEWED = 'APPMAP_INSTRUCTIONS_VIEWED';
   private static readonly RELEASE_KEY = 'APPMAP_RELEASE_KEY';
   private static readonly analysisManager = AnalysisManager;
+  private static readonly openWebviewPanels = new Map<string, vscode.WebviewPanel>();
   public static readonly APPMAP_OPENED = 'APPMAP_OPENED';
-  public static readonly INITIAL_STATE = 'INITIAL_STATE';
   public currentWebView?: vscode.WebviewPanel;
 
   constructor(
@@ -133,21 +122,6 @@ export default class AppMapEditorProvider
       }
     });
 
-    const initialState = (() => {
-      const state = document.uri.fragment || extensionSettings.viewConfiguration;
-      if (state !== undefined && state !== '') {
-        try {
-          JSON.parse(state);
-          return state;
-        } catch (e) {
-          console.warn(e);
-        }
-      }
-    })();
-
-    if (initialState)
-      this.context.globalState.update(AppMapEditorProvider.INITIAL_STATE, initialState);
-
     const updateWebview = () => {
       webviewPanel.webview.postMessage({
         type: 'update',
@@ -167,12 +141,6 @@ export default class AppMapEditorProvider
           type: 'displayUpdateNotification',
           version,
         });
-      }
-
-      const initialState = this.context.globalState.get(AppMapEditorProvider.INITIAL_STATE);
-      if (initialState) {
-        vscode.commands.executeCommand('appmap.setAppmapStateNoPrompt', initialState);
-        this.context.globalState.update(AppMapEditorProvider.INITIAL_STATE, null);
       }
     };
 
@@ -199,6 +167,7 @@ export default class AppMapEditorProvider
           vscode.window.setStatusBarMessage('AppMap state was copied to clipboard', 5000);
           break;
         case 'onLoadComplete':
+          AppMapEditorProvider.openWebviewPanels.set(document.uri.toString(), webviewPanel);
           this.documents.push(document);
           Telemetry.sendEvent(APPMAP_OPEN, {
             rootDirectory: document.workspaceFolder?.uri.fsPath,
@@ -259,6 +228,7 @@ export default class AppMapEditorProvider
 
     webviewPanel.onDidDispose(() => {
       this.currentWebView = undefined;
+      AppMapEditorProvider.openWebviewPanels.delete(document.uri.toString());
       removeOne(this.documents, document);
       if (document.workspaceFolder)
         this.extensionState.setClosedAppMap(document.workspaceFolder, true);
@@ -326,7 +296,32 @@ export default class AppMapEditorProvider
     context.globalState.update(AppMapEditorProvider.INSTRUCTIONS_VIEWED, null);
     context.globalState.update(AppMapEditorProvider.RELEASE_KEY, null);
     context.globalState.update(AppMapEditorProvider.APPMAP_OPENED, null);
-    context.globalState.update(AppMapEditorProvider.INITIAL_STATE, null);
+  }
+
+  public static setState(uri: vscode.Uri, state: string | Record<string, unknown>): void {
+    const panel = this.openWebviewPanels.get(uri.toString());
+    if (panel) {
+      panel.webview.postMessage({
+        type: 'setAppmapState',
+        state:
+          typeof state === 'string'
+            ? state
+            : Buffer.from(JSON.stringify(state), 'utf-8').toString('base64url'),
+      });
+    }
+  }
+
+  public static async webviewReady(
+    uri: vscode.Uri,
+    timeoutSeconds = 10,
+    tickRateMs = 100
+  ): Promise<boolean> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+      if (this.openWebviewPanels.has(uri.toString())) return true;
+      await new Promise((resolve) => setTimeout(resolve, tickRateMs));
+    }
+    return false;
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ import openCodeObjectInSource from './commands/openCodeObjectInSource';
 import learnMoreRuntimeAnalysis from './commands/learnMoreRuntimeAnalysis';
 import SignInViewProvider from './webviews/signInWebview';
 import SignInManager from './services/signInManager';
+import appMapOpen from './commands/openAppMap';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -128,6 +129,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     openCodeObjectInSource(context);
     learnMoreRuntimeAnalysis(context);
     appmapHoverProvider(context, lineInfoIndex);
+    appMapOpen(context);
 
     await workspaceServices.enroll(sourceFileWatcher);
     await workspaceServices.enroll(classMapWatcher);
@@ -224,7 +226,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     FindingInfoWebview.register(context);
 
     const processService = new NodeProcessService(context);
-    (async function() {
+    (async function () {
       processService.onReady(activateUptodateService);
       await processService.install();
       await workspaceServices.enroll(processService);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,7 +224,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     FindingInfoWebview.register(context);
 
     const processService = new NodeProcessService(context);
-    (async function () {
+    (async function() {
       processService.onReady(activateUptodateService);
       await processService.install();
       await workspaceServices.enroll(processService);

--- a/src/lib/buildClassMap.ts
+++ b/src/lib/buildClassMap.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ClassMapEntry, CodeObjectEntry, CodeObjectEntryRootType } from './CodeObjectEntry';
 
 const ROOT_ID = '<root>';
@@ -122,9 +123,9 @@ export async function buildClassMap(
           return;
         }
 
-        const classMapFileTokens = classMapFileURL.fsPath.split('/');
+        const classMapFileTokens = classMapFileURL.fsPath.split(/[\\/]/);
         classMapFileTokens.pop();
-        const indexDir = classMapFileTokens.join('/');
+        const indexDir = classMapFileTokens.join(path.sep);
         const appMapFilePath = [indexDir, 'appmap.json'].join('.');
         classMap.map(makeFolder).forEach(mergeCodeObject.bind(null, folder, appMapFilePath, root));
       })

--- a/src/tree/classMapTreeDataProvider.ts
+++ b/src/tree/classMapTreeDataProvider.ts
@@ -105,16 +105,10 @@ export class ClassMapTreeDataProvider implements vscode.TreeDataProvider<vscode.
           new vscode.Position(codeObject.lineNo - 1, 0)
         );
       }
-      let uri: vscode.Uri;
-      if (isAbsolute(codeObject.path)) {
-        uri = vscode.Uri.file(codeObject.path);
-      } else {
-        uri = vscode.Uri.joinPath(codeObject.folder.uri, codeObject.path);
-      }
       treeItem.command = {
         command: 'appmap.openCodeObjectInSource',
         title: `Open ${basename(codeObject.path)}`,
-        arguments: [uri, showOptions],
+        arguments: [codeObject.path, codeObject.folder, showOptions],
       };
     } else if (InspectableTypes.includes(codeObject.type) && codeObject.children.length === 0) {
       treeItem.command = {

--- a/src/uri/openAppMapUriHandler.ts
+++ b/src/uri/openAppMapUriHandler.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import AppMapEditorProvider from '../editor/appmapEditorProvider';
 import { RequestHandler } from './uriHandler';
 
 export default class OpenAppMapUriHandler implements RequestHandler {
@@ -8,16 +7,11 @@ export default class OpenAppMapUriHandler implements RequestHandler {
   constructor(protected readonly context: vscode.ExtensionContext) {}
 
   handle(queryParams: URLSearchParams): void {
-    if (queryParams.get('uri')) {
-      vscode.commands.executeCommand(
-        'vscode.open',
-        vscode.Uri.parse(queryParams.get('uri') as string)
-      );
-    }
+    const uri = queryParams.get('uri');
+    if (!uri) return;
 
-    if (queryParams.get('state')) {
-      this.context.globalState.update(AppMapEditorProvider.INITIAL_STATE, queryParams.get('state'));
-    }
+    const state = queryParams.get('state');
+    vscode.commands.executeCommand('appmap.open', vscode.Uri.parse(uri), state);
   }
 
   dispose(): void {

--- a/test/integration/editor/opensBySourcePathAndState.test.ts
+++ b/test/integration/editor/opensBySourcePathAndState.test.ts
@@ -30,9 +30,9 @@ describe('AppMapEditorProvider', () => {
         limitRootEvents: false,
       },
     };
-    const uri = vscode.Uri.parse(`file://${ExampleAppMap}#${JSON.stringify(state)}`);
+    const uri = vscode.Uri.file(ExampleAppMap);
 
-    await vscode.commands.executeCommand('vscode.open', uri);
+    await vscode.commands.executeCommand('appmap.open', uri, state);
 
     await waitFor('AppMap diagram should be opened', () => editorProvider.openDocuments.length > 0);
 

--- a/test/system/src/appMap.ts
+++ b/test/system/src/appMap.ts
@@ -41,6 +41,10 @@ export default class AppMap {
     return this.page.locator('.pane:has(.title:text("Runtime Analysis"))');
   }
 
+  get codeObjectsTree(): Locator {
+    return this.page.locator('.pane:has(.title:text("Code Objects"))');
+  }
+
   get appMapTree(): Locator {
     return this.page.locator('.pane:has(.title:text("AppMaps"))');
   }
@@ -51,6 +55,10 @@ export default class AppMap {
 
   public findingsTreeItem(nth?: number): Locator {
     return this.findingsTree.locator('.pane-body >> [role="treeitem"]').nth(nth || 0);
+  }
+
+  public codeObjectTreeItem(nth?: number): Locator {
+    return this.codeObjectsTree.locator('.pane-body >> [role="treeitem"]').nth(nth || 0);
   }
 
   public finding(nth?: number): Locator {
@@ -64,6 +72,12 @@ export default class AppMap {
   public async expandFindings(): Promise<void> {
     if (await this.findingsTree.locator('.pane-body').isHidden()) {
       await this.findingsTree.click();
+    }
+  }
+
+  public async expandCodeObjects(): Promise<void> {
+    if (await this.codeObjectsTree.locator('.pane-body').isHidden()) {
+      await this.codeObjectsTree.click();
     }
   }
 

--- a/test/system/src/appMapWebview.ts
+++ b/test/system/src/appMapWebview.ts
@@ -1,0 +1,19 @@
+import { FrameLocator, Locator, Page } from '@playwright/test';
+
+export default class AppMapWebview {
+  constructor(protected readonly page: Page) {}
+
+  private frameSelector = 'iframe.webview.ready';
+
+  private get frame(): FrameLocator {
+    return this.page.frameLocator(this.frameSelector).nth(1).frameLocator('#active-frame').first();
+  }
+
+  public get app(): Locator {
+    return this.frame.locator('#app').first();
+  }
+
+  public async ready(): Promise<void> {
+    await this.app.waitFor();
+  }
+}

--- a/test/system/src/driver.ts
+++ b/test/system/src/driver.ts
@@ -1,6 +1,7 @@
 import { BrowserContext, ElectronApplication, Locator, Page } from '@playwright/test';
 import { glob } from 'glob';
 import AppMap from './appMap';
+import AppMapWebview from './appMapWebview';
 import FindingDetailsWebview from './findingDetailsWebview';
 import FindingsOverviewWebview from './findingsOverviewWebview';
 import InstructionsWebview from './instructionsWebview';
@@ -25,6 +26,7 @@ export default class Driver {
     this.findingsOverviewWebview,
     this.findingDetailsWebview
   );
+  public readonly appMapWebview = new AppMapWebview(this.page);
   public readonly panel = new Panel(this.page);
 
   constructor(

--- a/test/system/tests/codeObjects.test.ts
+++ b/test/system/tests/codeObjects.test.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+
+describe('Code object tree', function () {
+  beforeEach(async function () {
+    const { driver, project } = this;
+
+    const pidfile = path.join(project.workspacePath, '**', 'index.pid');
+    await project.reset();
+    await driver.closePanel();
+    await driver.resetUsage();
+    await driver.reload();
+    await driver.waitForFile(pidfile);
+  });
+
+  it('opening a query code object opens an AppMap', async function () {
+    const { driver } = this;
+
+    await driver.appMap.openActionPanel();
+    await driver.appMap.expandCodeObjects();
+    await driver.appMap.codeObjectTreeItem(2).click();
+    await driver.appMap.codeObjectTreeItem(3).click();
+    await driver.appMapWebview.ready();
+
+    // TODO: We should be testing to see if the AppMap contains an active
+    // selection (i.e. the proper state is reflected), however this appears
+    // to be broken at the moment.
+  });
+});


### PR DESCRIPTION
Two main issues are fixed by this pull request:
1. When opening source code, the path was used verbatim. In Java, we only have partial paths (e.g. `myorg/myapp/package/Class.java`) so we should have been using `bestFilePath` when opening those files.
2. We were using URI fragments to send along the view state when opening an AppMap. This works everywhere but on Windows. The `URI` class will not allow us to create a properly formatted `file` URI containing a fragment on this platform. I'm not sure the usage is valid to begin with. Instead, a new command, `appmap.open` has been added to open an AppMap file with a particular state. We now use this instead.

I've added a frontend (system) test to guarantee we're getting visible selection of the intended item, however it seems a bug upstream is preventing us from setting the state properly. We'll need to address this in another pull request.  

Fixes #616