### PR TITLE
Lock system tests to vs code version 1.81.1

### DIFF
--- a/test/system/src/app.ts
+++ b/test/system/src/app.ts
@@ -30,6 +30,7 @@ interface LaunchOptions {
 
 export async function downloadCode(): Promise<string> {
   return await downloadAndUnzipVSCode({
+    version: '1.81.1',
     reporter: new ConsoleReporter(false),
   });
 }


### PR DESCRIPTION
Temporarily lock system tests to VS Code version 1.81.1 (same as integration tests)