### PR TITLE
Consistent delete behavior from command palette

### DIFF
--- a/src/lib/deleteAppMaps.ts
+++ b/src/lib/deleteAppMaps.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import deleteAppMap from './deleteAppMap';
+import closeEditorByUri from './closeEditorByUri';
 import { promisify } from 'util';
 import { glob } from 'glob';
 import AppMapCollection from '../services/appmapCollection';
@@ -14,7 +15,13 @@ export default async function deleteAppMaps(
     vscode.Uri.file(path)
   );
 
-  await Promise.all(appmapFiles.map((uri) => deleteAppMap(uri, appMapCollection)));
+  await Promise.all(
+    appmapFiles.map((uri) => {
+      deleteAppMap(uri, appMapCollection);
+      closeEditorByUri(uri);
+    })
+  );
+  appMapCollection.clear();
 
   return appmapFiles.length;
 }

--- a/src/services/appmapCollection.ts
+++ b/src/services/appmapCollection.ts
@@ -18,4 +18,6 @@ export default interface AppMapCollection {
   allAppMapsForWorkspaceFolder(workspaceFolder: WorkspaceFolder): AppMapLoader[];
 
   has(uri: vscode.Uri): boolean;
+
+  clear(): void;
 }

--- a/src/services/appmapCollectionFile.ts
+++ b/src/services/appmapCollectionFile.ts
@@ -140,4 +140,10 @@ export default class AppMapCollectionFile implements AppMapCollection, AppMapsSe
   public has(uri: vscode.Uri): boolean {
     return this.loaders.has(uri.fsPath);
   }
+
+  public clear(): void {
+    console.debug('Clearing AppMap collection from tree', this.loaders.size);
+    this.loaders.clear();
+    this.emitUpdated(undefined);
+  }
 }

--- a/src/tree/contextMenu.ts
+++ b/src/tree/contextMenu.ts
@@ -65,8 +65,21 @@ export default class ContextMenu {
     );
     context.subscriptions.push(
       vscode.commands.registerCommand('appmap.context.deleteAppMap', async (item: AppMapLoader) => {
-        await deleteAppMap(item.descriptor.resourceUri, appmaps);
-        await closeEditorByUri(item.descriptor.resourceUri);
+        let uri: vscode.Uri;
+        if (!item) {
+          const { activeTab } = vscode.window.tabGroups.activeTabGroup;
+          if (!activeTab) {
+            vscode.window.showErrorMessage('No active editor.');
+            return;
+          }
+
+          uri = (activeTab.input as vscode.TabInputCustom).uri;
+        } else {
+          uri = item.descriptor.resourceUri;
+        }
+
+        await deleteAppMap(uri, appmaps);
+        await closeEditorByUri(uri);
       })
     );
     context.subscriptions.push(

--- a/test/integration/command/deleteAppMap.test.ts
+++ b/test/integration/command/deleteAppMap.test.ts
@@ -2,16 +2,15 @@ import * as vscode from 'vscode';
 import { assert } from 'chai';
 import { join } from 'path';
 import * as sinon from 'sinon';
-import closeEditorByUri from '../../../src/lib/closeEditorByUri';
-import { initializeWorkspace, FixtureDir, waitForExtension } from '../util';
+import { initializeWorkspace, ProjectA, waitForExtension } from '../util';
 
-describe('closeEditorByUri Tests', function () {
+describe('deleteAppMap test', function () {
   let sandbox: sinon.SinonSandbox;
 
   const appmapFilePath = join(
-    FixtureDir,
-    'classMaps',
-    'ScannerJobsController_authenticated_user_admin_can_defer_a_finding.json'
+    ProjectA,
+    'tmp/appmap/minitest',
+    'Microposts_controller_can_get_microposts_as_JSON.appmap.json'
   );
 
   beforeEach(() => (sandbox = sinon.createSandbox()));
@@ -21,14 +20,12 @@ describe('closeEditorByUri Tests', function () {
   afterEach(initializeWorkspace);
   afterEach(() => sandbox.restore());
 
-  it('closes tab with matching URI', async () => {
+  it('deletes appmap with matching URI', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUri: vscode.Uri = { path: appmapFilePath } as any;
     await vscode.workspace.openTextDocument(mockUri);
     await vscode.window.showTextDocument(vscode.Uri.file(mockUri.path));
-    console.debug('tabs', mockUri.path);
-
-    await closeEditorByUri(mockUri);
+    await vscode.commands.executeCommand('appmap.context.deleteAppMap');
 
     const tabs = vscode.window.tabGroups.all.map((tg) => tg.tabs).flat();
     const index = tabs.findIndex(
@@ -38,7 +35,6 @@ describe('closeEditorByUri Tests', function () {
           tab.input instanceof vscode.TabInputNotebook) &&
         tab.input.uri.path === mockUri.path
     );
-
     assert.isTrue(index === -1);
   });
 });


### PR DESCRIPTION
Fixes: #799 

feat(deleteAppMaps.ts): add closeEditorByUri function after deleting appmaps
feat(contextMenu.ts): update deleteAppMap command to handle absence of item object
feat(deleteAppMap.test.ts): add new integration test for deleteAppMap
fix(closeEditorByUri.test.ts): fix test to include input conditions