### PR TITLE
feat: Rename AppMap auth provider to 'AppMap'

### DIFF
--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -35,7 +35,7 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     const provider = new AppMapServerAuthenticationProvider(context, uriHandler);
     const registration = vscode.authentication.registerAuthenticationProvider(
       AUTHN_PROVIDER_NAME,
-      'AppMap Server',
+      'AppMap',
       provider,
       { supportsMultipleAccounts: false }
     );
@@ -71,7 +71,7 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     this.session = await this.performSignIn();
     debug('createSession(); session %savailable', this.session ? '' : 'not ');
 
-    if (!this.session) throw new Error('AppMap Server authentication was not completed');
+    if (!this.session) throw new Error('AppMap authentication was not completed');
 
     this.context.secrets
       .store(APPMAP_SERVER_SESSION_KEY, JSON.stringify(this.session))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,8 +164,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       uriHandler
     );
     appmapServerAuthenticationProvider.onDidChangeSessions((e) => {
-      if (e.added) vscode.window.showInformationMessage('Logged in to AppMap Server');
-      if (e.removed) vscode.window.showInformationMessage('Logged out of AppMap Server');
+      if (e.added) vscode.window.showInformationMessage('Logged in to AppMap');
+      if (e.removed) vscode.window.showInformationMessage('Logged out of AppMap');
       AppMapServerConfiguration.updateAppMapClientConfiguration();
     });
     vscode.commands.registerCommand('appmap.login', async () => {

--- a/test/integration/authentication/appmapServerLogin.test.ts
+++ b/test/integration/authentication/appmapServerLogin.test.ts
@@ -25,7 +25,7 @@ describe('Authenticate', () => {
     account: { id: 'the-account-id', label: 'the-account-label' },
   };
 
-  describe('with AppMap Server', async () => {
+  describe('with AppMap', async () => {
     describe('when not signed in', () => {
       it('is activated by vscode.authentication.getSession', async () => {
         sandbox.stub(appmapService.appmapServerAuthenticationProvider, 'getSessions').resolves([]);


### PR DESCRIPTION
`AppMap Server` is misleading, because it's really an account management provider and not an "API Server".

Rename the `AppMap Server` auth provider to `AppMap`.