### PR TITLE
Update java jar instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -499,7 +499,7 @@
   "dependencies": {
     "@appland/appmap": "^3.80.2",
     "@appland/client": "^1.7.0",
-    "@appland/components": "^2.58.0",
+    "@appland/components": "^2.58.1",
     "@appland/diagrams": "^1.7.0",
     "@appland/models": "^2.6.3",
     "@appland/scanner": "^1.79.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,9 +137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^2.58.0":
-  version: 2.58.0
-  resolution: "@appland/components@npm:2.58.0"
+"@appland/components@npm:^2.58.1":
+  version: 2.58.1
+  resolution: "@appland/components@npm:2.58.1"
   dependencies:
     "@appland/diagrams": ^1.7.0
     "@appland/models": ^2.6.3
@@ -153,7 +153,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.14
     vuex: ^3.6.0
-  checksum: b367e9fb994929992eae7e74033f0ce79fcd16d2ab389af67f681ba01b86a7c351a18a5d9e4305fb1b9119132b2f8cb78bf44bf4efcb8b7009d32359563ed0e9
+  checksum: 6af690f0e2ca9a9af4370494c44f2d6baa723a9b45672247fdd0a1ab3b78617cadd88cb43c7d311e6a049c20551369bfc538fa65ad6d62635f6593505a718737
   languageName: node
   linkType: hard
 
@@ -2648,7 +2648,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.80.2
     "@appland/client": ^1.7.0
-    "@appland/components": ^2.58.0
+    "@appland/components": ^2.58.1
     "@appland/diagrams": ^1.7.0
     "@appland/models": ^2.6.3
     "@appland/scanner": ^1.79.0


### PR DESCRIPTION
Fixes #775 

Upgrade `@appland/components` to 2.58.1 to fix the instructions, which previously incorrectly specified the JVM arg to include the java agent.