### PR TITLE
Clicking sign-in button cancels previous sign-in attempt

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,7 +187,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     openCodeObjectInAppMap(context, appmapCollectionFile, classMapIndex);
 
     await SignInManager.register(extensionState);
-    const signInWebview = new SignInViewProvider(context);
+    const signInWebview = new SignInViewProvider(context, appmapServerAuthenticationProvider);
     context.subscriptions.push(
       vscode.window.registerWebviewViewProvider(SignInViewProvider.viewType, signInWebview)
     );


### PR DESCRIPTION
Fixes #792 

Previously, when signing in, if a user got this menu:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/3dbee37f-5e92-4f22-b22b-3579052172ca)

And then instinctively hit `Cancel` (as happened on a customer call), then they would get this progress menu in the bottom right corner:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/1e7ed099-a6d6-42e2-aba8-a85502ebc48f)

If a user then hits the `Sign In` button again, nothing will happen as long as that progress menu is open. They have to hit the `Cancel` button on the progress menu before they can attempt to sign in again. This is a problem because it's easy to not notice the progress menu.

This PR makes it so that clicking the `Sign In` button automatically cancels any previous sign-in attempts and re-starts the sign-in process.

## QA Instructions

1. If you are signed in with AppMap Server, please sign out using the accounts button in the bottom left corner:
 
![image](https://github.com/getappmap/vscode-appland/assets/45714532/60acc045-bffa-43e9-8046-25d4868c227e)

2. Click on the big blue Sign In button and then click Allow:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/96ed63fa-24ef-4097-8ee0-be7fb659c405)

3. Click `Cancel`:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/ef3d40c2-8005-435a-b5e9-5eb9a79e9646)

4. Then click the Sign In button again (it occasionally takes two clicks) and you should see this notification again:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/96ed63fa-24ef-4097-8ee0-be7fb659c405)