### PR TITLE
Select finding when opening map

### DIFF
--- a/package.json
+++ b/package.json
@@ -499,7 +499,7 @@
   "dependencies": {
     "@appland/appmap": "^3.80.2",
     "@appland/client": "^1.7.0",
-    "@appland/components": "^2.59.0",
+    "@appland/components": "^2.60.0",
     "@appland/diagrams": "^1.7.0",
     "@appland/models": "^2.6.3",
     "@appland/scanner": "^1.79.0",

--- a/src/diagnostics/findingsDiagnosticsProvider.ts
+++ b/src/diagnostics/findingsDiagnosticsProvider.ts
@@ -42,14 +42,21 @@ export default class FindingsDiagnosticsProvider implements vscode.Disposable {
     findings.map((finding) => {
       if (!finding.problemLocation) return;
 
-      const relatedInformation = finding.appMapUri
-        ? [
-            new vscode.DiagnosticRelatedInformation(
-              new vscode.Location(finding.appMapUri, new vscode.Position(0, 0)),
-              'Open AppMap'
-            ),
-          ]
-        : [];
+      const relatedInformation = [] as vscode.DiagnosticRelatedInformation[];
+      if (finding.appMapUri) {
+        const uri = finding.appMapUri.with({
+          fragment: JSON.stringify({
+            selectedObject: `analysis-finding:${finding.finding.hash_v2}`,
+          }),
+        });
+
+        const diagnosticInfo = new vscode.DiagnosticRelatedInformation(
+          new vscode.Location(uri, new vscode.Position(0, 0)),
+          'Open AppMap'
+        );
+
+        relatedInformation.push(diagnosticInfo);
+      }
 
       const problemUri = finding.problemLocation.uri;
       updatedProblemUriStrings.add(problemUri.toString());

--- a/src/webviews/findingInfoWebview.ts
+++ b/src/webviews/findingInfoWebview.ts
@@ -135,9 +135,7 @@ export default class FindingInfoWebview {
               break;
             case 'open-map':
               {
-                let state: string | undefined;
-
-                if (message.data.uri) state = message.data.uri.fragment;
+                const state = JSON.stringify({ selectedObject: `analysis-finding:${hash}` });
 
                 const uri = vscode.Uri.file(message.data.mapFile);
                 vscode.commands.executeCommand('vscode.open', uri.with({ fragment: state }));

--- a/test/integration/scanner/populateDiagostics.test.ts
+++ b/test/integration/scanner/populateDiagostics.test.ts
@@ -34,10 +34,19 @@ describe('Findings', () => {
       diagnostics[0][0].toString(),
       `file://${workspaceFolder.uri.fsPath}/app/controllers/microposts_controller.rb`
     );
-    assert(diagnostics[0][1][0]);
+    const diagnostic = diagnostics[0][1][0];
+    assert(diagnostic);
+
     assert.strictEqual(
-      diagnostics[0][1][0].message,
+      diagnostic.message,
       `Unbatched materialized SQL query: SELECT "microposts".* FROM "microposts" WHERE "microposts"."user_id" = ? ORDER BY "microposts"."created_at" DESC, app/controllers/microposts_controller.rb:5`
+    );
+
+    const { relatedInformation } = diagnostic;
+    assert(relatedInformation);
+    assert.deepStrictEqual(
+      relatedInformation[0].location.uri.fragment,
+      '{"selectedObject":"analysis-finding:a3c2342df8feae6698da11cba070d8de9a97ef9450636e2d5824120867a2c0b0"}'
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,9 +137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^2.59.0":
-  version: 2.59.0
-  resolution: "@appland/components@npm:2.59.0"
+"@appland/components@npm:^2.60.0":
+  version: 2.60.0
+  resolution: "@appland/components@npm:2.60.0"
   dependencies:
     "@appland/diagrams": ^1.7.0
     "@appland/models": ^2.6.3
@@ -153,7 +153,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.14
     vuex: ^3.6.0
-  checksum: d990c21502571ed3d6946c2bc2219c926d76e5979db018cf090a3258bab0ad1bfec2d05be5543cd2b9826c56c7ef303ca499c4bdc01ca51fb9261efb3466c2c3
+  checksum: 619bf33b2e46a4ab0cc7676597746998b72170be4885afb3cb2a7c88f32dda08afa02d5c510ff89a418e1810f5e45963143b39b4aed97332c1c102376fd7f570
   languageName: node
   linkType: hard
 
@@ -2648,7 +2648,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.80.2
     "@appland/client": ^1.7.0
-    "@appland/components": ^2.59.0
+    "@appland/components": ^2.60.0
     "@appland/diagrams": ^1.7.0
     "@appland/models": ^2.6.3
     "@appland/scanner": ^1.79.0


### PR DESCRIPTION
Fixes #789 

Previously, when opening an AppMap from the findings webview:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/b6974158-38e3-4eab-b787-e41170a0bc54)

It would open to the `Trace View`:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/69579a4b-1412-49a9-b244-70a0f2c23ecb)

This change makes it so that it opens the AppMap to the finding:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/e8023edc-de37-40eb-8d4c-32b94db7783c)
