### PR TITLE
feat: appmap_dir wip

### DIFF
--- a/src/commands/deleteAllAppMaps.ts
+++ b/src/commands/deleteAllAppMaps.ts
@@ -2,15 +2,34 @@ import * as vscode from 'vscode';
 import deleteAppMaps from '../lib/deleteAppMaps';
 import AnalysisManager from '../services/analysisManager';
 import ClassMapIndex from '../services/classMapIndex';
+import { AppmapConfigManager, AppmapConfigManagerInstance } from '../services/appmapConfigManager';
+import { workspaceServices } from '../services/workspaceServices';
+import assert from 'assert';
 
 export default function deleteAllAppMaps(
   context: vscode.ExtensionContext,
   classMapIndex?: ClassMapIndex
 ): void {
+  async function deleteWorkspaceAppMaps(folder: vscode.WorkspaceFolder) {
+    const appmapConfigManagerInstance = workspaceServices().getServiceInstanceFromClass(
+      AppmapConfigManager,
+      folder
+    ) as AppmapConfigManagerInstance | undefined;
+    assert(appmapConfigManagerInstance);
+
+    const appmapDir = (await appmapConfigManagerInstance.getAppmapConfig())?.appmapDir;
+    if (!appmapDir) {
+      console.warn(`No appmapDir for ${folder.uri}`);
+      return;
+    }
+
+    deleteAppMaps(appmapDir);
+  }
+
   context.subscriptions.push(
     vscode.commands.registerCommand('appmap.deleteAllAppMaps', async () => {
       await Promise.all(
-        (vscode.workspace.workspaceFolders || []).map((folder) => deleteAppMaps(folder.uri.fsPath))
+        (vscode.workspace.workspaceFolders || []).map((folder) => deleteWorkspaceAppMaps(folder))
       );
 
       const { findingsIndex } = AnalysisManager;

--- a/src/lib/deleteAppMaps.ts
+++ b/src/lib/deleteAppMaps.ts
@@ -1,10 +1,13 @@
 import * as vscode from 'vscode';
 import deleteAppMap from './deleteAppMap';
+import { promisify } from 'util';
+import { glob } from 'glob';
 
 export default async function deleteAppMaps(path: string): Promise<number> {
-  const appmapFiles = await vscode.workspace.findFiles(
-    new vscode.RelativePattern(vscode.Uri.file(path), '**/*.appmap.json'),
-    `**/node_modules/**`
+  // Use glob instead of the vscode find facility to bypass the find exclusion rules
+  // that might hide the AppMaps we are looking for.
+  const appmapFiles = (await promisify(glob)(`${path}/**/*.appmap.json`)).map((path) =>
+    vscode.Uri.file(path)
   );
 
   await Promise.all(appmapFiles.map(deleteAppMap.bind(null)));

--- a/src/lib/sequenceDiagram.ts
+++ b/src/lib/sequenceDiagram.ts
@@ -101,12 +101,12 @@ export async function promptForAppMap(
           if (projectFolder) {
             path = path.slice(projectFolder.uri.fsPath.length + 1);
 
-            const appmapConfigMangerInstance = workspaceServices().getServiceInstanceFromClass(
+            const appmapConfigManagerInstance = workspaceServices().getServiceInstanceFromClass(
               AppmapConfigManager,
               projectFolder
             ) as AppmapConfigManagerInstance | undefined;
-            assert(appmapConfigMangerInstance);
-            const detectedAppMapDir = (await appmapConfigMangerInstance.getAppmapConfig())
+            assert(appmapConfigManagerInstance);
+            const detectedAppMapDir = (await appmapConfigManagerInstance.getAppmapConfig())
               ?.appmapDir;
 
             if (detectedAppMapDir && path.startsWith(detectedAppMapDir)) {


### PR DESCRIPTION
WIP - Respect `appmap_dir` when looking for all kinds of appmap artifacts (appmaps, classMap.json, findings, etc).

With this in place, we can unpack AppMap archives in the project to e.g. `.appmap`, without having all those AppMaps get picked up and populate the AppMaps list, code objects view, etc.