### PR TITLE
AppMap deletion bug fixes

### DIFF
--- a/src/commands/deleteAllAppMaps.ts
+++ b/src/commands/deleteAllAppMaps.ts
@@ -6,9 +6,11 @@ import { AppmapConfigManager } from '../services/appmapConfigManager';
 import { workspaceServices } from '../services/workspaceServices';
 import assert from 'assert';
 import { join } from 'path';
+import AppMapCollection from '../services/appmapCollection';
 
 export default function deleteAllAppMaps(
   context: vscode.ExtensionContext,
+  appMapCollection: AppMapCollection,
   classMapIndex?: ClassMapIndex
 ): void {
   async function deleteWorkspaceAppMaps(folder: vscode.WorkspaceFolder) {
@@ -24,7 +26,7 @@ export default function deleteAllAppMaps(
       return;
     }
 
-    await deleteAppMaps(join(folder.uri.fsPath, appmapDir));
+    await deleteAppMaps(join(folder.uri.fsPath, appmapDir), appMapCollection);
   }
 
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     const classMapIndex = new ClassMapIndex();
     const lineInfoIndex = new LineInfoIndex(classMapIndex);
 
-    deleteAllAppMaps(context, classMapIndex);
+    deleteAllAppMaps(context, appmapCollectionFile, classMapIndex);
 
     const classMapProvider = new ClassMapTreeDataProvider(classMapIndex);
     const codeObjectsTree = vscode.window.createTreeView('appmap.views.codeObjects', {

--- a/src/lib/deleteAppMaps.ts
+++ b/src/lib/deleteAppMaps.ts
@@ -2,15 +2,19 @@ import * as vscode from 'vscode';
 import deleteAppMap from './deleteAppMap';
 import { promisify } from 'util';
 import { glob } from 'glob';
+import AppMapCollection from '../services/appmapCollection';
 
-export default async function deleteAppMaps(path: string): Promise<number> {
+export default async function deleteAppMaps(
+  path: string,
+  appMapCollection: AppMapCollection
+): Promise<number> {
   // Use glob instead of the vscode find facility to bypass the find exclusion rules
   // that might hide the AppMaps we are looking for.
   const appmapFiles = (await promisify(glob)(`${path}/**/*.appmap.json`)).map((path) =>
     vscode.Uri.file(path)
   );
 
-  await Promise.all(appmapFiles.map(deleteAppMap.bind(null)));
+  await Promise.all(appmapFiles.map((uri) => deleteAppMap(uri, appMapCollection)));
 
   return appmapFiles.length;
 }

--- a/src/lib/deleteFolderAppMaps.ts
+++ b/src/lib/deleteFolderAppMaps.ts
@@ -1,6 +1,7 @@
 import AppMapCollection from '../services/appmapCollection';
 import deleteAppMap from './deleteAppMap';
 import { AppMapTreeDataProvider } from '../tree/appMapTreeDataProvider';
+import * as vscode from 'vscode';
 
 export default async function deleteFolderAppMaps(
   appmaps: AppMapCollection,
@@ -8,7 +9,11 @@ export default async function deleteFolderAppMaps(
 ): Promise<number> {
   const filteredAppMaps = appmaps.appMaps().filter((appmap) => {
     const folderProperties = AppMapTreeDataProvider.appMapFolderItems(appmap);
-    return AppMapTreeDataProvider.folderName(folderProperties) === folderName;
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(appmap.descriptor.resourceUri);
+    return (
+      AppMapTreeDataProvider.folderName(folderProperties) === folderName ||
+      workspaceFolder?.name === folderName
+    );
   });
   await Promise.all(
     filteredAppMaps.map((appmap) => deleteAppMap(appmap.descriptor.resourceUri, appmaps))

--- a/src/lib/deleteFolderAppMaps.ts
+++ b/src/lib/deleteFolderAppMaps.ts
@@ -10,6 +10,8 @@ export default async function deleteFolderAppMaps(
     const folderProperties = AppMapTreeDataProvider.appMapFolderItems(appmap);
     return AppMapTreeDataProvider.folderName(folderProperties) === folderName;
   });
-  await Promise.all(filteredAppMaps.map((appmap) => deleteAppMap(appmap.descriptor.resourceUri)));
+  await Promise.all(
+    filteredAppMaps.map((appmap) => deleteAppMap(appmap.descriptor.resourceUri, appmaps))
+  );
   return filteredAppMaps.length;
 }

--- a/src/services/appmapCollection.ts
+++ b/src/services/appmapCollection.ts
@@ -1,5 +1,6 @@
 import { Event, WorkspaceFolder } from 'vscode';
 import AppMapLoader from './appmapLoader';
+import * as vscode from 'vscode';
 
 export default interface AppMapCollection {
   readonly onUpdated: Event<WorkspaceFolder | undefined>;
@@ -15,4 +16,6 @@ export default interface AppMapCollection {
   appMaps(): AppMapLoader[];
 
   allAppMapsForWorkspaceFolder(workspaceFolder: WorkspaceFolder): AppMapLoader[];
+
+  has(uri: vscode.Uri): boolean;
 }

--- a/src/services/appmapCollectionFile.ts
+++ b/src/services/appmapCollectionFile.ts
@@ -136,4 +136,8 @@ export default class AppMapCollectionFile implements AppMapCollection, AppMapsSe
       appmap.descriptor.resourceUri.fsPath.startsWith(workspaceFolder.uri.fsPath)
     );
   }
+
+  public has(uri: vscode.Uri): boolean {
+    return this.loaders.has(uri.fsPath);
+  }
 }

--- a/src/tree/contextMenu.ts
+++ b/src/tree/contextMenu.ts
@@ -72,7 +72,7 @@ export default class ContextMenu {
     );
     context.subscriptions.push(
       vscode.commands.registerCommand('appmap.context.deleteAppMap', async (item: AppMapLoader) => {
-        await deleteAppMap(item.descriptor.resourceUri);
+        await deleteAppMap(item.descriptor.resourceUri, appmaps);
       })
     );
     context.subscriptions.push(

--- a/test/integration/lib/indexJanitor.test.ts
+++ b/test/integration/lib/indexJanitor.test.ts
@@ -1,22 +1,35 @@
 import * as vscode from 'vscode';
-import { initializeWorkspace, waitFor, waitForIndexer, withAuthenticatedUser } from '../util';
+import {
+  initializeWorkspace,
+  waitFor,
+  waitForExtension,
+  waitForIndexer,
+  withAuthenticatedUser,
+} from '../util';
 import { pathExists } from 'fs-extra';
+import type AppMapService from '../../../src/appMapService';
 
 describe('AppMapIndex', () => {
   withAuthenticatedUser();
 
+  let extension: AppMapService;
+
   beforeEach(initializeWorkspace);
   beforeEach(waitForIndexer);
+  beforeEach(async () => (extension = await waitForExtension()));
   afterEach(initializeWorkspace);
 
-  // TODO: Restore this test once the IndexJanitor has been fixed or this test has been fixed.
-  xit('cleans up index directories', async () => {
+  it('cleans up index directories', async () => {
     const appmapFiles = await vscode.workspace.findFiles(`tmp/appmap/**/*.appmap.json`);
     const indexDirs = appmapFiles.map(({ fsPath }) => fsPath.replace(/\.appmap\.json$/, ''));
 
     await waitFor(`AppMaps have not all been indexed`, async () => {
       const mtimeFiles = await vscode.workspace.findFiles(`tmp/appmap/**/mtime`);
       return mtimeFiles.length === appmapFiles.length;
+    });
+
+    await waitFor(`AppMaps have not yet been acknowledged by the extension`, async () => {
+      return extension.localAppMaps.appMaps().length === appmapFiles.length;
     });
 
     vscode.commands.executeCommand('appmap.deleteAllAppMaps');

--- a/test/unit/lib/deleteAppMap.test.ts
+++ b/test/unit/lib/deleteAppMap.test.ts
@@ -1,0 +1,51 @@
+import { default as chai, expect } from 'chai';
+import { default as chaiFs } from 'chai-fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import '../mock/vscode';
+import { promises as fs } from 'fs';
+import type AppMapCollection from '../../../src/services/appmapCollection';
+import { URI } from 'vscode-uri';
+import deleteAppMap from '../../../src/lib/deleteAppMap';
+
+chai.use(chaiFs);
+
+describe('deleteAppMap', () => {
+  let tmpDir: string;
+  let indexDir: string;
+  let appMapUri: URI;
+
+  beforeEach(async () => {
+    tmpDir = path.join(tmpdir(), randomUUID());
+    indexDir = path.join(tmpDir, 'test');
+    appMapUri = URI.file(path.join(tmpDir, 'test.appmap.json'));
+
+    await fs.mkdir(indexDir, { recursive: true });
+    await fs.writeFile(appMapUri.fsPath, '{}');
+  });
+
+  afterEach(() => fs.rm(tmpDir, { recursive: true, force: true }));
+
+  it('retains the index directory if the AppMap is already known to the collection', async () => {
+    const mockCollection = {
+      has: () => true,
+    } as unknown as AppMapCollection;
+
+    await deleteAppMap(appMapUri, mockCollection);
+
+    expect(indexDir).to.be.a.directory();
+    expect(appMapUri.fsPath).to.not.be.a.path();
+  });
+
+  it('deletes the index directory if the AppMap has not yet been acknowledged by the collection', async () => {
+    const mockCollection = {
+      has: () => false,
+    } as unknown as AppMapCollection;
+
+    await deleteAppMap(appMapUri, mockCollection);
+
+    expect(indexDir).to.not.be.a.path();
+    expect(appMapUri.fsPath).to.not.be.a.path();
+  });
+});

--- a/test/unit/lib/deleteFolderAppMaps.test.ts
+++ b/test/unit/lib/deleteFolderAppMaps.test.ts
@@ -1,0 +1,58 @@
+import { default as chai, expect } from 'chai';
+import { default as chaiFs } from 'chai-fs';
+import sinonChai from 'sinon-chai';
+import { tmpdir } from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import '../mock/vscode';
+import { promises as fs } from 'fs';
+import type AppMapCollection from '../../../src/services/appmapCollection';
+import { URI } from 'vscode-uri';
+import deleteFolderAppMaps from '../../../src/lib/deleteFolderAppMaps';
+import Sinon from 'sinon';
+import MockVSCode from '../mock/vscode';
+
+chai.use(chaiFs);
+chai.use(sinonChai);
+
+describe('deleteFolderAppMaps', () => {
+  let projectName: string;
+  let projectDir: string;
+  let indexDir: string;
+  let appMapUri: URI;
+  let sandbox: Sinon.SinonSandbox;
+  let mockCollection: AppMapCollection;
+
+  beforeEach(async () => {
+    sandbox = Sinon.createSandbox();
+    projectName = randomUUID();
+    projectDir = path.join(tmpdir(), projectName);
+    indexDir = path.join(projectDir, 'test');
+    appMapUri = URI.file(path.join(projectDir, 'test.appmap.json'));
+    mockCollection = {
+      appMaps: () => [{ descriptor: { resourceUri: appMapUri } }],
+      has: () => true,
+    } as unknown as AppMapCollection;
+
+    await fs.mkdir(indexDir, { recursive: true });
+    await fs.writeFile(appMapUri.fsPath, '{}');
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+    sandbox.restore();
+  });
+
+  it('deletes AppMaps by project', async () => {
+    const getWorkspaceFolder = Sinon.stub(MockVSCode.workspace, 'getWorkspaceFolder')
+      .withArgs(appMapUri)
+      .returns({ uri: URI.file(projectDir), name: projectName, index: 0 });
+
+    expect(appMapUri.fsPath).to.be.a.file();
+
+    await deleteFolderAppMaps(mockCollection, projectName);
+
+    expect(getWorkspaceFolder).to.have.been.calledOnce;
+    expect(appMapUri.fsPath).to.not.be.a.path();
+  });
+});

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -27,6 +27,7 @@ const MockVSCode = {
   commands,
   StatusBarAlignment,
   env,
+  TreeItem: class {},
   UIKind,
 };
 

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -1,5 +1,8 @@
 /* eslint @typescript-eslint/naming-convention: 0 */
-import type { workspace } from 'vscode';
+/* eslint @typescript-eslint/no-unused-vars: 0 */
+
+import type { workspace, WorkspaceFolder } from 'vscode';
+import type { URI } from 'vscode-uri';
 
 const unimplemented = () => {
   throw new Error('unimplemented');
@@ -22,4 +25,5 @@ export default {
   getConfiguration: () => new Map<string, unknown>(),
   workspaceFolders: [],
   onDidChangeConfiguration: () => () => unimplemented,
+  getWorkspaceFolder: (_uri: URI): WorkspaceFolder | undefined => undefined,
 };


### PR DESCRIPTION
This PR addresses two issues with deleting AppMaps:

1. When right clicking on a project within the 'AppMaps' sidebar tree, the 'Delete AppMaps' option would do nothing. This has been resolved.
  ![Peek 2023-07-07 17-37](https://github.com/getappmap/vscode-appland/assets/8737782/47162a8a-883d-495c-a397-5ca2b4525704)


3. When using the `deleteAppMap` function, it was possible for empty index directories to be left behind. If an AppMap wasn't acknowledged through a file system event, the IndexJanitor would fail to clean up any index directories. With this fix, such directories will be deleted immediately if they've yet to be imported into the AppMap collection.
  ![image](https://github.com/getappmap/vscode-appland/assets/8737782/5e3582bd-1522-4ef2-8c19-5e97a767da1f)
