### PR TITLE
fix: Don't infinitely retry crashed processes

### DIFF
--- a/test/integration/nodeProcesses/processAbort.test.ts
+++ b/test/integration/nodeProcesses/processAbort.test.ts
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { DEFAULT_RETRY_OPTIONS, ProcessWatcher } from '../../../src/services/processWatcher';
+import { withAuthenticatedUser } from '../util';
+import { initializeProcesses, waitForDown, waitForUp } from './util';
+
+// This test resides in its own file because we want to run it in isolation.
+// Otherwise we don't know how many times processes have crashed due to other tests.
+describe('Background processes', () => {
+  withAuthenticatedUser();
+
+  let processWatchers: ReadonlyArray<ProcessWatcher>;
+  before(async () => {
+    processWatchers = await initializeProcesses();
+  });
+
+  it('eventually aborts if a process crashes too many times', async () => {
+    const expectedTimesUp = DEFAULT_RETRY_OPTIONS.retryTimes + 1;
+    let lastPids: Array<number | undefined> | undefined;
+    for (let i = 0; i < expectedTimesUp; ++i) {
+      await waitForUp(processWatchers, lastPids);
+      lastPids = processWatchers.map((p) => p.process?.pid);
+      assert.ok(lastPids.every((pid) => pid !== undefined));
+      assert.ok(
+        processWatchers.map((p) => p.process?.kill()).every((killed) => killed),
+        'every process is killed'
+      );
+    }
+
+    // Wait ten seconds to make sure the processes don't come back up
+    await new Promise((resolve) => setTimeout(resolve, 10 * 1000));
+    await waitForDown(processWatchers);
+  });
+});

--- a/test/integration/nodeProcesses/util.ts
+++ b/test/integration/nodeProcesses/util.ts
@@ -1,0 +1,78 @@
+import { ProcessWatcher } from '../../../src/services/processWatcher';
+import { retry } from '../../../src/util';
+import assert from 'assert';
+import NodeProcessServiceInstance from '../../../src/services/nodeProcessServiceInstance';
+import { WorkspaceServiceInstance } from '../../../src/services/workspaceService';
+import { waitForExtension } from '../util';
+import { NodeProcessService } from '../../../src/services/nodeProcessService';
+
+async function waitForProcessState(
+  processWatchers: ReadonlyArray<ProcessWatcher>,
+  isRunning: boolean,
+  pidExclusions: (number | undefined)[], // If a process is identified by a PID in `pidExclusions`, it will not pass the conditional,
+  action: string
+): Promise<void> {
+  await retry(
+    () => {
+      if (
+        !processWatchers.every(
+          (p) => p.running == isRunning && !pidExclusions.includes(p.process?.pid)
+        )
+      ) {
+        throw new Error(`Waiting for processes to ${action}`);
+      }
+    },
+    15,
+    1000
+  );
+}
+
+/* eslint-disable-next-line @typescript-eslint/naming-convention */
+export const waitForUp = (
+  processWatchers: ReadonlyArray<ProcessWatcher>,
+  pidExclusions: (number | undefined)[] = []
+): Promise<void> => waitForProcessState(processWatchers, true, pidExclusions, 'start');
+
+/* eslint-disable-next-line @typescript-eslint/naming-convention */
+export const waitForDown = (
+  processWatchers: ReadonlyArray<ProcessWatcher>,
+  pidExclusions: (number | undefined)[] = []
+): Promise<void> => waitForProcessState(processWatchers, false, pidExclusions, 'shut down');
+
+export interface InitializedProcessService {
+  processService: NodeProcessService;
+  processServiceInstance: NodeProcessServiceInstance;
+  processWatchers: ReadonlyArray<ProcessWatcher>;
+}
+
+export async function initializeProcesses(): Promise<ReadonlyArray<ProcessWatcher>> {
+  const extension = await waitForExtension();
+  const processService = extension.processService;
+  assert.ok(processService, 'the service exists');
+
+  if (!processService.ready) {
+    await new Promise<void>((resolve): void => {
+      const disposable = processService?.onReady((): void => {
+        disposable?.dispose();
+        resolve();
+      });
+    });
+  }
+
+  let serviceInstances: WorkspaceServiceInstance[] = [];
+  await retry(
+    () => {
+      serviceInstances = extension.workspaceServices.getServiceInstances(processService);
+      if (serviceInstances.length === 0) {
+        throw new Error(`Waiting for service instance creation`);
+      }
+    },
+    5,
+    1000
+  );
+
+  assert.strictEqual(serviceInstances.length, 1, 'a single service instance exists');
+
+  const processServiceInstance = serviceInstances[0] as NodeProcessServiceInstance;
+  return processServiceInstance['processes'];
+}


### PR DESCRIPTION
`NodeProcessServiceInstance#startAndStopProcesses` will try to restart services every second. Once the `ProcessWatcher` aborts a failed process, it'll begin restarting every second indefinitely. To resolve this, we'll first check if the process was previously aborted before attempting to start.

This change also adds a test to confirm crashed processes eventually stop spawning. Most of this change is refactoring out some of the testing utility functions into a separate file.

If you prefer to test manually, `kill` the PID of a single process in the `AppMap: Services` output window 4 times. After the fourth time, the process should not restart. The first token in each line is the PID.

```
12380 [Stdout] spawned /opt/vscode/code --ms-enable-electron-run-as-node /home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js index --watch --appmap-dir . with options {"retryTimes":3,"retryThreshold":180000,"id":"index","modulePath":"/home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js","log":{"name":"AppMap: Services"},"args":["index","--watch","--appmap-dir","."],"cwd":"/home/db/dev/spring-projects/spring-petclinic","env":{}}
12380 [Stderr] exited due to signal SIGTERM
12380 [Stderr] backing off for 2 seconds before restarting
12436 [Stdout] spawned /opt/vscode/code --ms-enable-electron-run-as-node /home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js index --watch --appmap-dir . with options {"retryTimes":3,"retryThreshold":180000,"id":"index","modulePath":"/home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js","log":{"name":"AppMap: Services"},"args":["index","--watch","--appmap-dir","."],"cwd":"/home/db/dev/spring-projects/spring-petclinic","env":{}}
12436 [Stderr] exited due to signal SIGTERM
12436 [Stderr] backing off for 4 seconds before restarting
12485 [Stdout] spawned /opt/vscode/code --ms-enable-electron-run-as-node /home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js index --watch --appmap-dir . with options {"retryTimes":3,"retryThreshold":180000,"id":"index","modulePath":"/home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js","log":{"name":"AppMap: Services"},"args":["index","--watch","--appmap-dir","."],"cwd":"/home/db/dev/spring-projects/spring-petclinic","env":{}}
12485 [Stderr] exited due to signal SIGTERM
12485 [Stderr] backing off for 8 seconds before restarting
12512 [Stdout] spawned /opt/vscode/code --ms-enable-electron-run-as-node /home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js index --watch --appmap-dir . with options {"retryTimes":3,"retryThreshold":180000,"id":"index","modulePath":"/home/db/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/cli.js","log":{"name":"AppMap: Services"},"args":["index","--watch","--appmap-dir","."],"cwd":"/home/db/dev/spring-projects/spring-petclinic","env":{}}
12512 [Stderr] exited due to signal SIGTERM
12512 [Stderr] too many crashes - aborting
```