### PR TITLE
fix: Completion of the 'runtime analysis' step must come last

### DIFF
--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -143,6 +143,21 @@ export default class InstallGuideWebView {
                 } else if (page === 'investigate-findings') {
                   if (!project) break;
 
+                  // Make sure all previous steps are completed
+                  // before flagging runtime analysis as complete.
+                  // Once runtime analysis is complete, the prompt
+                  // will say "setup is complete", so we want to make
+                  // sure this is completed last.
+                  const service = projectStates.find(
+                    ({ metadata }) => metadata.path === project?.path
+                  );
+                  const successConditions = [
+                    service?.metadata.agentInstalled,
+                    service?.metadata.numAppMaps,
+                    service?.metadata.appMapOpened,
+                  ];
+                  if (!successConditions.every(Boolean)) break;
+
                   const workspaceFolder = vscode.workspace.getWorkspaceFolder(
                     vscode.Uri.parse(project.path)
                   );

--- a/test/system/tests/instructions.test.ts
+++ b/test/system/tests/instructions.test.ts
@@ -54,17 +54,26 @@ describe('Instructions tree view', function () {
       InstructionStepStatus.Complete
     );
 
-    await project.restoreFiles('**/appmap-findings.json');
+    // Assert that viewing the runtime analysis step prior to completing the
+    // previous steps does not mark the runtime analysis step as complete.
     await driver.appMap.openInstruction(InstructionStep.InvestigateFindings);
-    await driver.instructionsWebview.clickButton('Open the PROBLEMS tab');
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.InvestigateFindings,
-      InstructionStepStatus.Complete
+      InstructionStepStatus.Pending
     );
 
+    await driver.appMap.openInstruction(InstructionStep.OpenAppMaps);
     await driver.appMap.openAppMap();
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.OpenAppMaps,
+      InstructionStepStatus.Complete
+    );
+
+    // All previous steps are now complete. Viewing the runtime analysis step
+    // should mark it as complete.
+    await driver.appMap.openInstruction(InstructionStep.InvestigateFindings);
+    await driver.appMap.assertInstructionStepStatus(
+      InstructionStep.InvestigateFindings,
       InstructionStepStatus.Complete
     );
 


### PR DESCRIPTION
The runtime analysis step no longer completes automatically upon opening the page if the user has not yet:
- Installed the agent,
- Recorded AppMaps, or
- Opened an AppMap

The previous steps must be completed prior to completing the final step.

Related to https://github.com/getappmap/appmap-js/issues/1383 