### PR TITLE
fix: Always show 'no projects found' when viewing instructions if no project is open

### DIFF
--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -39,6 +39,10 @@ export default class InstallGuideWebView {
       vscode.commands.registerCommand(this.command, async (page?: DocPageId) => {
         if (!page) page = defaultPageId(projectStates);
 
+        // Short circuit if no project is open. The project picker has the correct prompts
+        // to handle this case.
+        if (!vscode.workspace.workspaceFolders?.length) page = ProjectPicker;
+
         // Attempt to re-use an existing webview for this project if one exists
         if (this.existingPanel) {
           this.existingPanel.reveal(vscode.ViewColumn.One);

--- a/test/system/src/driver.ts
+++ b/test/system/src/driver.ts
@@ -110,4 +110,9 @@ export default class Driver {
   public async tabCount(): Promise<number> {
     return await this.page.locator('.tabs-and-actions-container >> [role="tab"]').count();
   }
+
+  public async closeFolder(): Promise<void> {
+    await this.page.press('body', getOsShortcut('Control+K'));
+    await this.page.press('body', getOsShortcut('F'));
+  }
 }

--- a/test/system/tests/instructions.test.ts
+++ b/test/system/tests/instructions.test.ts
@@ -182,4 +182,32 @@ describe('Instructions tree view', function () {
     await driver.instructionsWebview.clickButton('Open the PROBLEMS tab');
     await driver.panel.problems.waitFor({ state: 'visible' });
   });
+
+  it('always opens the project picker in an empty/undefined workspace', async function () {
+    const { driver } = this;
+    await driver.closeFolder();
+    await driver.waitForReady();
+    await driver.appMap.openActionPanel();
+    await driver.appMap.ready();
+
+    const expectProjectPicker = () =>
+      waitFor(
+        'Expected project picker to be visible',
+        async (): Promise<boolean> =>
+          (await driver.instructionsWebview.pageTitle()) === 'Add AppMap to your project'
+      );
+
+    const steps = [
+      InstructionStep.InstallAppMapAgent,
+      InstructionStep.RecordAppMaps,
+      InstructionStep.OpenAppMaps,
+      InstructionStep.InvestigateFindings,
+    ];
+
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      await driver.appMap.openInstruction(step);
+      await expectProjectPicker();
+    }
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/getappmap/appmap-js/issues/1386

To reproduce:
- `Ctrl+K F` will close the current workspace/folder
- Open any instructions page
