### PR TITLE
feat: Broaden install prompt

### DIFF
--- a/src/actions/promptInstall.ts
+++ b/src/actions/promptInstall.ts
@@ -3,6 +3,7 @@ import { WorkspaceServices } from '../services/workspaceServices';
 import * as vscode from 'vscode';
 import { INSTALL_PROMPT, Telemetry } from '../telemetry';
 import ExtensionState from '../configuration/extensionState';
+import { hasSupportedFramework, isLanguageSupported } from '../workspace/projectMetadata';
 
 export enum ButtonText {
   Confirm = 'Open instructions',
@@ -23,10 +24,9 @@ const promptResponses: ReadonlyArray<vscode.MessageItem> = [
 ];
 
 const meetsPromptCriteria = (project: ProjectStateServiceInstance): boolean =>
-  project.installable &&
-  !project.metadata.agentInstalled &&
-  project.metadata.language?.name === 'Ruby' &&
-  project.metadata.webFramework?.name === 'Rails';
+  isLanguageSupported(project.metadata) &&
+  hasSupportedFramework(project.metadata) &&
+  !project.metadata.agentInstalled;
 
 export default async function promptInstall(
   services: WorkspaceServices,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,8 +261,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     findByName(context, projectStates, appmapCollectionFile);
     resetUsageState(context, extensionState);
 
-    if (!openedInstallGuide && !SignInManager.shouldShowSignIn())
-      promptInstall(workspaceServices, extensionState);
+    if (!openedInstallGuide) promptInstall(workspaceServices, extensionState);
 
     vscode.env.onDidChangeTelemetryEnabled((enabled: boolean) => {
       Telemetry.sendEvent(TELEMETRY_ENABLED, {


### PR DESCRIPTION
Prompt to install if a project satisfies all of:

* Has a supported language
* Has a supported framework
* Does not already have an appmap.yml

@dividedmind FYI