### PR TITLE
Add installability details to telemetry

### DIFF
--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -18,6 +18,8 @@ export const PROJECT_OPEN = new Event({
     Properties.SCANNER_CONFIG_PRESENT,
     Properties.PROJECT_LANGUAGE,
     Properties.PROJECT_LANGUAGE_DISTRIBUTION,
+    Properties.WEB_FRAMEWORK,
+    Properties.TEST_FRAMEWORK,
     Properties.IS_INSTALLABLE,
     Properties.HAS_DEVCONTAINER,
     Properties.DEPENDENCIES,

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -153,6 +153,20 @@ export const PROJECT_LANGUAGE = new TelemetryDataProvider({
   },
 });
 
+export const WEB_FRAMEWORK = new TelemetryDataProvider({
+  id: 'appmap.project.web_framework',
+  async value({ project }: { project: ProjectMetadata }) {
+    return project?.webFramework?.name;
+  },
+});
+
+export const TEST_FRAMEWORK = new TelemetryDataProvider({
+  id: 'appmap.project.test_framework',
+  async value({ project }: { project: ProjectMetadata }) {
+    return project?.testFramework?.name;
+  },
+});
+
 export const PROJECT_LANGUAGE_DISTRIBUTION = new TelemetryDataProvider({
   id: 'appmap.project.language_distribution',
   cache: true,


### PR DESCRIPTION
Fixes #689 

Adds information about why a project is or is not installable. Specifically, it adds details about how we judge web and test frameworks for a project.