### PR TITLE
Open appmap sign-in on installation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,6 +292,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     await AnalysisManager.register(context, projectStates, extensionState, workspaceServices);
 
+    vscode.commands.executeCommand('appmap.views.signIn.focus');
+
     return {
       editorProvider,
       localAppMaps: appmapCollectionFile,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,7 +292,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     await AnalysisManager.register(context, projectStates, extensionState, workspaceServices);
 
-    vscode.commands.executeCommand('appmap.views.signIn.focus');
+    if (extensionState.isNewInstall) vscode.commands.executeCommand('appmap.views.signIn.focus');
 
     return {
       editorProvider,


### PR DESCRIPTION
Fixes #742 

This change makes it so that the appmap sidebar is opened to the sign-in page when the extension is installed. 

If the user is already signed-in, then the sign-in page won't be visible and the command will do nothing.