### PR TITLE
fix: Project language now reflects the preferred language

### DIFF
--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import AppMapEditorProvider from '../editor/appmapEditorProvider';
 import { hasPreviouslyInstalledExtension } from '../util';
 
 export const Keys = {
@@ -8,7 +7,6 @@ export const Keys = {
     INSTALL_TIMESTAMP: 'appmap.applandinc.installTimestamp',
     INSTALL_VERSION: 'appmap.applandinc.installVersion',
     ANALYSIS_CTA_DISMISSED: 'appmap.applandinc.analysisCTADismissed',
-    SEQ_DIAGRAM_FEEDBACK_REQUESTED: AppMapEditorProvider.SEQ_DIAGRAM_FEEDBACK_REQUESTED,
   },
   Workspace: {
     CONFIGURED_AGENT: 'appmap.applandinc.agentConfigured',

--- a/src/services/appmapWatcher.ts
+++ b/src/services/appmapWatcher.ts
@@ -22,18 +22,26 @@ export class AppMapWatcher
   async create(folder: vscode.WorkspaceFolder): Promise<AppMapWatcherInstance> {
     validateConfiguration();
 
+    // Sometimes its important to know if `onCreated` is firing due to the creation of a new
+    // AppMap, or if it's just firing because the watcher is being initialized. AppMaps present
+    // in the workspace when the watcher starts will all fire `onCreated` events.
+    let initializing = true;
+
     const watcher = new AppMapWatcherInstance(folder, {
       onChange: (uri, workspaceFolder) => {
         this._onChange.fire({ uri: appmapUri(uri), workspaceFolder });
       },
       onCreate: (uri, workspaceFolder) => {
-        this._onCreate.fire({ uri: appmapUri(uri), workspaceFolder });
+        this._onCreate.fire({ uri: appmapUri(uri), workspaceFolder, initializing });
       },
       onDelete: (uri, workspaceFolder) => {
         this._onDelete.fire({ uri: appmapUri(uri), workspaceFolder });
       },
     });
+
     await watcher.initialize();
+    initializing = false;
+
     return watcher;
   }
 }

--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -200,11 +200,6 @@ export const EXPORT_SVG = new Event({
   name: 'export_svg',
 });
 
-export const SEQ_DIAGRAM_FEEDBACK_CTA = new Event({
-  name: 'sequence_diagram_feedback_cta',
-  properties: [Properties.YES_NO_PROMPT, Properties.OPEN_EXTERNAL],
-});
-
 export const CLICKED_SIGN_IN_LINK = new Event({
   name: 'clicked_sign_in_link',
   properties: [Properties.LINK_TYPE],

--- a/test/integration/services/appmapWatcher.test.ts
+++ b/test/integration/services/appmapWatcher.test.ts
@@ -1,0 +1,18 @@
+import { assert } from 'console';
+import * as vscode from 'vscode';
+import { AppMapWatcher } from '../../../src/services/appmapWatcher';
+
+describe('WorkspaceService', () => {
+  it('informs the listener when it is initializing', async () => {
+    const service = new AppMapWatcher();
+    return new Promise((resolve) => {
+      service.onCreate((event) => {
+        assert(event.initializing === true);
+        resolve();
+      });
+
+      const workspaceFolder = vscode.workspace.workspaceFolders?.at(0) as vscode.WorkspaceFolder;
+      service.create(workspaceFolder);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where project language was being reported as an array of all languages present in the workspace folder. This presented an issue, because there was now no indication of what language the project would be defined as by the project picker.

Resolves #718 