### PR TITLE
fix: Use a stable node bin path when running the install CLI

### DIFF
--- a/src/commands/installAgent.ts
+++ b/src/commands/installAgent.ts
@@ -89,7 +89,9 @@ function escapePath(str: string): string {
 }
 
 function electronCommand(globalStorageDir: string, installLocation: string): string {
-  const nodePath = escapePath(process.argv0);
+  // `child_process.fork` uses `process.execPath` from the parent process to spawn a new process.
+  // This is the exact behavior we want to emulate in the terminal, so we'll use it here as well.
+  const nodePath = escapePath(process.execPath);
   const cliPath = join(globalStorageDir, 'node_modules', '@appland', 'appmap', 'built', 'cli.js');
   const flags = ['--ms-enable-electron-run-as-node', '-d', installLocation];
   return `ELECTRON_RUN_AS_NODE=true ${nodePath} ${cliPath} install ${flags.join(' ')}`;

--- a/test/integration/command/installAgent.test.ts
+++ b/test/integration/command/installAgent.test.ts
@@ -140,6 +140,8 @@ describe('generateInstallInfo function', () => {
     });
 
     describe('with a space in the path', () => {
+      const expectedBin = 'code';
+
       before(() => {
         cwd = '/home/user/projects/directory with spaces';
         globalStorageDir = '/home/user/.config/Code/user folder/globalStorage';
@@ -163,6 +165,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, { ELECTRON_RUN_AS_NODE: 'true' });
         assert(command.startsWith(expectedStart));
         assert(command.includes(expectedEnd));
+        assert(command.includes(expectedBin));
 
         const pythonCommand = generateInstallInfo(cwd, 'Python', false, globalStorageDir);
         command = pythonCommand.command;
@@ -170,6 +173,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, { ELECTRON_RUN_AS_NODE: 'true' });
         assert(command.startsWith(expectedStart));
         assert(command.includes(expectedEnd));
+        assert(command.includes(expectedBin));
       });
     });
 


### PR DESCRIPTION
`process.argv0` could sometimes point towards an incorrect binary path
`process.execPath` should be more accurate, and it's now testing for presence of `code` in the command