### PR TITLE
fix: reduce scanning for appmap.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -436,7 +436,7 @@
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "lint": "eslint . --ext .ts",
-    "pretest": "yarn run lint && tsc --noEmit --strict",
+    "pretest": "yarn run lint && tsc --strict",
     "test:integration": "ts-node ./test/integrationTest.ts",
     "test:web-client": "mocha web/test/*.test.mjs",
     "test:system": "ts-node test/systemTest.ts",

--- a/test/unit/services/processWatcher.test.ts
+++ b/test/unit/services/processWatcher.test.ts
@@ -1,12 +1,16 @@
-import './support/mockVscode';
-import { ProcessWatcher, ProcessWatcherOptions } from '../../../src/services/processWatcher';
-import { join } from 'path';
-import { Uri } from 'vscode';
 import { expect } from 'chai';
-import ps from 'ps-node';
 import assert from 'node:assert';
-import { promisify } from 'util';
+import { join } from 'path';
+import ps from 'ps-node';
 import sinon from 'sinon';
+import { promisify } from 'util';
+import { Uri } from 'vscode';
+import {
+  ConfigFileProvider,
+  ProcessWatcher,
+  ProcessWatcherOptions,
+} from '../../../src/services/processWatcher';
+import './support/mockVscode';
 const testModule = join(__dirname, 'support', 'simpleProcess.mjs');
 
 describe('ProcessWatcher', () => {
@@ -55,7 +59,16 @@ describe('ProcessWatcher', () => {
 });
 
 function makeWatcher(opts: Partial<ProcessWatcherOptions> = {}) {
-  return new ProcessWatcher(() => Promise.resolve([Uri.parse('test:///appmap.yml')]), {
+  const provider: ConfigFileProvider = {
+    files() {
+      return Promise.resolve([Uri.parse('test:///appmap.yml')]);
+    },
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    reset() {},
+  };
+
+  return new ProcessWatcher(provider, {
     id: 'test process',
     modulePath: testModule,
     ...opts,


### PR DESCRIPTION
**This shouldn't be merged until the `wip` commit gets removed. It's only there as a temporary measure to run the integration tests.**

Reduce the cases where the extension scans the entire subtree under the current project directory.

Fixes #633 .