### PR TITLE
feat: Ensure the latest cli version is used when installing agent in JS

### DIFF
--- a/src/commands/installAgent.ts
+++ b/src/commands/installAgent.ts
@@ -61,7 +61,7 @@ export function generateInstallInfo(
   const escapedStorageDir = escapePath(globalStorageDir);
   const installLocation = escapePath(path);
   const env = {};
-  let command = `npx @appland/appmap@latest install -d ${installLocation}`;
+  let command = `npx --prefer-online @appland/appmap@latest install -d ${installLocation}`;
 
   const isElectronApp = !vscode.env.remoteName;
   const canSendElectronComamnd = ELECTRON_COMMAND_PLATFORMS.includes(os.platform());

--- a/test/integration/command/installAgent.test.ts
+++ b/test/integration/command/installAgent.test.ts
@@ -50,7 +50,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, {});
         assert.strictEqual(
           command,
-          'npx @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory with a space"'
+          'npx --prefer-online @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory with a space"'
         );
       });
 
@@ -72,7 +72,7 @@ describe('generateInstallInfo function', () => {
       it('generates the correct command when there are no CLI binaries', () => {
         let { command, env } = generateInstallInfo(cwd, 'Ruby', false, globalStorageDir);
         const expected =
-          'npx @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory with a space"';
+          'npx --prefer-online @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory with a space"';
         assert.deepStrictEqual(env, {});
         assert.strictEqual(command, expected);
 
@@ -95,7 +95,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, {});
         assert.strictEqual(
           command,
-          'npx @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory-without-a-space"'
+          'npx --prefer-online @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory-without-a-space"'
         );
       });
 
@@ -117,7 +117,7 @@ describe('generateInstallInfo function', () => {
       it('generates the correct command when there are no CLI binaries', () => {
         let { command, env } = generateInstallInfo(cwd, 'Ruby', false, globalStorageDir);
         const expected =
-          'npx @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory-without-a-space"';
+          'npx --prefer-online @appland/appmap@latest install -d C:"\\Users\\user\\projects\\directory-without-a-space"';
         assert.deepStrictEqual(env, {});
         assert.strictEqual(command, expected);
 
@@ -152,7 +152,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, {});
         assert.strictEqual(
           command,
-          'npx @appland/appmap@latest install -d /home/user/projects/directory\\ with\\ spaces'
+          'npx --prefer-online @appland/appmap@latest install -d /home/user/projects/directory\\ with\\ spaces'
         );
       });
 
@@ -188,7 +188,7 @@ describe('generateInstallInfo function', () => {
         assert.deepStrictEqual(env, {});
         assert.strictEqual(
           command,
-          'npx @appland/appmap@latest install -d /home/user/projects/directory-without-spaces'
+          'npx --prefer-online @appland/appmap@latest install -d /home/user/projects/directory-without-spaces'
         );
       });
 


### PR DESCRIPTION
This is related to the discussion in https://github.com/getappmap/appmap-js/issues/1207