### PR TITLE
Index receives api key

### DIFF
--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ChildProcess, OutputStream, spawn, SpawnOptions } from './nodeDependencyProcess';
+import { getApiKey } from '../authentication';
 
 export type RetryOptions = {
   // The number of retries made before declaring the process as failed.
@@ -178,8 +179,17 @@ export class ProcessWatcher implements vscode.Disposable {
     }
   }
 
+  async accessToken(): Promise<string | undefined> {
+    return getApiKey(false);
+  }
+
   protected async loadEnvironment(): Promise<NodeJS.ProcessEnv> {
-    return {};
+    const env = {} as NodeJS.ProcessEnv;
+    const accessToken = await this.accessToken();
+    if (accessToken) {
+      env.APPMAP_API_KEY = accessToken;
+    }
+    return env;
   }
 
   dispose(): void {

--- a/src/services/scanProcessWatcher.ts
+++ b/src/services/scanProcessWatcher.ts
@@ -1,4 +1,3 @@
-import { getApiKey } from '../authentication';
 import { NodeProcessService } from './nodeProcessService';
 import { ConfigFileProvider, ProcessId, ProcessWatcher } from './processWatcher';
 
@@ -28,18 +27,5 @@ export default class ScanProcessWatcher extends ProcessWatcher {
       return { enabled: false, reason: 'User is not logged in to AppMap' };
 
     return { enabled: true };
-  }
-
-  async accessToken(): Promise<string | undefined> {
-    return getApiKey(false);
-  }
-
-  protected async loadEnvironment(): Promise<NodeJS.ProcessEnv> {
-    const env = await super.loadEnvironment();
-    const accessToken = await this.accessToken();
-    if (accessToken) {
-      env.APPMAP_API_KEY = accessToken;
-    }
-    return env;
   }
 }

--- a/test/unit/services/processWatcher.test.ts
+++ b/test/unit/services/processWatcher.test.ts
@@ -12,6 +12,8 @@ import {
   ProcessWatcher,
   ProcessWatcherOptions,
 } from '../../../src/services/processWatcher';
+import * as auth from '../../../src/authentication/index';
+
 const testModule = join(__dirname, 'support', 'simpleProcess.mjs');
 
 function makeWatcher(opts: Partial<ProcessWatcherOptions> = {}) {
@@ -32,6 +34,10 @@ function makeWatcher(opts: Partial<ProcessWatcherOptions> = {}) {
 }
 
 describe('ProcessWatcher', () => {
+  before(() => {
+    sinon.stub(auth, 'getApiKey').resolves('fakeApiKey');
+  });
+
   describe('stop', () => {
     it('does not send error event', async () => {
       const watcher = makeWatcher();


### PR DESCRIPTION
Fixes #784 

This PR makes it so that when `index --watch` or `scan --watch` is executed from the VS Code extension, the `APPMAP_API_KEY` is set as an environment variable.