### PR TITLE
Run configs for Java users

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,14 @@
         "title": "AppMap: Logout"
       },
       {
+        "command": "appmap.updateAppMapTestConfig",
+        "title": "AppMap: Add AppMap Test Configuration"
+      },
+      {
+        "command": "appmap.updateAppMapLaunchConfig",
+        "title": "AppMap: Add AppMap Launch Configuration"
+      },
+      {
         "command": "appmap.downloadLatestJavaJar",
         "title": "AppMap: Download Latest Java Jar"
       }

--- a/package.json
+++ b/package.json
@@ -195,6 +195,10 @@
       {
         "command": "appmap.logout",
         "title": "AppMap: Logout"
+      },
+      {
+        "command": "appmap.downloadLatestJavaJar",
+        "title": "AppMap: Download Latest Java Jar"
       }
     ],
     "configuration": {

--- a/src/appMapService.ts
+++ b/src/appMapService.ts
@@ -11,6 +11,7 @@ import { AppmapUptodateService } from './services/appmapUptodateService';
 import Command from './services/command';
 import { NodeProcessService } from './services/nodeProcessService';
 import ProjectStateService from './services/projectStateService';
+import { RunConfigService } from './services/runConfigService';
 import { SourceFileWatcher } from './services/sourceFileWatcher';
 import { WorkspaceServices } from './services/workspaceServices';
 import { AppMapTreeDataProvider } from './tree/appMapTreeDataProvider';
@@ -47,4 +48,5 @@ export default interface AppMapService {
   appmapServerAuthenticationProvider: AppMapServerAuthenticationProvider;
   recommender: AppMapRecommenderService;
   configManager: AppmapConfigManager;
+  runConfigService: RunConfigService;
 }

--- a/src/commands/downloadLatestJavaJar.ts
+++ b/src/commands/downloadLatestJavaJar.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+import AssetManager from '../services/assetManager';
+
+export default async function downloadLatestJavaJar(
+  context: vscode.ExtensionContext
+): Promise<void> {
+  const command = vscode.commands.registerCommand('appmap.downloadLatestJavaJar', async () => {
+    try {
+      await AssetManager.getLatestJavaJar();
+      vscode.window.showInformationMessage('AppMap usage state was reset.');
+    } catch (e) {
+      const err = e as Error;
+      vscode.window.showErrorMessage(`Failed to download latest Java jar: ${err.message}`);
+    }
+  });
+
+  context.subscriptions.push(command);
+}

--- a/src/commands/updateConfigs.ts
+++ b/src/commands/updateConfigs.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+
+import { RunConfigService, RunConfigServiceInstance } from '../services/runConfigService';
+import { WorkspaceServices } from '../services/workspaceServices';
+import chooseWorkspace from '../lib/chooseWorkspace';
+
+const JAVA_EXTENSIONS_PACK_ID = 'vscjava.vscode-java-pack';
+
+export default async function updateAppMapConfigs(
+  context: vscode.ExtensionContext,
+  runConfigService: RunConfigService,
+  workspaceServices: WorkspaceServices
+): Promise<void> {
+  async function getRunConfigInstance(): Promise<RunConfigServiceInstance> {
+    const workspace = await chooseWorkspace();
+    assert(workspace);
+
+    const runConfigServiceInstance = workspaceServices.getServiceInstance(
+      runConfigService,
+      workspace
+    ) as RunConfigServiceInstance | undefined;
+    assert(runConfigServiceInstance);
+
+    return runConfigServiceInstance;
+  }
+
+  const testCommand = vscode.commands.registerCommand('appmap.updateAppMapTestConfig', async () => {
+    try {
+      const runConfigServiceInstance = await getRunConfigInstance();
+      const updated = await runConfigServiceInstance.updateTestConfig();
+      if (updated) {
+        vscode.window.showInformationMessage('AppMap test configuration added.');
+      } else {
+        const choice = await vscode.window.showErrorMessage(
+          'Failed to add AppMap test configuration. Please install the Extension Pack for Java.',
+          'Install',
+          'Cancel'
+        );
+
+        if (choice === 'Install') {
+          vscode.commands.executeCommand('workbench.extensions.action.showExtensionsWithIds', [
+            JAVA_EXTENSIONS_PACK_ID,
+          ]);
+        }
+      }
+    } catch (e) {
+      const err = e as Error;
+      vscode.window.showErrorMessage(`Error: ${err.message}`);
+    }
+  });
+
+  context.subscriptions.push(testCommand);
+
+  const launchCommand = vscode.commands.registerCommand(
+    'appmap.updateAppMapLaunchConfig',
+    async () => {
+      try {
+        const runConfigServiceInstance = await getRunConfigInstance();
+        runConfigServiceInstance.updateLaunchConfig();
+      } catch (e) {
+        const err = e as Error;
+        vscode.window.showErrorMessage(`Error: ${err.message}`);
+      }
+    }
+  );
+
+  context.subscriptions.push(launchCommand);
+}

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -18,6 +18,8 @@ export const Keys = {
     GENERATED_OPENAPI: 'appmap.applandinc.generatedOpenApi',
     HIDE_INSTALL_PROMPT: 'appmap.applandinc.hideInstallPrompt',
     CLOSED_APPMAP: 'appmap.applandinc.closedAppMap',
+    UPDATED_RUN_CONFIG: 'appmap.applandinc.UpdatedLaunchConfig',
+    UPDATED_TEST_CONFIG: 'appmap.applandinc.UpdatedTestConfig',
   },
 };
 
@@ -179,6 +181,22 @@ export default class ExtensionState {
 
   setClosedAppMap(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
     this.setWorkspaceFlag(Keys.Workspace.CLOSED_APPMAP, value, workspaceFolder);
+  }
+
+  getUpdatedLaunchConfig(workspaceFolder: vscode.WorkspaceFolder): boolean {
+    return this.getWorkspaceFlag(Keys.Workspace.UPDATED_RUN_CONFIG, workspaceFolder.uri.fsPath);
+  }
+
+  setUpdatedLaunchConfig(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.setWorkspaceFlag(Keys.Workspace.UPDATED_RUN_CONFIG, value, workspaceFolder);
+  }
+
+  getUpdatedTestConfig(workspaceFolder: vscode.WorkspaceFolder): boolean {
+    return this.getWorkspaceFlag(Keys.Workspace.UPDATED_TEST_CONFIG, workspaceFolder.uri.fsPath);
+  }
+
+  setUpdatedTestConfig(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.setWorkspaceFlag(Keys.Workspace.UPDATED_TEST_CONFIG, value, workspaceFolder);
   }
 
   resetState(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ import tryOpenInstallGuide from './commands/tryOpenInstallGuide';
 import { AppmapConfigManager } from './services/appmapConfigManager';
 import { findByName } from './commands/findByName';
 import initializeDefaultFilter from './lib/initializeSavedFilters';
+import AssetManager from './services/assetManager';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -240,6 +241,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     FindingInfoWebview.register(context);
 
     const processService = new NodeProcessService(context);
+    AssetManager.register();
     (async function () {
       processService.onReady(activateUptodateService);
       await processService.install();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ import { AppmapConfigManager } from './services/appmapConfigManager';
 import { findByName } from './commands/findByName';
 import initializeDefaultFilter from './lib/initializeSavedFilters';
 import { RunConfigService } from './services/runConfigService';
+import updateAppMapConfigs from './commands/updateConfigs';
 import AssetManager from './services/assetManager';
 import downloadLatestJavaJar from './commands/downloadLatestJavaJar';
 
@@ -269,6 +270,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     generateOpenApi(context, extensionState);
     findByName(context, projectStates, appmapCollectionFile);
     resetUsageState(context, extensionState);
+    updateAppMapConfigs(context, runConfigService, workspaceServices);
     downloadLatestJavaJar(context);
 
     if (!openedInstallGuide && !SignInManager.shouldShowSignIn())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ import { AppmapConfigManager } from './services/appmapConfigManager';
 import { findByName } from './commands/findByName';
 import initializeDefaultFilter from './lib/initializeSavedFilters';
 import AssetManager from './services/assetManager';
+import downloadLatestJavaJar from './commands/downloadLatestJavaJar';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -264,6 +265,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     generateOpenApi(context, extensionState);
     findByName(context, projectStates, appmapCollectionFile);
     resetUsageState(context, extensionState);
+    downloadLatestJavaJar(context);
 
     if (!openedInstallGuide && !SignInManager.shouldShowSignIn())
       promptInstall(workspaceServices, extensionState);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ import tryOpenInstallGuide from './commands/tryOpenInstallGuide';
 import { AppmapConfigManager } from './services/appmapConfigManager';
 import { findByName } from './commands/findByName';
 import initializeDefaultFilter from './lib/initializeSavedFilters';
+import { RunConfigService } from './services/runConfigService';
 import AssetManager from './services/assetManager';
 import downloadLatestJavaJar from './commands/downloadLatestJavaJar';
 
@@ -242,7 +243,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     FindingInfoWebview.register(context);
 
     const processService = new NodeProcessService(context);
+    const runConfigService = new RunConfigService(projectState, workspaceServices, extensionState);
     AssetManager.register();
+    await workspaceServices.enroll(runConfigService);
+
     (async function () {
       processService.onReady(activateUptodateService);
       await processService.install();
@@ -306,6 +310,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       },
       recommender,
       configManager,
+      runConfigService,
     };
   } catch (exception) {
     Telemetry.sendEvent(DEBUG_EXCEPTION, {

--- a/src/lib/githubRelease.ts
+++ b/src/lib/githubRelease.ts
@@ -1,0 +1,36 @@
+import fetch from 'node-fetch';
+import { createWriteStream, WriteStream } from 'fs';
+
+export interface GithubReleaseAsset {
+  name: string;
+  content_type: string;
+  browser_download_url: string;
+}
+
+export default class GithubRelease {
+  constructor(private repoOwner: string, private repoName: string) {}
+
+  async getLatestAssets(): Promise<Array<GithubReleaseAsset>> {
+    const url = `https://api.github.com/repos/${this.repoOwner}/${this.repoName}/releases/latest`;
+    const response = await fetch(url);
+    const { assets } = (await response.json()) as { assets: Array<GithubReleaseAsset> };
+    return assets;
+  }
+
+  static async downloadAsset(asset: GithubReleaseAsset, path: string): Promise<void> {
+    return fetch(asset.browser_download_url).then((response) => {
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      if (!response.body) throw new Error('Response body is empty');
+
+      const fileStream: WriteStream = createWriteStream(path);
+      response.body.pipe(fileStream);
+      response.body.on('error', (e) => {
+        throw new Error(e);
+      });
+
+      return new Promise((resolve) => {
+        fileStream.on('finish', resolve);
+      });
+    });
+  }
+}

--- a/src/services/assetManager.ts
+++ b/src/services/assetManager.ts
@@ -1,0 +1,100 @@
+import * as vscode from 'vscode';
+
+import { copyFileSync, mkdirSync, statSync, symlinkSync, unlinkSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import GithubRelease, { GithubReleaseAsset } from '../lib/githubRelease';
+import { touch } from '../lib/touch';
+import { DEBUG_EXCEPTION, DOWNLOADED_JAVA_JAR, Telemetry } from '../telemetry';
+import { fileExists } from '../util';
+import ErrorCode from '../telemetry/definitions/errorCodes';
+
+export default class AssetManager {
+  private static FIVE_MINUTES_IN_MILLISECONDS = 5 * 60 * 1000;
+  private static appmapJavaRelease = new GithubRelease('getappmap', 'appmap-java');
+  private static outputChannel = vscode.window.createOutputChannel('AppMap: Assets');
+  public static logLines: string[] = [];
+
+  private static get javaAgentDir(): string {
+    return path.join(os.homedir(), '.appmap', 'lib', 'java');
+  }
+
+  private static log(line: string) {
+    this.logLines.push(line);
+    this.outputChannel.appendLine(line);
+  }
+
+  private static async getLatestJavaJarInfo(): Promise<GithubReleaseAsset> {
+    const assets = await this.appmapJavaRelease.getLatestAssets();
+    const asset = assets.find((a) => a.content_type === 'application/java-archive');
+    if (!asset) throw Error('Could not retrieve latest Java agent release');
+    return asset;
+  }
+
+  private static async createLockfile(assetName: string): Promise<string> {
+    const lockfilePath = path.join(this.javaAgentDir, assetName + '.downloading');
+    if (await fileExists(lockfilePath)) {
+      const lockfileCreationTime = statSync(lockfilePath).mtime;
+      const timeSinceCreation = new Date().getTime() - lockfileCreationTime.getTime();
+      if (timeSinceCreation < AssetManager.FIVE_MINUTES_IN_MILLISECONDS)
+        throw Error(`Could not download ${assetName} because lockfile already exists`);
+    }
+    await touch(lockfilePath);
+    return lockfilePath;
+  }
+
+  private static updateLatestFile(
+    assetName: string,
+    assetPath: string,
+    symlinkPath: string
+  ): boolean {
+    let symlinkCreated = true;
+    try {
+      symlinkSync(assetName, symlinkPath, 'file');
+    } catch (e) {
+      copyFileSync(assetPath, symlinkPath);
+      symlinkCreated = false;
+    }
+    return symlinkCreated;
+  }
+
+  public static async getLatestJavaJar(): Promise<void> {
+    try {
+      const asset = await this.getLatestJavaJarInfo();
+      if (!(await fileExists(this.javaAgentDir))) mkdirSync(this.javaAgentDir, { recursive: true });
+      const assetPath = path.join(this.javaAgentDir, asset.name);
+      if (await fileExists(assetPath)) return;
+
+      const lockfilePath = await this.createLockfile(asset.name);
+      this.log(`Downloading AppMap Java agent ${asset.name}`);
+      await GithubRelease.downloadAsset(asset, assetPath);
+
+      const symlinkPath = path.join(this.javaAgentDir, 'appmap.jar');
+      try {
+        unlinkSync(symlinkPath);
+      } catch (e) {
+        // if the symlink that we're trying to remove does not exist, don't do anything
+      }
+
+      const symlinkCreated = this.updateLatestFile(asset.name, assetPath, symlinkPath);
+      unlinkSync(lockfilePath);
+
+      this.log(`Finished downloading AppMap Java agent to ${assetPath}`);
+      Telemetry.sendEvent(DOWNLOADED_JAVA_JAR, { symlinkCreated, version: asset.name });
+    } catch (e) {
+      const err = e as Error;
+      this.log(err.message);
+
+      Telemetry.sendEvent(DEBUG_EXCEPTION, {
+        exception: err,
+        errorCode: ErrorCode.AssetAcquisitionFailure,
+        log: this.logLines.join('\n'),
+      });
+    }
+  }
+
+  public static async register(): Promise<void> {
+    await this.getLatestJavaJar();
+  }
+}

--- a/src/services/runConfigService.ts
+++ b/src/services/runConfigService.ts
@@ -1,0 +1,155 @@
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import path from 'path';
+
+import { WorkspaceService, WorkspaceServiceInstance } from './workspaceService';
+import ProjectStateService, { ProjectStateServiceInstance } from './projectStateService';
+import { WorkspaceServices } from './workspaceServices';
+import ExtensionState from '../configuration/extensionState';
+import { CONFIG_ADDED, DEBUG_EXCEPTION, Telemetry } from '../telemetry';
+import ErrorCode from '../telemetry/definitions/errorCodes';
+
+type JavaTestConfig = {
+  name?: string;
+  vmArgs?: Array<string>;
+};
+
+export class RunConfigServiceInstance implements WorkspaceServiceInstance {
+  private static JAVA_TEST_RUNNER_EXTENSION_ID = 'vscjava.vscode-java-test';
+  protected disposables: vscode.Disposable[] = [];
+
+  public get appmapLaunchConfig(): vscode.DebugConfiguration {
+    return {
+      type: 'java',
+      name: 'Run with AppMap',
+      request: 'launch',
+      mainClass: '',
+      vmArgs: `-javaagent:${this.javaJarPath}`,
+    };
+  }
+
+  public get appmapTestConfig(): JavaTestConfig {
+    return {
+      name: 'Test with AppMap',
+      vmArgs: [`-javaagent:${this.javaJarPath}`],
+    };
+  }
+
+  private get hasPreviouslyUpdatedLaunchConfig(): boolean {
+    return this.extensionState.getUpdatedLaunchConfig(this.folder);
+  }
+
+  private get hasPreviouslyUpdatedTestConfig(): boolean {
+    return this.extensionState.getUpdatedTestConfig(this.folder);
+  }
+
+  private get javaJarPath(): string {
+    return path.join('${userHome}', '.appmap', 'lib', 'java', 'appmap.jar');
+  }
+
+  constructor(
+    public folder: vscode.WorkspaceFolder,
+    public projectStateServiceInstance: ProjectStateServiceInstance,
+    private extensionState: ExtensionState
+  ) {
+    projectStateServiceInstance.onStateChange(this.updateConfigs.bind(this));
+    vscode.extensions.onDidChange(this.updateConfigs.bind(this));
+
+    this.updateConfigs();
+  }
+
+  private async updateConfigs(): Promise<void> {
+    if (!this.isJavaProject()) return;
+    if (!this.hasPreviouslyUpdatedLaunchConfig) await this.updateLaunchConfig();
+    if (!this.hasPreviouslyUpdatedTestConfig) await this.updateTestConfig();
+  }
+
+  public async updateLaunchConfig(): Promise<void> {
+    try {
+      await this.updateConfig('launch', 'configurations', this.appmapLaunchConfig);
+      this.extensionState.setUpdatedLaunchConfig(this.folder, true);
+
+      this.sendConfigUpdateSuccess('launch');
+    } catch (e) {
+      this.sendConfigUpdateError(e);
+    }
+  }
+
+  public async updateTestConfig(): Promise<boolean> {
+    if (this.hasJavaTestExtension()) {
+      try {
+        await this.updateConfig('java.test', 'config', this.appmapTestConfig);
+        this.extensionState.setUpdatedTestConfig(this.folder, true);
+
+        this.sendConfigUpdateSuccess('test');
+        return true;
+      } catch (e) {
+        this.sendConfigUpdateError(e);
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private async updateConfig(
+    parentSection: string,
+    section: string,
+    appmapConfig: vscode.DebugConfiguration | JavaTestConfig
+  ): Promise<void> {
+    const parentConfig = vscode.workspace.getConfiguration(parentSection);
+    let configs = parentConfig.get<Array<vscode.DebugConfiguration | JavaTestConfig>>(section);
+    if (!Array.isArray(configs)) configs = [];
+
+    configs.push(appmapConfig);
+    await parentConfig.update(section, configs);
+  }
+
+  private isJavaProject(): boolean {
+    const { language } = this.projectStateServiceInstance.metadata;
+    return !!(language && language.name && language.name === 'Java');
+  }
+
+  public hasJavaTestExtension(): boolean {
+    const extensions = vscode.extensions.all;
+    return extensions.some(
+      (exension) => exension.id === RunConfigServiceInstance.JAVA_TEST_RUNNER_EXTENSION_ID
+    );
+  }
+
+  private sendConfigUpdateError(e: unknown): void {
+    const err = e as Error;
+    Telemetry.sendEvent(DEBUG_EXCEPTION, {
+      exception: err,
+      errorCode: ErrorCode.ConfigUpdateError,
+    });
+  }
+
+  private sendConfigUpdateSuccess(configType: string): void {
+    Telemetry.sendEvent(CONFIG_ADDED, {
+      configType,
+    });
+  }
+
+  public async dispose(): Promise<void> {
+    return;
+  }
+}
+
+export class RunConfigService implements WorkspaceService<RunConfigServiceInstance> {
+  constructor(
+    private projectStateService: ProjectStateService,
+    private workspaceServices: WorkspaceServices,
+    private extensionState: ExtensionState
+  ) {}
+
+  async create(folder: vscode.WorkspaceFolder): Promise<RunConfigServiceInstance> {
+    const projectStateServiceInstance = this.workspaceServices.getServiceInstance(
+      this.projectStateService,
+      folder
+    ) as ProjectStateServiceInstance | undefined;
+    assert(projectStateServiceInstance);
+
+    return new RunConfigServiceInstance(folder, projectStateServiceInstance, this.extensionState);
+  }
+}

--- a/src/telemetry/definitions/errorCodes.ts
+++ b/src/telemetry/definitions/errorCodes.ts
@@ -12,6 +12,7 @@ enum ErrorCode {
   SeqDiagramFeedbackCtaError,
   GenerateMapStatsError,
   PruneLargeMapError,
+  ConfigUpdateError,
   AssetAcquisitionFailure,
 }
 

--- a/src/telemetry/definitions/errorCodes.ts
+++ b/src/telemetry/definitions/errorCodes.ts
@@ -12,6 +12,7 @@ enum ErrorCode {
   SeqDiagramFeedbackCtaError,
   GenerateMapStatsError,
   PruneLargeMapError,
+  AssetAcquisitionFailure,
 }
 
 export default ErrorCode;

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -220,3 +220,7 @@ export const DOWNLOADED_JAVA_JAR = new Event({
   properties: [Properties.SYMLINK_CREATED, Properties.VERSION],
 });
 
+export const CONFIG_ADDED = new Event({
+  name: 'config_added',
+  properties: [Properties.CONFIG_TYPE],
+});

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -214,3 +214,9 @@ export const INSTALL_BUTTON_ABORT = new Event({
   name: 'install_button:abort',
   properties: [Properties.REASON, Properties.OPTIONAL_RESULT],
 });
+
+export const DOWNLOADED_JAVA_JAR = new Event({
+  name: 'downloaded_java_jar',
+  properties: [Properties.SYMLINK_CREATED, Properties.VERSION],
+});
+

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -359,3 +359,17 @@ export const LINK_TYPE = new TelemetryDataProvider({
     return linkType;
   },
 });
+
+export const SYMLINK_CREATED = new TelemetryDataProvider({
+  id: 'appmap.symlink_created',
+  async value({ symlinkCreated }: { symlinkCreated: boolean }) {
+    return String(symlinkCreated);
+  },
+});
+
+export const VERSION = new TelemetryDataProvider({
+  id: 'appmap.version',
+  async value({ version }: { version: string }) {
+    return version;
+  },
+});

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -367,6 +367,13 @@ export const SYMLINK_CREATED = new TelemetryDataProvider({
   },
 });
 
+export const CONFIG_TYPE = new TelemetryDataProvider({
+  id: 'appmap.config_type',
+  async value({ configType }: { configType: string }) {
+    return configType;
+  },
+});
+
 export const VERSION = new TelemetryDataProvider({
   id: 'appmap.version',
   async value({ version }: { version: string }) {

--- a/test/fixtures/workspaces/project-java/src/main/java/PetClinicApplication.java
+++ b/test/fixtures/workspaces/project-java/src/main/java/PetClinicApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * PetClinic Spring Boot Application.
+ *
+ * @author Dave Syer
+ *
+ */
+@SpringBootApplication
+@ImportRuntimeHints(PetClinicRuntimeHints.class)
+public class PetClinicApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(PetClinicApplication.class, args);
+	}
+
+}

--- a/test/integration/assetManager/javaJarDownload.test.ts
+++ b/test/integration/assetManager/javaJarDownload.test.ts
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import { existsSync, lstatSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { SinonSandbox, createSandbox } from 'sinon';
+
+import { ProjectA, initializeWorkspace, waitFor, waitForExtension } from '../util';
+import GithubRelease from '../../../src/lib/githubRelease';
+
+const expectedJavaDir = path.join(ProjectA, '.appmap', 'lib', 'java');
+const expectedLatestJarPath = path.join(expectedJavaDir, 'appmap.jar');
+
+describe('node process service installation', () => {
+  let sinon: SinonSandbox;
+
+  before(async () => {
+    sinon = createSandbox();
+    sinon.stub(os, 'homedir').returns(ProjectA);
+
+    await waitForExtension();
+    await waitFor('Waiting for jar to be downloaded', () => existsSync(expectedLatestJarPath));
+  });
+
+  after(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+  });
+
+  it('downloads the latest jar', async () => {
+    const release = new GithubRelease('getappmap', 'appmap-java');
+    const assets = await release.getLatestAssets();
+    const asset = assets.find((a) => a.content_type === 'application/java-archive');
+    assert(asset);
+    const expectedAssetPath = path.join(expectedJavaDir, asset.name);
+    assert(existsSync(expectedAssetPath));
+    const stats = lstatSync(expectedAssetPath);
+    assert(stats.isFile());
+  });
+
+  it('creates a symlink to the latest jar', () => {
+    assert(existsSync(expectedLatestJarPath));
+    const stats = lstatSync(expectedLatestJarPath);
+    assert(stats.isSymbolicLink());
+  });
+});

--- a/test/integration/assetManager/javaJarLockfileExists.test.ts
+++ b/test/integration/assetManager/javaJarLockfileExists.test.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import { existsSync, mkdirSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { createSandbox } from 'sinon';
+
+import { ProjectA, initializeWorkspace, waitFor, waitForExtension } from '../util';
+import GithubRelease from '../../../src/lib/githubRelease';
+import { touch } from '../../../src/lib/touch';
+
+const expectedJavaDir = path.join(ProjectA, '.appmap', 'lib', 'java');
+const expectedLatestJarPath = path.join(expectedJavaDir, 'appmap.jar');
+
+const fakeOutputChannel = {
+  name: '',
+  lines: [] as string[],
+  appendLine(line: string) {
+    this.lines.push(line);
+  },
+  append() {
+    // not implemented
+  },
+  clear() {
+    // not implemented
+  },
+  dispose() {
+    // not implemented
+  },
+  hide() {
+    // not implemented
+  },
+  replace() {
+    // not implemented
+  },
+  show() {
+    // not implemented
+  },
+};
+
+const sinon = createSandbox();
+sinon
+  .stub(vscode.window, 'createOutputChannel')
+  .withArgs('AppMap: Assets')
+  .returns(fakeOutputChannel);
+
+describe('node process service installation with existing lockfile for jar download', () => {
+  let assetPath: string;
+  let lockfile: string;
+
+  before(async () => {
+    await initializeWorkspace();
+    sinon.stub(os, 'homedir').returns(ProjectA);
+
+    const release = new GithubRelease('getappmap', 'appmap-java');
+    const assets = await release.getLatestAssets();
+    const asset = assets.find((a) => a.content_type === 'application/java-archive');
+    assert(asset);
+
+    assetPath = path.join(expectedJavaDir, asset.name);
+    lockfile = assetPath + '.downloading';
+    mkdirSync(path.join(expectedJavaDir), { recursive: true });
+    await touch(lockfile);
+
+    await waitForExtension();
+    await waitFor('java jar download attempt', () =>
+      fakeOutputChannel.lines.some((line) => line.includes('because lockfile already exists'))
+    );
+  });
+
+  after(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+  });
+
+  it('does not download the latest jar', async () => {
+    assert(!existsSync(expectedLatestJarPath));
+  });
+});

--- a/test/integration/runConfigs/runConfigsJava.test.ts
+++ b/test/integration/runConfigs/runConfigsJava.test.ts
@@ -1,0 +1,92 @@
+// @project project-java
+
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { SinonSandbox, createSandbox, SinonStub, SinonSpy } from 'sinon';
+
+import { RunConfigServiceInstance } from '../../../src/services/runConfigService';
+import ExtensionState from '../../../src/configuration/extensionState';
+import { ExpectedLaunchConfig, ExpectedTestConfig, FakeConfig } from './util';
+import { ProjectJava, initializeWorkspace, waitFor, waitForExtension } from '../util';
+
+describe('run config service in a Java Project', () => {
+  let sinon: SinonSandbox;
+  let runConfigServiceInstance: RunConfigServiceInstance;
+  let state: ExtensionState;
+  let fakeConfigGetSpy: SinonSpy;
+  let fakeConfigUpdateSpy: SinonSpy;
+  let getConfigStub: SinonStub;
+
+  before(async () => {
+    sinon = createSandbox();
+    sinon.stub(os, 'homedir').returns(ProjectJava);
+
+    // This needs to be faked because the Test Runner for Java extension is not installed during testing
+    // and VS Code will throw an error when attempting to update an unregistered config ("java.test.config")
+    fakeConfigGetSpy = sinon.spy(FakeConfig, 'get');
+    fakeConfigUpdateSpy = sinon.spy(FakeConfig, 'update');
+    getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration');
+    getConfigStub.withArgs('java.test').returns(FakeConfig);
+    getConfigStub.callThrough();
+
+    const { workspaceServices, runConfigService, extensionState } = await waitForExtension();
+    state = extensionState;
+
+    const runConfigServiceInstances = workspaceServices.getServiceInstances(runConfigService);
+    assert.strictEqual(runConfigServiceInstances.length, 1);
+    runConfigServiceInstance = runConfigServiceInstances[0];
+
+    // Pretend that the Test Runner for Java extension is installed
+    sinon.stub(runConfigServiceInstance, 'hasJavaTestExtension').returns(true);
+  });
+
+  after(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+  });
+
+  it('correctly generates the expected configurations', () => {
+    assert.deepStrictEqual(runConfigServiceInstance.appmapLaunchConfig, ExpectedLaunchConfig);
+    assert.deepStrictEqual(runConfigServiceInstance.appmapTestConfig, ExpectedTestConfig);
+  });
+
+  it('creates a new run configuration', async () => {
+    await waitFor('launch.json to be created', () =>
+      existsSync(path.join(ProjectJava, '.vscode', 'launch.json'))
+    );
+
+    let configs;
+    await waitFor('launch config to be created', () => {
+      const config = vscode.workspace.getConfiguration('launch');
+      configs = config.get('configurations');
+      return configs.length > 0;
+    });
+
+    assert.deepStrictEqual(configs, [runConfigServiceInstance.appmapLaunchConfig]);
+  });
+
+  it('saves that the launch config was created', () => {
+    assert(state.getUpdatedLaunchConfig(runConfigServiceInstance.folder));
+  });
+
+  it('creates a new test configuration', async () => {
+    await waitFor(
+      'test config to be created',
+      () => state.getUpdatedTestConfig(runConfigServiceInstance.folder),
+      60000
+    );
+
+    // The settings.json file will not be created, but we can check that the correct function calls were made
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
+    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
+      'config',
+      [runConfigServiceInstance.appmapTestConfig],
+    ]);
+  });
+});

--- a/test/integration/runConfigs/runConfigsJavaNoTestExt.test.ts
+++ b/test/integration/runConfigs/runConfigsJavaNoTestExt.test.ts
@@ -1,0 +1,79 @@
+// @project project-java
+
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { SinonSandbox, createSandbox, SinonStub, SinonSpy } from 'sinon';
+
+import { RunConfigServiceInstance } from '../../../src/services/runConfigService';
+import ExtensionState from '../../../src/configuration/extensionState';
+import { ExpectedLaunchConfig, ExpectedTestConfig, FakeConfig } from './util';
+import { ProjectJava, initializeWorkspace, waitFor, waitForExtension } from '../util';
+
+describe('run config service in a Java Project without the Test Runner for Java extension', () => {
+  let sinon: SinonSandbox;
+  let runConfigServiceInstance: RunConfigServiceInstance;
+  let state: ExtensionState;
+  let fakeConfigGetSpy: SinonSpy;
+  let fakeConfigUpdateSpy: SinonSpy;
+  let getConfigStub: SinonStub;
+
+  before(async () => {
+    sinon = createSandbox();
+    sinon.stub(os, 'homedir').returns(ProjectJava);
+
+    fakeConfigGetSpy = sinon.spy(FakeConfig, 'get');
+    fakeConfigUpdateSpy = sinon.spy(FakeConfig, 'update');
+    getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration');
+    getConfigStub.withArgs('java.test').returns(FakeConfig);
+    getConfigStub.callThrough();
+
+    const { workspaceServices, runConfigService, extensionState } = await waitForExtension();
+    state = extensionState;
+
+    const runConfigServiceInstances = workspaceServices.getServiceInstances(runConfigService);
+    assert.strictEqual(runConfigServiceInstances.length, 1);
+    runConfigServiceInstance = runConfigServiceInstances[0];
+  });
+
+  after(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+  });
+
+  it('correctly generates the expected configurations', () => {
+    assert.deepStrictEqual(runConfigServiceInstance.appmapLaunchConfig, ExpectedLaunchConfig);
+    assert.deepStrictEqual(runConfigServiceInstance.appmapTestConfig, ExpectedTestConfig);
+  });
+
+  it('creates a new run configuration', async () => {
+    await waitFor('launch.json to be created', () =>
+      existsSync(path.join(ProjectJava, '.vscode', 'launch.json'))
+    );
+
+    let configs;
+    await waitFor('launch config to be created', () => {
+      const config = vscode.workspace.getConfiguration('launch');
+      configs = config.get('configurations');
+      return configs.length > 0;
+    });
+
+    assert.deepStrictEqual(configs, [runConfigServiceInstance.appmapLaunchConfig]);
+  });
+
+  it('saves that the launch config was created', () => {
+    assert(state.getUpdatedLaunchConfig(runConfigServiceInstance.folder));
+  });
+
+  it('does not create a new test configuration', () => {
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 0);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 0);
+  });
+
+  it('saves that the test config was not created', () => {
+    assert(!state.getUpdatedTestConfig(runConfigServiceInstance.folder));
+  });
+});

--- a/test/integration/runConfigs/runConfigsRuby.test.ts
+++ b/test/integration/runConfigs/runConfigsRuby.test.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { SinonSandbox, createSandbox, SinonStub, SinonSpy } from 'sinon';
+
+import { RunConfigServiceInstance } from '../../../src/services/runConfigService';
+import ExtensionState from '../../../src/configuration/extensionState';
+import { FakeConfig } from './util';
+import { ProjectA, initializeWorkspace, waitForExtension } from '../util';
+
+describe('run config service in a Ruby project', () => {
+  let sinon: SinonSandbox;
+  let runConfigServiceInstance: RunConfigServiceInstance;
+  let state: ExtensionState;
+  let fakeConfigGetSpy: SinonSpy;
+  let fakeConfigUpdateSpy: SinonSpy;
+  let getConfigStub: SinonStub;
+
+  before(async () => {
+    sinon = createSandbox();
+    sinon.stub(os, 'homedir').returns(ProjectA);
+
+    fakeConfigGetSpy = sinon.spy(FakeConfig, 'get');
+    fakeConfigUpdateSpy = sinon.spy(FakeConfig, 'update');
+    getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration');
+    getConfigStub.withArgs('java.test').returns(FakeConfig);
+    getConfigStub.withArgs('launch').returns(FakeConfig);
+    getConfigStub.callThrough();
+
+    const { workspaceServices, runConfigService, extensionState } = await waitForExtension();
+    state = extensionState;
+
+    const runConfigServiceInstances = workspaceServices.getServiceInstances(runConfigService);
+    assert.strictEqual(runConfigServiceInstances.length, 1);
+    runConfigServiceInstance = runConfigServiceInstances[0];
+  });
+
+  after(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+  });
+
+  it('does not create a new run configuration or test configuration', async () => {
+    assert(!existsSync(path.join(ProjectA, '.vscode', 'launch.json')));
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 0);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 0);
+  });
+
+  it('saves that the launch config was not created', () => {
+    assert(!state.getUpdatedLaunchConfig(runConfigServiceInstance.folder));
+  });
+
+  it('saves that the test config was not created', () => {
+    assert(!state.getUpdatedTestConfig(runConfigServiceInstance.folder));
+  });
+});

--- a/test/integration/runConfigs/util.ts
+++ b/test/integration/runConfigs/util.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+
+const expectedJarPath = path.join('${userHome}', '.appmap', 'lib', 'java', 'appmap.jar');
+
+export const FakeConfig = {
+  get() {
+    return [];
+  },
+  update() {
+    return;
+  },
+};
+
+export const ExpectedLaunchConfig = {
+  type: 'java',
+  name: 'Run with AppMap',
+  request: 'launch',
+  mainClass: '',
+  vmArgs: `-javaagent:${expectedJarPath}`,
+};
+
+export const ExpectedTestConfig = {
+  name: 'Test with AppMap',
+  vmArgs: [`-javaagent:${expectedJarPath}`],
+};

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -23,8 +23,9 @@ export const ProjectUptodate = join(
   __dirname,
   '../../../test/fixtures/workspaces/project-uptodate'
 );
+export const ProjectJava = join(__dirname, '../../../test/fixtures/workspaces/project-java');
 
-const PROJECTS = [ProjectA, ProjectUptodate];
+const PROJECTS = [ProjectA, ProjectUptodate, ProjectJava];
 
 export async function withTmpDir(fn: (tmpDir: string) => void | Promise<void>): Promise<void> {
   const tmpDir = await promisify(tmp.dir)();

--- a/test/system/tests/findings.test.ts
+++ b/test/system/tests/findings.test.ts
@@ -25,46 +25,4 @@ describe('Findings and scanning', function () {
     await driver.appMap.findingsTreeItem().waitFor();
     await driver.appMap.findingsTreeItem(1).waitFor();
   });
-
-  it('shows the findings overview page', async function () {
-    const { driver, project } = this;
-    const findingsOverviewWebview = driver.appMap['findingsOverviewWebview'];
-
-    await project.restoreFiles('**/*.appmap.json');
-    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
-
-    await driver.appMap.openActionPanel();
-    await driver.appMap.expandFindings();
-    await driver.appMap.openFindingsOverview();
-    const expectedFrames = 2;
-    await findingsOverviewWebview.initialize(expectedFrames);
-    await driver.appMap.findingsTreeItem(1).waitFor();
-    await findingsOverviewWebview.assertNumberOfFindingsInOverview(3);
-  });
-
-  it('opens the findings details page from the findings overview page', async function () {
-    const { driver, project } = this;
-
-    await project.restoreFiles('**/*.appmap.json');
-    await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
-
-    const findingsOverviewWebview = driver.appMap['findingsOverviewWebview'];
-    const findingDetailsWebview = driver.appMap['findingDetailsWebview'];
-
-    await driver.appMap.openActionPanel();
-    await driver.appMap.expandFindings();
-    await driver.appMap.openFindingsOverview();
-
-    let expectedFrames = 2;
-    await findingsOverviewWebview.initialize(expectedFrames);
-    await findingsOverviewWebview.assertTitleRenders();
-    await driver.appMap.findingsTreeItem(1).waitFor();
-    await findingsOverviewWebview.openFirstFindingDetail();
-
-    expectedFrames = 3;
-    await findingDetailsWebview.initialize(expectedFrames);
-
-    const expectedTitle = 'N plus 1 SQL query';
-    await findingDetailsWebview.assertTitleRenders(expectedTitle);
-  });
 });


### PR DESCRIPTION
Fixes getappmap/board#269

This PR helps Java users in VS Code.

* When the extension starts, the latest version of the appmap Java agent JAR will get downloaded to `$HOME/.appmap/java`. This will happen regardless of the language of the project. 

* When a user opens a project, the extension will create a new launch config in `.vscode/launch.json` called `Run with AppMap` that will launch their application with the appmap agent. For this to work, the user must have the [Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) installed. If they don't, then they will see this message when they attempt to use our launch configuration:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/294ccbab-327d-4fba-b2ec-aaff3e55b2bf)

* When a user opens a project, the extension will also check to see if they have the [Test Runner for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test) extension installed (it is part of the Extension Pack for Java). If the user does have it installed, then the extension will add a test config called `Test with AppMap`. If the user already has a test configuration, then when they attempt to run their tests, they will get a drop down menu:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/78dd4506-5296-44fb-abe8-0aef3b387530)

* Appmaps will be generated in `tmp/appmap`.

* The extension will only add a launch config once. If the user deletes the launch config, then the extension will not regenerate one. This is also true of the test config.
