### PR TITLE
Handle large appmaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -508,11 +508,11 @@
     "yaml": "^2.1.1"
   },
   "dependencies": {
-    "@appland/appmap": "^3.66.1",
+    "@appland/appmap": "^3.75.0",
     "@appland/client": "^1.6.0",
-    "@appland/components": "^2.34.0",
+    "@appland/components": "^2.36.0",
     "@appland/diagrams": "^1.6.3",
-    "@appland/models": "^2.4.1",
+    "@appland/models": "^2.4.2",
     "@appland/scanner": "^1.76.6",
     "@appland/sequence-diagram": "^1.5.0",
     "bent": "^7.3.12",

--- a/src/editor/AppMapDocument.ts
+++ b/src/editor/AppMapDocument.ts
@@ -11,11 +11,11 @@ export default class AppMapDocument implements vscode.CustomDocument {
 
   constructor(
     public uri: vscode.Uri,
-    public raw: Uint8Array,
+    public raw: string,
     stats: MapStats,
     public findings?: FindingInfo[]
   ) {
-    const appMap = JSON.parse(raw.toString());
+    const appMap = JSON.parse(raw);
     if (findings && findings.length !== 0) appMap.findings = findings;
     appMap.stats = stats || {};
     this.data = appMap;

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -23,6 +23,7 @@ import ErrorCode from '../telemetry/definitions/errorCodes';
 import {
   getModulePath,
   OutputStream,
+  ProcessLog,
   ProgramName,
   spawn,
   verifyCommandOutput,
@@ -117,6 +118,12 @@ export default class AppMapEditorProvider
     });
   }
 
+  outputLogToString(log: ProcessLog): string {
+    return log
+      .filter((line) => line.stream === OutputStream.Stdout)
+      .map((line) => line.data)
+      .join('');
+  }
 
   async generateStats(uri: vscode.Uri): Promise<FunctionStats[] | undefined> {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
@@ -138,12 +145,7 @@ export default class AppMapEditorProvider
 
     try {
       await verifyCommandOutput(statsCommand);
-
-      const statsString = statsCommand.log
-        .filter((line) => line.stream === OutputStream.Stdout)
-        .map((line) => line.data)
-        .join('');
-
+      const statsString = this.outputLogToString(statsCommand.log);
       return JSON.parse(statsString);
     } catch (e) {
       Telemetry.sendEvent(DEBUG_EXCEPTION, {

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -145,9 +145,6 @@ export default class AppMapEditorProvider
   async pruneMap(uri: vscode.Uri): Promise<string | undefined> {
     const modulePath = await this.cliPath();
 
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-    assert(workspaceFolder);
-
     const pruneCommand = spawn({
       modulePath,
       args: ['prune', uri.fsPath, '--size', '10mb', '--output-data', '--auto'],
@@ -168,9 +165,6 @@ export default class AppMapEditorProvider
   }
 
   async generateStats(uri: vscode.Uri): Promise<FunctionStats[] | undefined> {
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-    assert(workspaceFolder);
-
     const statsCommand = spawn({
       modulePath: await this.cliPath(),
       args: [

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -110,17 +110,20 @@ export default class AppMapEditorProvider
     return new AppMapDocument(uri, data, stats, findings);
   }
 
-  async generateStats(uri: vscode.Uri): Promise<FunctionStats[] | undefined> {
-    const modulePath = await getModulePath({
+  async cliPath(): Promise<string> {
+    return await getModulePath({
       dependency: ProgramName.Appmap,
       globalStoragePath: this.context.globalStorageUri.fsPath,
     });
+  }
 
+
+  async generateStats(uri: vscode.Uri): Promise<FunctionStats[] | undefined> {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
     assert(workspaceFolder);
 
     const statsCommand = spawn({
-      modulePath,
+      modulePath: await this.cliPath(),
       args: [
         'stats',
         '--appmap-file',

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -94,7 +94,7 @@ export default class AppMapEditorProvider
   private static readonly RELEASE_KEY = 'APPMAP_RELEASE_KEY';
   public static readonly APPMAP_OPENED = 'APPMAP_OPENED';
   public static readonly SEQ_DIAGRAM_FEEDBACK_REQUESTED = 'SEQ_DIAGRAM_FEEDBACK_REQUESTED';
-  private static readonly LARGE_APPMAP_SIZE = 20 * 1000 * 1000; // 20 MB
+  private static readonly LARGE_APPMAP_SIZE = 10 * 1000 * 1000; // 10 MB
   private static readonly GIANT_APPMAP_SIZE = 200 * 1000 * 1000; // 200 MB
   private static readonly analysisManager = AnalysisManager;
   private static readonly openWebviewPanels = new Map<string, vscode.WebviewPanel>();
@@ -117,7 +117,7 @@ export default class AppMapEditorProvider
 
     let data = (await vscode.workspace.fs.readFile(uri)).toString();
 
-    // If the map is Large, automatically prune it to ~ 20 MB
+    // If the map is Large, automatically prune it to ~ 10 MB
     if (appmapFileSize > AppMapEditorProvider.LARGE_APPMAP_SIZE) {
       const prunedData = await this.pruneMap(uri);
       if (prunedData) data = prunedData;
@@ -150,7 +150,7 @@ export default class AppMapEditorProvider
 
     const pruneCommand = spawn({
       modulePath,
-      args: ['prune', uri.fsPath, '--size', '20mb', '--output-data', '--auto'],
+      args: ['prune', uri.fsPath, '--size', '10mb', '--output-data', '--auto'],
       saveOutput: true,
     });
 

--- a/src/telemetry/definitions/errorCodes.ts
+++ b/src/telemetry/definitions/errorCodes.ts
@@ -11,6 +11,7 @@ enum ErrorCode {
   ExportSvgError,
   SeqDiagramFeedbackCtaError,
   GenerateMapStatsError,
+  PruneLargeMapError,
 }
 
 export default ErrorCode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,14 +47,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/appmap@npm:^3.66.1":
-  version: 3.66.1
-  resolution: "@appland/appmap@npm:3.66.1"
+"@appland/appmap@npm:^3.75.0":
+  version: 3.75.0
+  resolution: "@appland/appmap@npm:3.75.0"
   dependencies:
     "@appland/client": ^1
     "@appland/components": ^2
     "@appland/diagrams": ^1
-    "@appland/models": ^2.2.0
+    "@appland/models": ^2.4.2
     "@appland/openapi": ^1.4.3
     "@appland/sequence-diagram": ^1
     "@sidvind/better-ajv-errors": ^0.9.1
@@ -68,12 +68,13 @@ __metadata:
     chalk: ^4.1.2
     chokidar: ^3.5.1
     cli-progress: ^3.9.0
-    conf: ^10.0.2
+    conf: <11
     console-table-printer: ^2.9.0
     crypto-js: ^4.0.0
     detect-indent: ^6.1.0
     diff: ^5.1.0
     fs-extra: ^10.1.0
+    gitconfiglocal: ^2.1.0
     glob: ^7.2.3
     graceful-fs: ^4.2.10
     inquirer: ^8.1.2
@@ -87,6 +88,7 @@ __metadata:
     port-pid: ^0.0.7
     pretty-bytes: ^5.6.0
     ps-node: ^0.1.6
+    puppeteer: ^19.7.5
     read-pkg-up: ^7.0.1
     semver: ^7.3.5
     strip-ansi: ^6.0.0
@@ -94,9 +96,12 @@ __metadata:
     validator: ^13.7.0
     w3c-xmlserializer: ^2.0.0
     yargs: ^17.1.1
+  dependenciesMeta:
+    puppeteer:
+      optional: true
   bin:
     appmap: built/cli.js
-  checksum: 5a54020c16e506f434cf0376c5b061b2355ad2b4837c94d1bfa09233d5a7cf87c0c0997c9d925c7a1eb9e6ffac54bbdc2b803eda0641b17003663788bafb6bcf
+  checksum: 2e12f77ee776d350a2fd34a916b081ca8a0fdd35a98f9ff47f03f7fa5426802da6989bcadbc051a9c8eb882a4c7a7c1319db1f79d2a669ee45db8762f1255dd0
   languageName: node
   linkType: hard
 
@@ -124,7 +129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^2, @appland/components@npm:^2.34.0":
+"@appland/components@npm:^2":
   version: 2.34.0
   resolution: "@appland/components@npm:2.34.0"
   dependencies:
@@ -139,6 +144,24 @@ __metadata:
     vue: ^2.7.14
     vuex: ^3.6.0
   checksum: 53b780f891cd103c08930e53cade58762666eeef4fddf677300f9b803b06e7cd463ccbfa7e4a8577ab59730e24591f807b8306baf2c48157bc035701d57cceea
+  languageName: node
+  linkType: hard
+
+"@appland/components@npm:^2.36.0":
+  version: 2.36.0
+  resolution: "@appland/components@npm:2.36.0"
+  dependencies:
+    "@appland/diagrams": ^1.6.2
+    "@appland/models": ^2.4.2
+    "@appland/sequence-diagram": ^1.5.0
+    buffer: ^6.0.3
+    diff: ^5.1.0
+    dom-to-svg: ^0.12.2
+    highlight.js: ^10.7.2
+    sql-formatter: ^4.0.2
+    vue: ^2.7.14
+    vuex: ^3.6.0
+  checksum: af3f1b8865ce45b8795e5d03d8735927ab887b2d05217f62af0f4024c1203ef36fcb57ca75e7ac27bba5071b36a2a0c5c20d860f1a9b1263f90c1f4c1f0ce350
   languageName: node
   linkType: hard
 
@@ -177,13 +200,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/models@npm:^2.2.0, @appland/models@npm:^2.4.0, @appland/models@npm:^2.4.1":
+"@appland/models@npm:^2.2.0, @appland/models@npm:^2.4.0":
   version: 2.4.1
   resolution: "@appland/models@npm:2.4.1"
   dependencies:
     "@appland/sql-parser": ^1.5.0
     crypto-js: ^4.0.0
   checksum: 0b412801d66f7f839b0d5ec13153925221657804e7bcac0ab78a9aa279d7056200857aedd7f22e626f19e733e290a4251a857cc34bb5d7af4a09aa9e1d401e66
+  languageName: node
+  linkType: hard
+
+"@appland/models@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "@appland/models@npm:2.4.2"
+  dependencies:
+    "@appland/sql-parser": ^1.5.0
+    crypto-js: ^4.0.0
+  checksum: 2da3c2c665edffd7ea7f5492e34e0b00939a31485d50dd28c659bfa6b82a13b904901e7ad794e9775e493b41aa76e6a2ab8aa881a7120a51a3829dd9bd17bafd
   languageName: node
   linkType: hard
 
@@ -1105,6 +1138,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@puppeteer/browsers@npm:0.3.1":
+  version: 0.3.1
+  resolution: "@puppeteer/browsers@npm:0.3.1"
+  dependencies:
+    debug: 4.3.4
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.1
+    progress: 2.0.3
+    proxy-from-env: 1.1.0
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    yargs: 17.7.1
+  peerDependencies:
+    typescript: ">= 4.7.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    browsers: lib/cjs/main-cli.js
+  checksum: cd080ccf36653ea29566a0754f1365e4bc6a08488b3bc9ddfee38ddedab6fa2511e67c9ac7770f81201a5616b5a0c05731deac1ca4021f463dddbad9a726eba9
+  languageName: node
+  linkType: hard
+
 "@semantic-release/changelog@npm:^5.0.1":
   version: 5.0.1
   resolution: "@semantic-release/changelog@npm:5.0.1"
@@ -1569,6 +1625,15 @@ __metadata:
   version: 1.59.0
   resolution: "@types/vscode@npm:1.59.0"
   checksum: da849f793cce43dd5521b420d1b6becb8e2101a82681f051cf97fb5625ec5b7e5db283f8428a030c63c1a233da18d86c1a7c2f2a703f2fec362eedaa00e91e04
+  languageName: node
+  linkType: hard
+
+"@types/yauzl@npm:^2.9.1":
+  version: 2.10.0
+  resolution: "@types/yauzl@npm:2.10.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: 55d27ae5d346ea260e40121675c24e112ef0247649073848e5d4e03182713ae4ec8142b98f61a1c6cbe7d3b72fa99bbadb65d8b01873e5e605cdc30f1ff70ef2
   languageName: node
   linkType: hard
 
@@ -2190,11 +2255,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "appmap@workspace:."
   dependencies:
-    "@appland/appmap": ^3.66.1
+    "@appland/appmap": ^3.75.0
     "@appland/client": ^1.6.0
-    "@appland/components": ^2.34.0
+    "@appland/components": ^2.36.0
     "@appland/diagrams": ^1.6.3
-    "@appland/models": ^2.4.1
+    "@appland/models": ^2.4.2
     "@appland/scanner": ^1.76.6
     "@appland/sequence-diagram": ^1.5.0
     "@playwright/test": ^1.22.2
@@ -2896,7 +2961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0":
+"buffer@npm:^5.2.1, buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -3252,6 +3317,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromium-bidi@npm:0.4.6":
+  version: 0.4.6
+  resolution: "chromium-bidi@npm:0.4.6"
+  dependencies:
+    mitt: 3.0.0
+  peerDependencies:
+    devtools-protocol: "*"
+  checksum: 1d6365896bca4592ddd95233a784e4743d2c8c692d065327a416a09acddc3d05e300c360b859d7049f91924be326d801e6fe9860ace4541325b25f4ec6b94b97
+  languageName: node
+  linkType: hard
+
 "cidr-regex@npm:^3.1.1":
   version: 3.1.1
   resolution: "cidr-regex@npm:3.1.1"
@@ -3369,6 +3445,17 @@ __metadata:
     strip-ansi: ^6.0.0
     wrap-ansi: ^7.0.0
   checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
   languageName: node
   linkType: hard
 
@@ -3572,6 +3659,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"conf@npm:<11":
+  version: 10.2.0
+  resolution: "conf@npm:10.2.0"
+  dependencies:
+    ajv: ^8.6.3
+    ajv-formats: ^2.1.1
+    atomically: ^1.7.0
+    debounce-fn: ^4.0.0
+    dot-prop: ^6.0.1
+    env-paths: ^2.2.1
+    json-schema-typed: ^7.0.3
+    onetime: ^5.1.2
+    pkg-up: ^3.1.0
+    semver: ^7.3.5
+  checksum: 27066f38a25411c1e72e81a5219e2c7ed675cd39d8aa2a2f1797bb2c9255725e92e335d639334177a23d488b22b1290bbe0708e9a005574e5d83d5432df72bd3
+  languageName: node
+  linkType: hard
+
 "conf@npm:^10.0.2":
   version: 10.1.2
   resolution: "conf@npm:10.1.2"
@@ -3708,6 +3813,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:8.1.3":
+  version: 8.1.3
+  resolution: "cosmiconfig@npm:8.1.3"
+  dependencies:
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+  checksum: b3d277bc3a8a9e649bf4c3fc9740f4c52bf07387481302aa79839f595045368903bf26ea24a8f7f7b8b180bf46037b027c5cb63b1391ab099f3f78814a147b2b
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^7.0.0":
   version: 7.0.0
   resolution: "cosmiconfig@npm:7.0.0"
@@ -3762,6 +3879,15 @@ __metadata:
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
   checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
+"cross-fetch@npm:3.1.5":
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
+  dependencies:
+    node-fetch: 2.6.7
+  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
   languageName: node
   linkType: hard
 
@@ -4046,6 +4172,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:4.3.4, debug@npm:^4.3.1, debug@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  languageName: node
+  linkType: hard
+
 "debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -4061,18 +4199,6 @@ __metadata:
   dependencies:
     ms: ^2.1.1
   checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.3.1, debug@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
-  dependencies:
-    ms: 2.1.2
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -4307,6 +4433,13 @@ __metadata:
   version: 2.0.1
   resolution: "detect-libc@npm:2.0.1"
   checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
+  languageName: node
+  linkType: hard
+
+"devtools-protocol@npm:0.0.1107588":
+  version: 0.0.1107588
+  resolution: "devtools-protocol@npm:0.0.1107588"
+  checksum: 9064fd643f39ae0adabb8f425b746899ff24371d89a5047d38752653259e6afcb6bcb2d9759ff727eb5885cfc0f9ba8eb384850a2af00694135622e88080e3e5
   languageName: node
   linkType: hard
 
@@ -5193,6 +5326,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extract-zip@npm:2.0.1":
+  version: 2.0.1
+  resolution: "extract-zip@npm:2.0.1"
+  dependencies:
+    "@types/yauzl": ^2.9.1
+    debug: ^4.1.1
+    get-stream: ^5.1.0
+    yauzl: ^2.10.0
+  dependenciesMeta:
+    "@types/yauzl":
+      optional: true
+  bin:
+    extract-zip: cli.js
+  checksum: 8cbda9debdd6d6980819cc69734d874ddd71051c9fe5bde1ef307ebcedfe949ba57b004894b585f758b7c9eeeea0e3d87f2dda89b7d25320459c2c9643ebb635
+  languageName: node
+  linkType: hard
+
 "extsprintf@npm:1.3.0":
   version: 1.3.0
   resolution: "extsprintf@npm:1.3.0"
@@ -5666,7 +5816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0":
+"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -5702,6 +5852,15 @@ __metadata:
     through2: ~2.0.0
     traverse: ~0.6.6
   checksum: 57294e72f91920d3262ff51fb0fd81dba1465c9e1b25961e19c757ae39bb38e72dd4a5da40649eeb368673b08be449a0844a2bafc0c0ded7375a8a56a6af8640
+  languageName: node
+  linkType: hard
+
+"gitconfiglocal@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "gitconfiglocal@npm:2.1.0"
+  dependencies:
+    ini: ^1.3.2
+  checksum: 4b4b44d992a6abf2900eec8cfe960dc36e0d3c2467d20ec69e0a0f13b6b7645b926daa004df42f94c34ad28a58529cf2522fa0bf261e4e7b95958fb451dcedda
   languageName: node
   linkType: hard
 
@@ -6092,6 +6251,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"https-proxy-agent@npm:5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: 6
+    debug: 4
+  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
+  languageName: node
+  linkType: hard
+
 "https-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "https-proxy-agent@npm:5.0.0"
@@ -6265,17 +6434,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ini@npm:^1.3.2, ini@npm:~1.3.0":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
+  languageName: node
+  linkType: hard
+
 "ini@npm:^2.0.0":
   version: 2.0.0
   resolution: "ini@npm:2.0.0"
   checksum: e7aadc5fb2e4aefc666d74ee2160c073995a4061556b1b5b4241ecb19ad609243b9cceafe91bae49c219519394bbd31512516cb22a3b1ca6e66d869e0447e84e
-  languageName: node
-  linkType: hard
-
-"ini@npm:~1.3.0":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
   languageName: node
   linkType: hard
 
@@ -8000,6 +8169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitt@npm:3.0.0":
+  version: 3.0.0
+  resolution: "mitt@npm:3.0.0"
+  checksum: f7be5049d27d18b1dbe9408452d66376fa60ae4a79fe9319869d1b90ae8cbaedadc7e9dab30b32d781411256d468be5538996bb7368941c09009ef6bbfa6bfc7
+  languageName: node
+  linkType: hard
+
 "mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
@@ -8278,17 +8454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^1.6.3":
-  version: 1.7.3
-  resolution: "node-fetch@npm:1.7.3"
-  dependencies:
-    encoding: ^0.1.11
-    is-stream: ^1.0.1
-  checksum: 3bb0528c05d541316ebe52770d71ee25a6dce334df4231fd55df41a644143e07f068637488c18a5b0c43f05041dbd3346752f9e19b50df50569a802484544d5b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.0.0, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.0.0, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -8299,6 +8465,16 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^1.6.3":
+  version: 1.7.3
+  resolution: "node-fetch@npm:1.7.3"
+  dependencies:
+    encoding: ^0.1.11
+    is-stream: ^1.0.1
+  checksum: 3bb0528c05d541316ebe52770d71ee25a6dce334df4231fd55df41a644143e07f068637488c18a5b0c43f05041dbd3346752f9e19b50df50569a802484544d5b
   languageName: node
   linkType: hard
 
@@ -9618,7 +9794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0, progress@npm:^2.0.3":
+"progress@npm:2.0.3, progress@npm:^2.0.0, progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
@@ -9682,6 +9858,13 @@ __metadata:
     retry: ^0.12.0
     signal-exit: ^3.0.2
   checksum: 00078ee6a61c216a56a6140c7d2a98c6c733b3678503002dc073ab8beca5d50ca271de4c85fca13b9b8ee2ff546c36674d1850509b84a04a5d0363bcb8638939
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 
@@ -9757,6 +9940,43 @@ __metadata:
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+  languageName: node
+  linkType: hard
+
+"puppeteer-core@npm:19.8.1":
+  version: 19.8.1
+  resolution: "puppeteer-core@npm:19.8.1"
+  dependencies:
+    chromium-bidi: 0.4.6
+    cross-fetch: 3.1.5
+    debug: 4.3.4
+    devtools-protocol: 0.0.1107588
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.1
+    proxy-from-env: 1.1.0
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    ws: 8.13.0
+  peerDependencies:
+    typescript: ">= 4.7.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 83575735c35b2d7bc2e657c1ab5aa5e290b5bf4820163896d472d8eed49e11e0f0a9f7e218d7b673432b7d5fdbadda0e3fe2ffc163f744885c31265c05e1915a
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:^19.7.5":
+  version: 19.8.2
+  resolution: "puppeteer@npm:19.8.2"
+  dependencies:
+    "@puppeteer/browsers": 0.3.1
+    cosmiconfig: 8.1.3
+    https-proxy-agent: 5.0.1
+    progress: 2.0.3
+    proxy-from-env: 1.1.0
+    puppeteer-core: 19.8.1
+  checksum: db2c832b5b92acc656ba3fb0702277a3606a9eb7c43a30dde57e71ea623af14919a52b726323bff44578d36d41ade397009533a1c538c459e9fde96c3e473d53
   languageName: node
   linkType: hard
 
@@ -11234,7 +11454,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
+"tar-fs@npm:2.1.1, tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
   dependencies:
@@ -11831,6 +12051,16 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"unbzip2-stream@npm:1.4.3":
+  version: 1.4.3
+  resolution: "unbzip2-stream@npm:1.4.3"
+  dependencies:
+    buffer: ^5.2.1
+    through: ^2.3.8
+  checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
+  languageName: node
+  linkType: hard
+
 "underscore@npm:^1.12.1":
   version: 1.13.1
   resolution: "underscore@npm:1.13.1"
@@ -12387,6 +12617,21 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"ws@npm:8.13.0":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
+  languageName: node
+  linkType: hard
+
 "ws@npm:^7.4.6":
   version: 7.5.7
   resolution: "ws@npm:7.5.7"
@@ -12522,6 +12767,13 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
 "yargs-unparser@npm:2.0.0":
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
@@ -12549,6 +12801,21 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"yargs@npm:17.7.1":
+  version: 17.7.1
+  resolution: "yargs@npm:17.7.1"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^17.1.1":
   version: 17.4.1
   resolution: "yargs@npm:17.4.1"
@@ -12564,7 +12831,7 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.3.1":
+"yauzl@npm:^2.10.0, yauzl@npm:^2.3.1":
   version: 2.10.0
   resolution: "yauzl@npm:2.10.0"
   dependencies:


### PR DESCRIPTION
Fixes #651

- [x] When opening an appmap > 10 MB, the extension will automatically prune the map down to 10 MB in memory, and then display the pruned map with notifications.

![image](https://user-images.githubusercontent.com/45714532/228660408-22c0c232-aa61-4e04-8151-7d1bb7cf8ca7.png)

- [x] When opening an appmap > 200 MB, the extension will generate stats about the map, and then display an empty map opened to the Stats panel with notifications.

![image](https://user-images.githubusercontent.com/45714532/228660792-721247bd-277e-46a3-a7ce-3d131c33b4d9.png)