### PR TITLE
fix: Prefer web framework language

### DIFF
--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -17,9 +17,13 @@ const analyzers = {
   unknown: UnknownAnalyzer,
 };
 
-export type Score = 'bad' | 'ok' | 'good';
-export const SCORE_VALUES = { bad: 0, ok: 1, good: 2 };
-export const OVERALL_SCORE_VALUES = { bad: 1, ok: 2, good: 3 };
+export type Score = 'unsupported' | 'early-access' | 'ga';
+export const SCORE_VALUES: Record<Score, number> = { unsupported: 0, 'early-access': 1, ga: 2 };
+export const OVERALL_SCORE_VALUES: Record<Score, number> = {
+  unsupported: 1,
+  'early-access': 2,
+  ga: 3,
+};
 
 export function scoreValue(...scores: Score[]): number {
   return scores.reduce((s, x) => s + SCORE_VALUES[x], 0);
@@ -27,14 +31,8 @@ export function scoreValue(...scores: Score[]): number {
 
 export function overallScore(result: Features): number {
   const languageScore = result.lang.score;
-  const webFrameworkScore = result?.web?.score || 'bad';
-  const testFrameworkScore = result?.test?.score || 'bad';
 
-  // score edge cases
-  if (languageScore === 'bad') return OVERALL_SCORE_VALUES['bad'];
-  if (languageScore === 'ok' && (webFrameworkScore === 'ok' || testFrameworkScore === 'ok')) {
-    return OVERALL_SCORE_VALUES['ok'];
-  }
+  if (languageScore === 'unsupported') return OVERALL_SCORE_VALUES['unsupported'];
 
   // standard scoring
   return scoreValue(...Object.entries(result).map(([, t]) => t.score));

--- a/src/analyzers/java.ts
+++ b/src/analyzers/java.ts
@@ -6,8 +6,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
   const features: Features = {
     lang: {
       title: 'Java',
-      score: 'good',
-      text: "This project looks like Java. It's one of the languages supported by AppMap.",
+      score: 'ga',
+      text: "This project uses Java. It's one of the languages supported by AppMap.",
     },
   };
 
@@ -26,8 +26,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
     if (dependency('spring')) {
       features.web = {
         title: 'Spring',
-        score: 'good',
-        text: 'This project uses Spring. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.',
+        score: 'ga',
+        text: 'This project uses Spring. AppMap can record the HTTP requests served by your app.',
       };
     }
 
@@ -35,8 +35,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
       if (dependency(framework)) {
         features.test = {
           title: framework,
-          score: 'good',
-          text: `This project uses ${framework}. Test execution can be automatically recorded.`,
+          score: 'ga',
+          text: `This project uses ${framework}. AppMap can record your tests.`,
         };
         break;
       }
@@ -44,8 +44,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
   } catch (_) {
     features.lang = {
       title: 'Java',
-      score: 'ok',
-      text: `This project looks like Java. It's one of the languages supported by AppMap, but no supported dependency file was found.`,
+      score: 'early-access',
+      text: `This project uses Java. It's one of the languages supported by AppMap, but no supported dependency file was found.`,
     };
   }
 

--- a/src/analyzers/python.ts
+++ b/src/analyzers/python.ts
@@ -1,5 +1,5 @@
 import { RelativePattern, Uri, workspace, WorkspaceFolder } from 'vscode';
-import { ProjectAnalysis, overallScore, Features } from '.';
+import { ProjectAnalysis, Features, overallScore } from '.';
 import { fileWordScanner, DependencyFinder } from './deps';
 import utfDecoder from '../utfDecoder';
 const fs = workspace.fs;
@@ -35,8 +35,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
   const features: Features = {
     lang: {
       title: 'Python',
-      score: 'ok',
-      text: `Python is currently in Open Beta and is not fully supported. Please read the docs before proceeding.`,
+      score: 'ga',
+      text: `This project uses Python. It's one of the languages supported by AppMap.`,
     },
   };
 
@@ -50,41 +50,32 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
     if (dependency('django')) {
       features.web = {
         title: 'Django',
-        score: 'ok',
-        text: 'This project uses Django. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.',
+        score: 'ga',
+        text: 'This project uses Django. AppMap can record the HTTP requests served by your app.',
       };
     } else if (dependency('flask')) {
       features.web = {
         title: 'flask',
-        score: 'ok',
-        text: 'Flask support is currently in Beta. Please read the docs.',
+        score: 'ga',
+        text: 'This project uses Flask. AppMap can record the HTTP requests served by your app.',
       };
     }
 
     if (dependency('pytest')) {
       features.test = {
-        score: 'ok',
         title: 'pytest',
-        text: 'This project uses pytest. Test execution can be automatically recorded.',
+        score: 'ga',
+        text: 'This project uses pytest. AppMap can record your  tests.',
       };
     } else if (await grepFiles('unittest', folder)) {
       features.test = {
-        score: 'ok',
+        score: 'ga',
         title: 'unittest',
-        text: 'This project uses unittest. Test execution can be automatically recorded.',
-      };
-    } else {
-      features.test = {
-        score: 'bad',
-        text: "This project doesn't seem to use a supported test framework. Automatic test recording won't be possible.",
+        text: 'This project uses unittest. AppMap can record your tests.',
       };
     }
-  } catch (_) {
-    features.lang = {
-      title: 'Python',
-      score: 'ok',
-      text: `This looks like a Python project without a package manager. Python is currently in Open Beta and is not fully supported. Please read the docs before proceeding.`,
-    };
+  } catch (e) {
+    console.warn(e);
   }
 
   return {

--- a/src/analyzers/ruby.ts
+++ b/src/analyzers/ruby.ts
@@ -8,8 +8,8 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
   const features: Features = {
     lang: {
       title: 'Ruby',
-      score: 'good',
-      text: "This project looks like Ruby. It's one of the languages supported by AppMap.",
+      score: 'ga',
+      text: "This project uses Ruby. It's one of the languages supported by AppMap.",
     },
   };
 
@@ -19,27 +19,23 @@ export default async function analyze(folder: WorkspaceFolder): Promise<ProjectA
     if (dependency('rails')) {
       features.web = {
         title: 'Rails',
-        score: 'good',
-        text: 'This project uses Rails. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.',
+        score: 'ga',
+        text: 'This project uses Rails. AppMap can record the HTTP requests served by your app.',
       };
     }
 
-    for (const framework of ['minitest', 'rspec', 'cucumber']) {
+    for (const framework of ['minitest', 'rspec']) {
       if (dependency(framework)) {
         features.test = {
           title: framework,
-          score: 'good',
-          text: `This project uses ${framework}. Test execution can be automatically recorded.`,
+          score: 'ga',
+          text: `This project uses ${framework}. AppMap can record your tests.`,
         };
         break;
       }
     }
-  } catch (_) {
-    features.lang = {
-      title: 'Ruby',
-      score: 'ok',
-      text: `This project looks like Ruby. It's one of the languages supported by AppMap, but no Gemfile was detected.`,
-    };
+  } catch (e) {
+    console.warn(e);
   }
 
   return {

--- a/src/analyzers/unknown.ts
+++ b/src/analyzers/unknown.ts
@@ -5,8 +5,8 @@ export default function analyze(folder: WorkspaceFolder): ProjectAnalysis {
   return {
     features: {
       lang: {
-        score: 'bad',
-        text: `This project looks like it's written in a language not currently supported by AppMap.`,
+        score: 'unsupported',
+        text: `AppMap works with Ruby, Java, Python and JavaScript. None of those languages were detected in this project.`,
       },
     },
     name: folder.name,

--- a/src/services/appmapUptodateService.ts
+++ b/src/services/appmapUptodateService.ts
@@ -109,7 +109,7 @@ export default class AppmapUptodateServiceInstance
       processLog
         .filter((line) => line.stream === OutputStream.Stdout)
         .map((line) => line.data)
-        .join('\n')
+        .join('')
         .split('\n')
         .map((line) => line.trim())
         .filter((line) => line.length > 0)

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -146,22 +146,9 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
     return this._metadata as Readonly<ProjectMetadata>;
   }
 
-  // Returns true if the project is installable and the agent has yet to be configured or
-  // AppMaps have yet to be recorded
+  // Returns true if the project is installable and the agent has yet to be configured.
   get installable(): boolean {
-    return (
-      this.metadata.score !== undefined &&
-      this.metadata.score >= 2 &&
-      !(this.isAgentConfigured && this.hasRecordedAppMaps && this.metadata.analysisPerformed)
-    );
-  }
-
-  get supported(): boolean {
-    return (
-      (this.metadata.language?.score || 0) >= SCORE_VALUES.good &&
-      ((this.metadata.webFramework?.score || 0) >= SCORE_VALUES.ok ||
-        (this.metadata.testFramework?.score || 0) >= SCORE_VALUES.ok)
-    );
+    return this.metadata.score !== undefined && this.metadata.score >= 2 && !this.isAgentConfigured;
   }
 
   get complete(): boolean {

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -6,7 +6,7 @@ import TelemetryDataProvider from '../telemetryDataProvider';
 import LanguageResolver, { UNKNOWN_LANGUAGE } from '../../services/languageResolver';
 import { fileExists, getRecords } from '../../util';
 import ErrorCode from './errorCodes';
-import ProjectMetadata from '../../workspace/projectMetadata';
+import ProjectMetadata, { isLanguageSupported } from '../../workspace/projectMetadata';
 import { TerminalConfig } from '../../commands/installAgent';
 import * as vscode from 'vscode';
 import { Finding } from '@appland/scanner';
@@ -137,6 +137,7 @@ export const PROJECT_LANGUAGE = new TelemetryDataProvider({
   cache: true,
   async value(data: { rootDirectory?: string; metadata?: Record<string, unknown> }) {
     // If metadata is available, use the language property.
+    // TODO: what is this record string,unknown?
     if (data.metadata) {
       const language = data.metadata.language as Record<string, string> | undefined;
       if (language?.name) {
@@ -149,7 +150,7 @@ export const PROJECT_LANGUAGE = new TelemetryDataProvider({
       return UNKNOWN_LANGUAGE;
     }
 
-    return (await LanguageResolver.getLanguage(data.rootDirectory)) || UNKNOWN_LANGUAGE;
+    return (await LanguageResolver.getLanguages(data.rootDirectory)) || UNKNOWN_LANGUAGE;
   },
 });
 
@@ -214,15 +215,14 @@ export const IS_TELEMETRY_ENABLED = new TelemetryDataProvider({
 export const IS_INSTALLABLE = new TelemetryDataProvider({
   id: 'appmap.project.installable',
   async value({ project }: { project: ProjectMetadata }) {
-    const isInstallable = project?.score && project.score > 1;
-    return String(isInstallable);
+    return String(isLanguageSupported(project));
   },
 });
 
 export const HAS_INSTALLABLE_PROJECT = new TelemetryDataProvider({
   id: 'appmap.project.any_installable',
   async value({ projects }: { projects: ProjectMetadata[] }) {
-    const isInstallable = projects.some((project) => project?.score && project.score > 1);
+    const isInstallable = projects.some((project) => isLanguageSupported(project));
     return String(isInstallable);
   },
 });

--- a/src/tree/appMapTreeDataProvider.ts
+++ b/src/tree/appMapTreeDataProvider.ts
@@ -62,9 +62,11 @@ export class AppMapTreeDataProvider implements vscode.TreeDataProvider<AppMapTre
 
   public getTreeItem(element: AppMapTreeItem): vscode.TreeItem {
     if (isAppMapLoader(element)) {
-      const iconPath = this.uptodate(element)
-        ? new vscode.ThemeIcon('file')
-        : { light: darkChangedIcon, dark: lightChangedIcon };
+      let iconPath: vscode.ThemeIcon | { light: string; dark: string } = new vscode.ThemeIcon(
+        'file'
+      );
+      if (!this.isUptodate(element)) iconPath = { light: darkChangedIcon, dark: lightChangedIcon };
+      if (this.isFailed(element)) iconPath = new vscode.ThemeIcon('warning');
 
       const { descriptor } = element;
 
@@ -178,7 +180,11 @@ export class AppMapTreeDataProvider implements vscode.TreeDataProvider<AppMapTre
     return listItems;
   }
 
-  protected uptodate(appmap: AppMapLoader): boolean {
+  protected isFailed(appmap: AppMapLoader): boolean {
+    return appmap.descriptor.metadata?.test_status === 'failed';
+  }
+
+  protected isUptodate(appmap: AppMapLoader): boolean {
     if (!this.appmapsUpToDate) return true;
 
     return this.appmapsUpToDate.isUpToDate(appmap.descriptor.resourceUri);

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -79,18 +79,14 @@ export class FindingsTreeDataProvider
     };
     overviewTreeItem.iconPath = new vscode.ThemeIcon('preview');
 
-    return topLevelTreeLabels.reduce(
-      (treeItems, impactDomain) => {
-        const treeItem = new vscode.TreeItem(
-          impactDomain,
-          vscode.TreeItemCollapsibleState.Expanded
-        );
+    const topLevelTreeItems = [overviewTreeItem];
 
-        treeItems.push(treeItem);
-        return treeItems;
-      },
-      [overviewTreeItem]
-    );
+    return topLevelTreeLabels.reduce((treeItems, impactDomain) => {
+      const treeItem = new vscode.TreeItem(impactDomain, vscode.TreeItemCollapsibleState.Expanded);
+
+      treeItems.push(treeItem);
+      return treeItems;
+    }, topLevelTreeItems);
   }
 
   getChildrenForImpactDomain(impactDomain: string): vscode.TreeItem[] {

--- a/src/workspace/installationStatus.ts
+++ b/src/workspace/installationStatus.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
+import { isLanguageSupported } from './projectMetadata';
 
 export default class InstallationStatusBadge {
   protected watcher?: vscode.Disposable;
@@ -14,7 +15,7 @@ export default class InstallationStatusBadge {
 
     const installableProjects: ProjectStateServiceInstance[] = [];
     for (const projectState of projectStates) {
-      if (projectState.installable) {
+      if (isLanguageSupported(projectState.metadata)) {
         installableProjects.push(projectState);
       }
     }

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -1,4 +1,5 @@
 import { AppMapSummary } from '../analyzers';
+import { SUPPORTED_LANGUAGES } from '../services/languageResolver';
 import { SampleCodeObjects } from '../services/projectStateService';
 import { FindingsDomainCounts } from '../services/projectStateService';
 import Feature from './feature';
@@ -17,10 +18,32 @@ export default interface ProjectMetadata {
   numFindings?: number;
   numHttpRequests?: number;
   numAppMaps?: number;
+  // Most preferred language available.
   language?: Feature;
+  // All recognized languages.
+  languages?: Feature[];
+  // Test framework recognized in the preferred language, if any.
   testFramework?: Feature;
+  // Web framework recognized in the preferred language, if any.
   webFramework?: Feature;
   appMaps?: Readonly<Array<AppMapSummary>>;
   sampleCodeObjects?: SampleCodeObjects;
   findingsDomainCounts?: FindingsDomainCounts;
+}
+
+export function isLanguageSupported(project?: ProjectMetadata): boolean {
+  if (!project) return false;
+
+  return !!project.languages?.some(
+    (language) => language.name && SUPPORTED_LANGUAGES.includes(language.name?.toLowerCase() as any)
+  );
+}
+
+export function hasSupportedFramework(project?: ProjectMetadata): boolean {
+  if (!project) return false;
+
+  return !!(
+    (project.webFramework && project.webFramework.score > 0) ||
+    (project.testFramework && project.testFramework.score > 0)
+  );
 }

--- a/test/integration/index/updateAsAppMapsAreModified.test.ts
+++ b/test/integration/index/updateAsAppMapsAreModified.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { unlink } from 'fs';
 import { promisify } from 'util';
 import * as vscode from 'vscode';

--- a/test/integration/languageResolver.test.ts
+++ b/test/integration/languageResolver.test.ts
@@ -34,7 +34,8 @@ describe('LanguageResolver', () => {
     });
 
     it('correctly identifies the project language', async () => {
-      const language = await LanguageResolver.getLanguage(ProjectRuby);
+      const languages = await LanguageResolver.getLanguages(ProjectRuby);
+      const language = languages[0];
       assert.strictEqual(language, 'ruby');
     });
 
@@ -48,7 +49,8 @@ describe('LanguageResolver', () => {
         await fs.writeFile(join(ProjectRuby, 'ignored_dir', '.gitignore'), '*');
       });
 
-      const language = await LanguageResolver.getLanguage(ProjectRuby);
+      const languages = await LanguageResolver.getLanguages(ProjectRuby);
+      const language = languages[0];
       assert.strictEqual(language, 'ruby');
     });
   });

--- a/test/integration/projectAnalyzers/javascript.test.ts
+++ b/test/integration/projectAnalyzers/javascript.test.ts
@@ -26,7 +26,7 @@ describe('JavaScript project analyzer', () => {
 
         assert(result);
         assert(result.features.test);
-        assert(result.features.test.score == 'ok');
+        assert(result.features.test.score == 'early-access');
       });
     });
   });

--- a/test/integration/scanner/performAsAppMapsAreModified.test.ts
+++ b/test/integration/scanner/performAsAppMapsAreModified.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import assert from 'assert';
-import { exists, rename } from 'fs';
+import { exists } from 'fs';
 import { join, relative } from 'path';
 import { promisify } from 'util';
 import {

--- a/test/system/tests/findings.test.ts
+++ b/test/system/tests/findings.test.ts
@@ -85,30 +85,4 @@ describe('Findings and scanning', function () {
     const expectedTitle = 'N plus 1 SQL query';
     await findingDetailsWebview.assertTitleRenders(expectedTitle);
   });
-
-  // TODO: Fix this test
-  xit('reuses the finding details webview', async function () {
-    const { driver, project } = this;
-    const findingsOverviewWebview = driver.appMap['findingsOverviewWebview'];
-    const findingDetailsWebview = driver.appMap['findingDetailsWebview'];
-
-    await driver.appMap.openActionPanel();
-    await driver.appMap.expandFindings();
-    await driver.appMap.openFindingsOverview();
-    let expectedFrames = 2;
-    await findingsOverviewWebview.initialize(expectedFrames);
-
-    await project.restoreFiles('**/*.appmap.json');
-    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
-    await driver.appMap.findingsTreeItem(1).waitFor();
-
-    await findingsOverviewWebview.openFirstFindingDetail();
-    expectedFrames = 3;
-    await findingDetailsWebview.initialize(expectedFrames);
-    await driver.appMap.openNthFinding(2);
-    await findingDetailsWebview.initialize(expectedFrames);
-
-    const numTabs = await driver.tabCount();
-    strictEqual(numTabs, expectedFrames);
-  });
 });

--- a/test/unit/analyzers/javascript.test.ts
+++ b/test/unit/analyzers/javascript.test.ts
@@ -10,27 +10,29 @@ import { Features } from '../../../src/analyzers';
 
 describe('JavaScript analyzer', () => {
   test('notes the lack of package.json', null, (f) =>
-    expect(f.lang.text).to.include('without a dependency file')
+    expect(f.lang.text).to.include(
+      'You can add AppMap to this project by creating a package.json file'
+    )
   );
 
   test('detects express.js', { dependencies: { express: 'latest' } }, (f) =>
-    expect(f.web?.score).to.equal('ok')
+    expect(f.web?.score).to.equal('early-access')
   );
 
   test('detects mocha', { devDependencies: { mocha: 'latest' } }, (f) =>
-    expect(f.test).to.include({ title: 'mocha', score: 'ok' })
+    expect(f.test).to.include({ title: 'mocha', score: 'early-access' })
   );
 
   test('rejects old mocha', { devDependencies: { mocha: '^7' } }, (f) =>
-    expect(f.test).to.include({ title: 'mocha', score: 'bad' })
+    expect(f.test).to.include({ title: 'mocha', score: 'unsupported' })
   );
 
   test('detects jest', { devDependencies: { jest: 'latest' } }, (f) =>
-    expect(f.test).to.include({ title: 'jest', score: 'ok' })
+    expect(f.test).to.include({ title: 'jest', score: 'early-access' })
   );
 
   test('rejects old jest', { devDependencies: { jest: '^24' } }, (f) =>
-    expect(f.test).to.include({ title: 'jest', score: 'bad' })
+    expect(f.test).to.include({ title: 'jest', score: 'unsupported' })
   );
 });
 


### PR DESCRIPTION
For installation purposes, prefer a language that has a detected web framework. Don't base preference purely on file count statistics.

This fixes a situation in which, once a project has more JS files than web app files (e.g. Ruby), the project picker chooses JS as the install language. 

A couple of other things are included:

1) Use a warning icon when AppMap test_status is `failed`
2) Fix a bug parsing `depends` output
