### PR TITLE
Java test config respects appmap_dir

### DIFF
--- a/src/commands/getAppmapDir.ts
+++ b/src/commands/getAppmapDir.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import { WorkspaceServices } from '../services/workspaceServices';
+import { AppmapConfigManager, AppmapConfigManagerInstance } from '../services/appmapConfigManager';
+
+export default async function getAppmapDir(
+  context: vscode.ExtensionContext,
+  workspaceServices: WorkspaceServices
+): Promise<void> {
+  const command = vscode.commands.registerCommand(
+    'appmap.getAppmapDir',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (arg: any): Promise<string> => {
+      const { cwd } = arg;
+      // AFAIK this will always have cwd, but we'll check just in case
+      if (!cwd) return 'tmp/appmap';
+
+      const uri = vscode.Uri.file(cwd);
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+      assert(workspaceFolder);
+
+      const configInstance = workspaceServices.getServiceInstanceFromClass(
+        AppmapConfigManager,
+        workspaceFolder
+      ) as AppmapConfigManagerInstance | undefined;
+      assert(configInstance);
+
+      const config = await configInstance.getAppmapConfig();
+      // TODO: determine project type and pick default based on that
+      if (!config) return 'tmp/appmap';
+
+      return config.appmapDir;
+    }
+  );
+
+  context.subscriptions.push(command);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ import AssetManager from './services/assetManager';
 import downloadLatestJavaJar from './commands/downloadLatestJavaJar';
 import IndexJanitor from './lib/indexJanitor';
 import { unregister as unregisterTerminal } from './commands/installer/terminals';
+import getAppmapDir from './commands/getAppmapDir';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   Telemetry.register(context);
@@ -275,6 +276,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     resetUsageState(context, extensionState);
     updateAppMapConfigs(context, runConfigService, workspaceServices);
     downloadLatestJavaJar(context);
+    getAppmapDir(context, workspaceServices);
 
     if (!openedInstallGuide && !SignInManager.shouldShowSignIn())
       promptInstall(workspaceServices, extensionState);

--- a/test/integration/runConfigs/runConfigsJava.test.ts
+++ b/test/integration/runConfigs/runConfigsJava.test.ts
@@ -6,7 +6,7 @@ import assert from 'assert';
 import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { SinonSandbox, createSandbox, SinonStub, SinonSpy } from 'sinon';
+import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
 
 import { RunConfigServiceInstance } from '../../../src/services/runConfigService';
 import ExtensionState from '../../../src/configuration/extensionState';
@@ -17,8 +17,6 @@ describe('run config service in a Java Project', () => {
   let sinon: SinonSandbox;
   let runConfigServiceInstance: RunConfigServiceInstance;
   let state: ExtensionState;
-  let fakeConfigGetSpy: SinonSpy;
-  let fakeConfigUpdateSpy: SinonSpy;
   let getConfigStub: SinonStub;
 
   before(async () => {
@@ -27,8 +25,6 @@ describe('run config service in a Java Project', () => {
 
     // This needs to be faked because the Test Runner for Java extension is not installed during testing
     // and VS Code will throw an error when attempting to update an unregistered config ("java.test.config")
-    fakeConfigGetSpy = sinon.spy(FakeConfig, 'get');
-    fakeConfigUpdateSpy = sinon.spy(FakeConfig, 'update');
     getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration');
     getConfigStub.withArgs('java.test').returns(FakeConfig);
     getConfigStub.callThrough();
@@ -71,22 +67,5 @@ describe('run config service in a Java Project', () => {
 
   it('saves that the launch config was created', () => {
     assert(state.getUpdatedLaunchConfig(runConfigServiceInstance.folder));
-  });
-
-  it('creates a new test configuration', async () => {
-    await waitFor(
-      'test config to be created',
-      () => state.getUpdatedTestConfig(runConfigServiceInstance.folder),
-      60000
-    );
-
-    // The settings.json file will not be created, but we can check that the correct function calls were made
-    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
-    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
-    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
-    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
-      'config',
-      [runConfigServiceInstance.appmapTestConfig],
-    ]);
   });
 });

--- a/test/integration/runConfigs/testConfigsJava.test.ts
+++ b/test/integration/runConfigs/testConfigsJava.test.ts
@@ -1,0 +1,167 @@
+// @project project-java
+
+import * as vscode from 'vscode';
+
+import assert from 'assert';
+import os from 'os';
+import path from 'path';
+import { SinonSandbox, createSandbox, SinonStub, SinonSpy } from 'sinon';
+
+import { RunConfigServiceInstance } from '../../../src/services/runConfigService';
+import ExtensionState from '../../../src/configuration/extensionState';
+import { ProjectJava, initializeWorkspace } from '../util';
+import { ProjectStateServiceInstance } from '../../../src/services/projectStateService';
+
+class MockExtensionState {
+  updatedTestConfig = false;
+  getUpdatedTestConfig(): boolean {
+    return this.updatedTestConfig;
+  }
+  setUpdatedTestConfig(_workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.updatedTestConfig = value;
+  }
+  getUpdatedLaunchConfig(): boolean {
+    return true;
+  }
+}
+
+class MockConfig {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data = [] as any;
+  get() {
+    return this.data;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  update(_section: string, value: any) {
+    this.data = value;
+  }
+}
+
+const fakeProjectState = {
+  onStateChange() {
+    // not implemented
+  },
+  metadata: {
+    language: {
+      name: 'Java',
+    },
+  },
+} as unknown;
+
+describe('test configs in a Java Project', () => {
+  let sinon: SinonSandbox;
+  let runConfigServiceInstance: RunConfigServiceInstance;
+  let getConfigStub: SinonStub;
+  let extensionState: ExtensionState;
+  let fakeConfigGetSpy: SinonSpy;
+  let fakeConfigUpdateSpy: SinonSpy;
+
+  const fakeConfig = new MockConfig();
+
+  beforeEach(async () => {
+    sinon = createSandbox();
+    sinon.stub(os, 'homedir').returns(ProjectJava);
+
+    fakeConfigGetSpy = sinon.spy(fakeConfig, 'get');
+    fakeConfigUpdateSpy = sinon.spy(fakeConfig, 'update');
+
+    const workspaceFolder: vscode.WorkspaceFolder = {
+      name: path.basename(ProjectJava),
+      uri: vscode.Uri.file(ProjectJava),
+      index: -1,
+    };
+    const mockExtensionState = new MockExtensionState() as unknown;
+    extensionState = mockExtensionState as ExtensionState;
+    runConfigServiceInstance = new RunConfigServiceInstance(
+      workspaceFolder,
+      fakeProjectState as ProjectStateServiceInstance,
+      extensionState
+    );
+
+    // Pretend that the Test Runner for Java extension is installed
+    sinon.stub(runConfigServiceInstance, 'hasJavaTestExtension').returns(true);
+
+    // This is tested in runConfigsJava.test.ts so we can ignore it here
+    sinon.stub(runConfigServiceInstance, 'updateLaunchConfig');
+
+    // This needs to be faked because the Test Runner for Java extension is not installed during testing
+    // and VS Code will throw an error when attempting to update an unregistered config ("java.test.config")
+    getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration');
+    getConfigStub.withArgs('java.test').returns(fakeConfig);
+    getConfigStub.callThrough();
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await initializeWorkspace();
+    fakeConfig.data = [];
+  });
+
+  it('correctly generates a test config', async () => {
+    await runConfigServiceInstance.updateConfigs();
+
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
+    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
+      'config',
+      [runConfigServiceInstance.appmapTestConfig],
+    ]);
+    assert.deepStrictEqual(fakeConfig.get(), [runConfigServiceInstance.appmapTestConfig]);
+  });
+
+  it('correctly generates a test config when another test config is already present', async () => {
+    const preexistingTestConfig = { name: 'Test' };
+    fakeConfig.data = [preexistingTestConfig];
+
+    await runConfigServiceInstance.updateConfigs();
+
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
+    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
+      'config',
+      [preexistingTestConfig, runConfigServiceInstance.appmapTestConfig],
+    ]);
+    assert.deepStrictEqual(fakeConfig.get(), [
+      preexistingTestConfig,
+      runConfigServiceInstance.appmapTestConfig,
+    ]);
+  });
+
+  it('does not add a test config if one was previously generated', async () => {
+    fakeConfig.data = [runConfigServiceInstance.appmapTestConfig];
+    extensionState.setUpdatedTestConfig({} as vscode.WorkspaceFolder, true);
+
+    await runConfigServiceInstance.updateConfigs();
+
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
+    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
+      'config',
+      [runConfigServiceInstance.appmapTestConfig],
+    ]);
+    assert.deepStrictEqual(fakeConfig.get(), [runConfigServiceInstance.appmapTestConfig]);
+  });
+
+  it('updates a previously added test config if it does not have the output dir vmArg', async () => {
+    const incompleteAppmapConfig = {
+      name: 'Test with AppMap',
+      vmArgs: ['-javaagent:${userHome}/.appmap/lib/java/appmap.jar'],
+    };
+    fakeConfig.data = [incompleteAppmapConfig];
+    extensionState.setUpdatedTestConfig({} as vscode.WorkspaceFolder, true);
+
+    await runConfigServiceInstance.updateConfigs();
+
+    assert.deepStrictEqual(fakeConfigGetSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigUpdateSpy.callCount, 1);
+    assert.deepStrictEqual(fakeConfigGetSpy.getCall(0).args[0], 'config');
+    assert.deepStrictEqual(fakeConfigUpdateSpy.getCall(0).args, [
+      'config',
+      [runConfigServiceInstance.appmapTestConfig],
+    ]);
+    assert.deepStrictEqual(fakeConfig.get(), [runConfigServiceInstance.appmapTestConfig]);
+  });
+});

--- a/test/integration/runConfigs/util.ts
+++ b/test/integration/runConfigs/util.ts
@@ -21,5 +21,8 @@ export const ExpectedLaunchConfig = {
 
 export const ExpectedTestConfig = {
   name: 'Test with AppMap',
-  vmArgs: [`-javaagent:${expectedJarPath}`],
+  vmArgs: [
+    `-javaagent:${expectedJarPath}`,
+    '-Dappmap.output.directory=${command:appmap.getAppmapDir}',
+  ],
 };


### PR DESCRIPTION
Fixes #730

- [x] When a test config is created, a vmArg is added that specifies the output directory based on the current value of `appmap_dir` in `appmap.yml`
- [x] Checks whether there is a `Test with AppMap` test config without the required `-Dappmap.output.directory` vmArg and adds the vmArg if it is not present.
- [x] If there is no `appmap_dir` in `appmap.yml` then the default is `target/appmap`.
- [x] Also, removes the intermittently failing test `creates a new test config` and adds an equivalent unit test in
`runConfigs/testConfigsJava.test.ts`.