### PR TITLE
Remove broken docs links

### DIFF
--- a/src/tree/links.ts
+++ b/src/tree/links.ts
@@ -12,13 +12,13 @@ export default {
       label: 'How to use AppMap diagrams',
       link: 'https://appmap.io/docs/how-to-use-appmap-diagrams',
     },
+    DOC_SEQUENCE_DIAGRAMS: {
+      label: 'Sequence diagrams',
+      link: 'https://appmap.io/docs/diagrams/sequence-diagrams.html',
+    },
     DOC_REFERENCE: {
       label: 'Reference',
       link: 'https://appmap.io/docs/reference',
-    },
-    DOC_TROUBLESHOOTING: {
-      label: 'Troubleshooting',
-      link: 'https://appmap.io/docs/troubleshooting',
     },
     DOC_RECORDING_METHODS: {
       label: 'Recording methods',
@@ -27,10 +27,6 @@ export default {
     DOC_COMMUNITY: {
       label: 'Community',
       link: 'https://appmap.io/docs/community',
-    },
-    DOC_FAQ: {
-      label: 'FAQ',
-      link: 'https://appmap.io/docs/faq',
     },
   },
 };


### PR DESCRIPTION
Fixes #686 

The `Troubleshooting` and `FAQ` links are currently broken, so I removed them. We've seen lots of interest in sequence diagrams, so I added a link for that.

Before:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/a265b0f3-2789-4f45-b767-732fabf65754)

After:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/a37cdc9d-9ab7-4776-980c-762cb21b06f9)
