### PR TITLE
Top level of runtime analysis tree is expanded by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
         {
           "id": "appmap.views.findings",
           "name": "Runtime Analysis",
-          "visibility": "collapsed",
+          "visibility": "visible",
           "when": "!appMap.showSignIn"
         },
         {


### PR DESCRIPTION
Fixes #793 