### PR TITLE
AppMaps are organized by workspace in tree view

### DIFF
--- a/test/integration/appmaps/appmapsTree.test.ts
+++ b/test/integration/appmaps/appmapsTree.test.ts
@@ -8,29 +8,38 @@ describe('AppMaps', () => {
   beforeEach(waitForExtension);
   afterEach(initializeWorkspace);
 
-  it('is a two-level tree', async () => {
+  it('is a three-level tree', async () => {
     const trees = (await waitForExtension()).trees;
 
     const appmapsTree = trees.appmaps;
 
     await waitFor(
-      `AppMaps tree first root should be 'minitest'`,
+      `AppMaps tree first root should be 'project-a'`,
       () =>
         appmapsTree
           .getChildren()
           .map((root) => root.name)
           .sort()
-          .shift() === 'minitest'
+          .shift() === 'project-a'
     );
-    const minitests = appmapsTree.getChildren()[0];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const projectA = appmapsTree.getChildren()[0] as any;
+
+    await waitFor(
+      `'project-a' should contain one child`,
+      () => appmapsTree.getChildren(projectA).length === 1
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const minitest = appmapsTree.getChildren(projectA)[0] as any;
 
     await waitFor(
       `'minitest' should contain two children`,
-      () => appmapsTree.getChildren(minitests)?.length === 2
+      () => appmapsTree.getChildren(minitest)?.length === 2
     );
 
-    const appmaps = appmapsTree.getChildren(minitests);
-    assert(appmaps, `No appmaps for ${minitests.name}`);
+    const appmaps = appmapsTree.getChildren(minitest);
+    assert(appmaps, `No appmaps for ${minitest.name}`);
     assert.deepStrictEqual(
       appmaps.map((appmap) => appmap.descriptor.metadata?.name),
       [


### PR DESCRIPTION
Fixes #744 

Using a workspace with both `spring-petclinic` and `sample_app_6th_ed` open:

Before:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/e6c47118-37c8-4ff0-9541-adbb0d12f187)


After:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/0d4d6a23-5e1b-4572-babb-90f4712db958)
