### PR TITLE
fix: Look for appmaps in subprojects

### DIFF
--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -44,7 +44,7 @@ export default class Watcher {
 
   get watchPatterns(): vscode.RelativePattern[] {
     return ['tmp/appmap', 'build/appmap', 'target/appmap'].map((dir) => {
-      return new vscode.RelativePattern(this.folder, `${dir}/**/${this.filePattern}`);
+      return new vscode.RelativePattern(this.folder, `**/${dir}/**/${this.filePattern}`);
     });
   }
 }


### PR DESCRIPTION
A recent change limited places in which VSCode looks for AppMaps to hardcoded `/{tmp,target,build}/appmap`. This caused it to no longer pick up AppMaps in subprojects of a monorepo.

Now it looks for those directories in the full tree.