### PR TITLE
Remove generate sequence diagram option for appmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,10 +163,6 @@
         "title": "AppMap View: Compare Sequence Diagrams"
       },
       {
-        "command": "appmap.context.sequenceDiagram",
-        "title": "AppMap View: Generate Sequence Diagram"
-      },
-      {
         "command": "appmap.context.inspectCodeObject",
         "title": "AppMap View: Inspect Code Object"
       },
@@ -340,10 +336,6 @@
           "when": "false"
         },
         {
-          "command": "appmap.context.sequenceDiagram",
-          "when": "false"
-        },
-        {
           "command": "appmap.context.compareSequenceDiagrams",
           "when": "false"
         },
@@ -395,10 +387,6 @@
         },
         {
           "command": "appmap.context.saveToCollection",
-          "when": "view == appmap.views.appmaps && viewItem == appmap.views.appmaps.appMap"
-        },
-        {
-          "command": "appmap.context.sequenceDiagram",
           "when": "view == appmap.views.appmaps && viewItem == appmap.views.appmaps.appMap"
         },
         {

--- a/src/tree/contextMenu.ts
+++ b/src/tree/contextMenu.ts
@@ -63,14 +63,6 @@ export default class ContextMenu {
       )
     );
     context.subscriptions.push(
-      vscode.commands.registerCommand(
-        'appmap.context.sequenceDiagram',
-        async (item: AppMapLoader) => {
-          vscode.commands.executeCommand('appmap.sequenceDiagram', item.descriptor.resourceUri);
-        }
-      )
-    );
-    context.subscriptions.push(
       vscode.commands.registerCommand('appmap.context.deleteAppMap', async (item: AppMapLoader) => {
         await deleteAppMap(item.descriptor.resourceUri, appmaps);
       })


### PR DESCRIPTION
Fixes #621 

We don't need this since we have sequence diagrams built in to the AppMap view.

### Before:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/87f2a41f-cb65-4b26-a129-98a98a4e0212)

### After:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/b6d2ced9-5101-429a-aba0-5ee31628143b)
