### PR TITLE
feat: add flame graph setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,10 @@
         "appMap.commandLineToolsPath": {
           "type": "string",
           "description": "Location of AppMap command line tools (used for extension development only)"
+        },
+        "appMap.flamegraphEnabled": {
+          "type": "boolean",
+          "description": "Enable flamegraph diagram"
         }
       }
     },

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -45,4 +45,10 @@ export default class ExtensionSettings {
   public static async enableFindings(): Promise<void> {
     vscode.workspace.getConfiguration('appMap').update('findingsEnabled', true);
   }
+
+  public static get flamegraphEnabled(): boolean {
+    return [true, 'true'].includes(
+      vscode.workspace.getConfiguration('appMap').get('flamegraphEnabled') || false
+    );
+  }
 }

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -351,6 +351,7 @@ export default class AppMapEditorProvider
             shareEnabled: extensionSettings.shareEnabled,
             defaultView: extensionSettings.defaultDiagramView || 'viewSequence',
             savedFilters: this.context.workspaceState.get(AppMapEditorProvider.SAVED_FILTERS),
+            flamegraphEnabled: extensionSettings.flamegraphEnabled,
           });
           break;
         case 'appmapStateResult':

--- a/web/src/appmapView.js
+++ b/web/src/appmapView.js
@@ -11,11 +11,12 @@ export default function mountApp() {
   const messages = new MessagePublisher(vscode);
 
   messages.on('init-appmap', (initialData) => {
-    const { shareEnabled, defaultView, savedFilters } = initialData;
+    const { shareEnabled, defaultView, savedFilters, flamegraphEnabled } = initialData;
     const props = {
       appMapUploadable: shareEnabled,
       defaultView,
       savedFilters,
+      flamegraphEnabled,
     };
 
     const app = new Vue({


### PR DESCRIPTION
Add (again) the flamegraph extension flag. This has nothing to do with the bug that got introduced by importing conflicting d3 dependencies and caused the main panel to become unresponsive.