### PR TITLE
Remote recording respects `appmap_dir` in `appmap.yml`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,15 @@
       }
     },
     {
+      "name": "Unit tests",
+      "args": ["--timeout", "999999", "--colors", "${workspaceFolder}/test/unit/**/**.test.[tj]s"],
+      "internalConsoleOptions": "openOnSessionStart",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "name": "Integration test",
       "type": "extensionHost",
       "request": "launch",

--- a/package.json
+++ b/package.json
@@ -214,11 +214,6 @@
     "configuration": {
       "title": "AppMap",
       "properties": {
-        "appMap.recordingOutputDirectory": {
-          "type": "string",
-          "default": "",
-          "description": "Path for remote recordings"
-        },
         "appMap.applandUrl": {
           "type": "string",
           "default": "https://app.land",

--- a/src/actions/remoteRecording.ts
+++ b/src/actions/remoteRecording.ts
@@ -116,7 +116,7 @@ export default class RemoteRecording {
     this.addRecentUrl(recordingUrl);
   }
 
-  private async stop(url: string): Promise<boolean> {
+  public async stop(url: string): Promise<boolean> {
     let isFinished = false;
     if (!url) {
       // We'll consider this a valid case - no error is thrown.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,7 +259,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     appmapLinkProvider();
     const editorProvider = AppMapEditorProvider.register(context, extensionState);
-    RemoteRecording.register(context);
+    RemoteRecording.register(context, workspaceServices);
     ContextMenu.register(context, projectStates, appmapCollectionFile);
 
     generateOpenApi(context, extensionState);

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -3,7 +3,6 @@ import { GenerateOpenApi } from '../commands/generateOpenApi';
 import { InstallAgent } from '../commands/installAgent';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import { COPY_COMMAND, OPEN_VIEW, Telemetry } from '../telemetry';
-import { getWorkspaceFolderFromPath } from '../util';
 import ProjectMetadata from '../workspace/projectMetadata';
 import ExtensionState from '../configuration/extensionState';
 import { DocPageId, ProjectPicker, RecordAppMaps } from '../tree/instructionsTreeDataProvider';

--- a/test/unit/actions/remoteRecording.test.ts
+++ b/test/unit/actions/remoteRecording.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import mockVscode from '../mock/vscode';
+
+import assert from 'assert';
+import { SinonSandbox, createSandbox } from 'sinon';
+
+import RemoteRecording from '../../../src/actions/remoteRecording';
+import RemoteRecordingClient from '../../../src/actions/remoteRecordingClient';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+
+describe('remote recording', () => {
+  let sinon: SinonSandbox;
+  let remoteRecording: RemoteRecording;
+  let tmpDir: string;
+  let mockWorkspaceServices: any;
+  let mockWorkspaceFolder: any;
+  let mockedMap: any;
+
+  beforeEach(() => {
+    sinon = createSandbox();
+    tmpDir = path.join(tmpdir(), randomUUID());
+
+    const mockContext = {
+      subscriptions: [],
+    } as any;
+
+    mockWorkspaceServices = {
+      getServiceInstanceFromClass() {
+        return;
+      },
+    };
+
+    mockWorkspaceFolder = {
+      uri: {
+        fsPath: tmpDir,
+      },
+    };
+
+    mockedMap = { metadata: {} };
+
+    remoteRecording = new RemoteRecording(mockContext, mockWorkspaceServices);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false on command stop with a 404 response', async () => {
+    sinon.stub(RemoteRecordingClient, 'stop').resolves({ statusCode: 404 });
+    const response = await remoteRecording.stop('http://localhost:8080/');
+    assert(!response);
+  });
+
+  it('returns false on command stop with no appmap name', async () => {
+    sinon.stub(mockVscode.window, 'showInputBox').resolves('');
+    const response = await remoteRecording.stop('http://localhost:8080/');
+    assert(!response);
+  });
+
+  it('uses appmap_dir as the output folder', async () => {
+    const expectedName = 'test_map_name';
+    const mockConfigManager = {
+      getAppmapConfig() {
+        return {
+          appmapDir: 'fake/appmap',
+        };
+      },
+    };
+
+    sinon.stub(RemoteRecordingClient, 'stop').resolves({ statusCode: 200, body: mockedMap });
+    sinon.stub(mockVscode.workspace, 'workspaceFolders').value([mockWorkspaceFolder]);
+    sinon.stub(mockVscode.window, 'showInputBox').returns(expectedName);
+    sinon.stub(mockWorkspaceServices, 'getServiceInstanceFromClass').returns(mockConfigManager);
+
+    const response = await remoteRecording.stop('http://localhost:8080/');
+
+    assert(response);
+    assert.strictEqual(mockedMap.metadata.name, expectedName);
+    assert(
+      existsSync(path.join(tmpDir, 'fake', 'appmap', 'recordings', expectedName + '.appmap.json'))
+    );
+    assert(!existsSync(path.join(tmpDir, 'tmp', 'appmap', 'recordings')));
+    assert(!existsSync(path.join(tmpDir, 'build', 'appmap', 'recordings')));
+    assert(!existsSync(path.join(tmpDir, 'target', 'appmap', 'recordings')));
+  });
+
+  it('uses tmp/appmap as the output folder if there is no appmap_dir', async () => {
+    const expectedName = 'test_map_name';
+
+    sinon.stub(RemoteRecordingClient, 'stop').resolves({ statusCode: 200, body: mockedMap });
+    sinon.stub(mockVscode.workspace, 'workspaceFolders').value([mockWorkspaceFolder]);
+    sinon.stub(mockVscode.window, 'showInputBox').returns(expectedName);
+
+    const response = await remoteRecording.stop('http://localhost:8080/');
+
+    assert(response);
+    assert.strictEqual(mockedMap.metadata.name, expectedName);
+    assert(
+      existsSync(path.join(tmpDir, 'tmp', 'appmap', 'recordings', expectedName + '.appmap.json'))
+    );
+    assert(!existsSync(path.join(tmpDir, 'build', 'appmap', 'recordings')));
+    assert(!existsSync(path.join(tmpDir, 'target', 'appmap', 'recordings')));
+  });
+
+  it('uses build/appmap as the output folder if it exists and there is no appmap_dir', async () => {
+    mkdirSync(path.join(tmpDir, 'build', 'appmap'), { recursive: true });
+    const expectedName = 'test_map_name';
+
+    sinon.stub(RemoteRecordingClient, 'stop').resolves({ statusCode: 200, body: mockedMap });
+    sinon.stub(mockVscode.workspace, 'workspaceFolders').value([mockWorkspaceFolder]);
+    sinon.stub(mockVscode.window, 'showInputBox').returns(expectedName);
+
+    const response = await remoteRecording.stop('http://localhost:8080/');
+
+    assert(response);
+    assert.strictEqual(mockedMap.metadata.name, expectedName);
+    assert(
+      existsSync(path.join(tmpDir, 'build', 'appmap', 'recordings', expectedName + '.appmap.json'))
+    );
+    assert(!existsSync(path.join(tmpDir, 'tmp', 'appmap', 'recordings')));
+    assert(!existsSync(path.join(tmpDir, 'target', 'appmap', 'recordings')));
+  });
+
+  it('uses target/appmap as the output folder if the config does not have an appmap_dir and target/appmap exists', async () => {
+    mkdirSync(path.join(tmpDir, 'target', 'appmap'), { recursive: true });
+    const expectedName = 'test_map_name';
+    const mockConfigManager = {
+      getAppmapConfig() {
+        return {};
+      },
+    };
+
+    sinon.stub(RemoteRecordingClient, 'stop').resolves({ statusCode: 200, body: mockedMap });
+    sinon.stub(mockVscode.workspace, 'workspaceFolders').value([mockWorkspaceFolder]);
+    sinon.stub(mockVscode.window, 'showInputBox').returns(expectedName);
+    sinon.stub(mockWorkspaceServices, 'getServiceInstanceFromClass').returns(mockConfigManager);
+
+    const response = await remoteRecording.stop('http://localhost:8080/');
+
+    assert(response);
+    assert.strictEqual(mockedMap.metadata.name, expectedName);
+    assert(
+      existsSync(path.join(tmpDir, 'target', 'appmap', 'recordings', expectedName + '.appmap.json'))
+    );
+    assert(!existsSync(path.join(tmpDir, 'tmp', 'appmap', 'recordings')));
+    assert(!existsSync(path.join(tmpDir, 'build', 'appmap', 'recordings')));
+  });
+});

--- a/test/unit/mock/vscode/commands.ts
+++ b/test/unit/mock/vscode/commands.ts
@@ -1,0 +1,5 @@
+export default {
+  executeCommand() {
+    return;
+  },
+};

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -12,7 +12,10 @@ const MockVSCode = {
   workspace,
 };
 
+class mockTelemetry {}
+
 mockery.registerMock('vscode', MockVSCode);
+mockery.registerMock('vscode-extension-telemetry', mockTelemetry);
 mockery.enable({ warnOnUnregistered: false });
 
 export default MockVSCode;

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -3,13 +3,20 @@ import mockery from 'mockery';
 import EventEmitter from './EventEmitter';
 import * as extensions from './extensions';
 import { URI, Utils } from 'vscode-uri';
-import * as workspace from './workspace';
+import workspace from './workspace';
+import window from './window';
+import commands from './commands';
 
 const MockVSCode = {
   EventEmitter,
   extensions,
   Uri: { ...URI, ...Utils },
   workspace,
+  window,
+  commands,
+  StatusBarAlignment: {
+    Left: '',
+  },
 };
 
 class mockTelemetry {}

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -1,0 +1,19 @@
+export default {
+  createStatusBarItem() {
+    return {
+      show() {
+        return '';
+      },
+    };
+  },
+  showInputBox() {
+    return '';
+  },
+  showErrorMessage() {
+    return;
+  },
+  showInformationMessage() {
+    return;
+  },
+  workspaceFolders: [],
+};

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -4,8 +4,7 @@ const unimplemented = () => {
   throw new Error('unimplemented');
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const fs: typeof workspace.fs = {
+const fs: typeof workspace.fs = {
   copy: unimplemented,
   createDirectory: unimplemented,
   delete: unimplemented,
@@ -15,4 +14,12 @@ export const fs: typeof workspace.fs = {
   rename: unimplemented,
   stat: unimplemented,
   writeFile: unimplemented,
+};
+
+export default {
+  fs,
+  getConfiguration() {
+    return;
+  },
+  workspaceFolders: [],
 };


### PR DESCRIPTION
Fixes #734

This PR makes it so that the AppMaps generated in a remote recording are stored in the `appmap_dir` specified in the `appmap.yml` configuration file. 

As discussed recently, we want to move away from the VS Code integration tests and towards unit tests, so the tests for the changes in this PR are unit tests. Also, a launch config was added for the unit tests, so that breakpoints can be used when writing/debugging unit tests.