### PR TITLE
Emit delete appmap event reliably

### DIFF
--- a/src/lib/deleteAppMap.ts
+++ b/src/lib/deleteAppMap.ts
@@ -20,6 +20,9 @@ export default async function deleteAppMap(
 
   const indexDir = uri.fsPath.substring(0, uri.fsPath.lastIndexOf('.appmap.json'));
 
+  // This triggers the FileSystemWatcher to emit a delete event for the AppMap file reliably.
+  await retry(async () => rm(`${indexDir}/metadata.json`, { force: true }));
+
   await retry(async () => rm(uri.fsPath, { force: true }));
   await retry(async () => {
     for (const file of await promisify(glob)(`${indexDir}/*`)) {

--- a/src/lib/deleteAppMap.ts
+++ b/src/lib/deleteAppMap.ts
@@ -1,5 +1,3 @@
-import { glob } from 'glob';
-import { promisify } from 'util';
 import * as vscode from 'vscode';
 import { retry } from '../util';
 import { rm } from 'fs/promises';
@@ -12,7 +10,7 @@ export default async function deleteAppMap(
   uri: vscode.Uri,
   appMapCollection: AppMapCollection
 ): Promise<void> {
-  // Remove AppMap file, remove index directory contents, then remove index directory.
+  // Remove AppMap metadata file in the index folder, remove AppMap file, then remove index directory (recursively).
   // In this order, we expect that the file change events will be reliable.
   // Need to use native filesystem operations here here, for some reason. vscode.findAllFiles isn't returning the index
   // contents, and fs.delete doesn't remove files.
@@ -20,19 +18,12 @@ export default async function deleteAppMap(
 
   const indexDir = uri.fsPath.substring(0, uri.fsPath.lastIndexOf('.appmap.json'));
 
-  // This triggers the FileSystemWatcher to emit a delete event for the AppMap file reliably.
-  await retry(async () => rm(`${indexDir}/metadata.json`, { force: true }));
-
-  await retry(async () => rm(uri.fsPath, { force: true }));
-  await retry(async () => {
-    for (const file of await promisify(glob)(`${indexDir}/*`)) {
-      await rm(file, { force: true });
-    }
-  });
+  await retry(async () => await rm(`${indexDir}/metadata.json`, { force: true }));
+  await retry(async () => await rm(uri.fsPath, { force: true }));
 
   if (!appMapCollection.has(uri)) {
     // The collection doesn't yet know about this AppMap, so it's safe to delete the index directory without
     // worry of missing events.
-    await retry(async () => rm(indexDir, { recursive: true, force: true }));
+    await retry(async () => await rm(indexDir, { recursive: true, force: true }));
   }
 }


### PR DESCRIPTION
Fixes: #833 

feat(deleteAppMap.ts): ensure reliable delete event emission by adding retry on metadata.json removal