### PR TITLE
feat: Propagate VS Code identity to CLI

### DIFF
--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -96,7 +96,12 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
 
     const env =
       Environment.isSystemTest || Environment.isIntegrationTest
-        ? { ...process.env, APPMAP_WRITE_PIDFILE: 'true' }
+        ? {
+            ...process.env,
+            APPMAP_WRITE_PIDFILE: 'true',
+            APPMAP_USER_ID: vscode.env.machineId,
+            APPMAP_SESSION_ID: vscode.env.sessionId,
+          }
         : undefined;
 
     const tryModulePath = async (program: ProgramName): Promise<string | undefined> => {

--- a/test/integration/nodeProcesses/backgroundProcess.test.ts
+++ b/test/integration/nodeProcesses/backgroundProcess.test.ts
@@ -104,6 +104,17 @@ describe('Background processes', () => {
           assert(cmd.includes('--appmap-dir tmp/appmap'));
         });
     });
+
+    it('inherits identity from the extension host', async () => {
+      await waitForUp();
+      const processes = await getBackgroundProcesses();
+      Object.values(processes)
+        .map((p) => p.options.env)
+        .forEach((env) => {
+          assert(env?.APPMAP_SESSION_ID === vscode.env.sessionId);
+          assert(env?.APPMAP_USER_ID === vscode.env.machineId);
+        });
+    });
   });
 
   context('with appmap_dir specified in appmap.yml', () => {


### PR DESCRIPTION
This change specifies user id / session id overrides in the environment of background processes to ensure a single thread of user activity.

As it turns out, we don't need to override VS Code's implementation of Session ID. It doesn't appear to ever renew within the lifetime of the window.