### PR TITLE
Require all users to sign in

### DIFF
--- a/src/commands/tryOpenInstallGuide.ts
+++ b/src/commands/tryOpenInstallGuide.ts
@@ -11,7 +11,7 @@ export default function tryOpenInstallGuide(extensionState: ExtensionState): vsc
       // time of installation. We will use this to determine whether or not our UX improvements are effective, without
       // before rolling them out to our existing user base.
 
-      if (!extensionState.hasViewedInstallGuide && !SignInManager.shouldShowSignIn()) {
+      if (!extensionState.hasViewedInstallGuide && SignInManager.signedIn) {
         extensionState.hasViewedInstallGuide = true;
         await vscode.commands.executeCommand('appmap.openInstallGuide', 'project-picker');
         return true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     openCodeObjectInAppMap(context, appmapCollectionFile, classMapIndex);
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register();
     const signInWebview = new SignInViewProvider(context);
     context.subscriptions.push(
       vscode.window.registerWebviewViewProvider(SignInViewProvider.viewType, signInWebview)
@@ -248,7 +248,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     downloadLatestJavaJar(context);
     getAppmapDir(context, workspaceServices);
 
-    if (!openedInstallGuide && !SignInManager.shouldShowSignIn())
+    if (!openedInstallGuide && SignInManager.signedIn)
       promptInstall(workspaceServices, extensionState);
 
     vscode.env.onDidChangeTelemetryEnabled((enabled: boolean) => {

--- a/test/integration/authentication/sidebarSignIn.test.ts
+++ b/test/integration/authentication/sidebarSignIn.test.ts
@@ -3,17 +3,11 @@ import assert from 'assert';
 import sinon from 'sinon';
 import * as auth from '../../../src/authentication';
 import SignInManager from '../../../src/services/signInManager';
-import MockExtensionContext from '../../mocks/mockExtensionContext';
-import ExtensionState from '../../../src/configuration/extensionState';
 
 describe('Sidebar sign-in', () => {
   let sandbox: sinon.SinonSandbox;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stubbedExecuteCommand: sinon.SinonStub<[command: string, ...rest: any[]], Thenable<unknown>>;
-  const context = new MockExtensionContext();
-  const extensionState = new ExtensionState(context);
-  const existingUserVersion = '0.66.2';
-  const newUserVersion = '0.66.3';
   const fakeApiKey = 'fake api key';
   const noApiKey = undefined;
 
@@ -26,13 +20,12 @@ describe('Sidebar sign-in', () => {
     sandbox.restore();
   });
 
-  it('is not shown for an existing user who is logged in and then logs out', async () => {
+  it('is shown for a user who is logged in and then logs out', async () => {
     const getApiKeyStub = sandbox.stub(auth, 'getApiKey');
     getApiKeyStub.returns(Promise.resolve(fakeApiKey));
-    sandbox.stub(extensionState, 'firstVersionInstalled').value(existingUserVersion);
 
-    await SignInManager.register(extensionState);
-    assert(!SignInManager.shouldShowSignIn());
+    await SignInManager.register();
+    assert(SignInManager.signedIn);
 
     let expectedArgs = ['setContext', 'appMap.showSignIn', false];
     assert.deepStrictEqual(stubbedExecuteCommand.getCall(0).args, expectedArgs);
@@ -40,59 +33,18 @@ describe('Sidebar sign-in', () => {
     // user logs out
     getApiKeyStub.returns(Promise.resolve(noApiKey));
     await SignInManager.updateSignInState();
-    assert(!SignInManager.shouldShowSignIn());
-
-    expectedArgs = ['setContext', 'appMap.showSignIn', false];
-    assert.deepStrictEqual(stubbedExecuteCommand.getCall(1).args, expectedArgs);
-  });
-
-  it('is not shown for a new user who is authenticated, but is shown when they log out', async () => {
-    const getApiKeyStub = sandbox.stub(auth, 'getApiKey');
-    getApiKeyStub.returns(Promise.resolve(fakeApiKey));
-    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
-
-    await SignInManager.register(extensionState);
-    assert(!SignInManager.shouldShowSignIn());
-
-    let expectedArgs = ['setContext', 'appMap.showSignIn', false];
-    assert.deepStrictEqual(stubbedExecuteCommand.getCall(0).args, expectedArgs);
-
-    // user logs out
-    getApiKeyStub.returns(Promise.resolve(noApiKey));
-    await SignInManager.updateSignInState();
-    assert(SignInManager.shouldShowSignIn());
+    assert(!SignInManager.signedIn);
 
     expectedArgs = ['setContext', 'appMap.showSignIn', true];
     assert.deepStrictEqual(stubbedExecuteCommand.getCall(1).args, expectedArgs);
   });
 
-  it('is not shown for an existing user who is not authenticated and then logs in', async () => {
+  it('is shown for an existing user who is not authenticated and then logs in', async () => {
     const getApiKeyStub = sandbox.stub(auth, 'getApiKey');
     getApiKeyStub.returns(Promise.resolve(noApiKey));
-    sandbox.stub(extensionState, 'firstVersionInstalled').value(existingUserVersion);
 
-    await SignInManager.register(extensionState);
-    assert(!SignInManager.shouldShowSignIn());
-
-    let expectedArgs = ['setContext', 'appMap.showSignIn', false];
-    assert.deepStrictEqual(stubbedExecuteCommand.getCall(0).args, expectedArgs);
-
-    // user logs in
-    getApiKeyStub.returns(Promise.resolve(fakeApiKey));
-    await SignInManager.updateSignInState();
-    assert(!SignInManager.shouldShowSignIn());
-
-    expectedArgs = ['setContext', 'appMap.showSignIn', false];
-    assert.deepStrictEqual(stubbedExecuteCommand.getCall(1).args, expectedArgs);
-  });
-
-  it('is shown for a new user who is not authenticated, but is not shown once they log in', async () => {
-    const getApiKeyStub = sandbox.stub(auth, 'getApiKey');
-    getApiKeyStub.returns(Promise.resolve(noApiKey));
-    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
-
-    await SignInManager.register(extensionState);
-    assert(SignInManager.shouldShowSignIn());
+    await SignInManager.register();
+    assert(!SignInManager.signedIn);
 
     let expectedArgs = ['setContext', 'appMap.showSignIn', true];
     assert.deepStrictEqual(stubbedExecuteCommand.getCall(0).args, expectedArgs);
@@ -100,7 +52,7 @@ describe('Sidebar sign-in', () => {
     // user logs in
     getApiKeyStub.returns(Promise.resolve(fakeApiKey));
     await SignInManager.updateSignInState();
-    assert(!SignInManager.shouldShowSignIn());
+    assert(SignInManager.signedIn);
 
     expectedArgs = ['setContext', 'appMap.showSignIn', false];
     assert.deepStrictEqual(stubbedExecuteCommand.getCall(1).args, expectedArgs);


### PR DESCRIPTION
Fixes #786 

This makes it so that any user that is logged out will see the sign-in page in the sidebar.