### PR TITLE
Authenticate the chat search frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,12 @@
         "appMap.applandUrl": {
           "type": "string",
           "default": "https://getappmap.com",
-          "description": "URL of an AppLand cloud instance for AppMap storage"
+          "description": "URL of AppMap"
+        },
+        "appMap.apiUrl": {
+          "type": "string",
+          "default": "https://api.getappmap.com",
+          "description": "URL of the AppMap API"
         },
         "appMap.viewConfiguration": {
           "type": "string",

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -1,3 +1,4 @@
+import { DefaultApiURL } from '@appland/client';
 import * as vscode from 'vscode';
 
 export default class ExtensionSettings {
@@ -26,5 +27,9 @@ export default class ExtensionSettings {
 
   public static get appMapCommandLineToolsPath(): string | undefined {
     return vscode.workspace.getConfiguration('appMap').get('commandLineToolsPath');
+  }
+
+  public static get apiUrl(): string {
+    return vscode.workspace.getConfiguration('appMap').get('apiUrl') || DefaultApiURL;
   }
 }

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ChildProcess, OutputStream, spawn, SpawnOptions } from './nodeDependencyProcess';
 import { getApiKey } from '../authentication';
+import ExtensionSettings from '../configuration/extensionSettings';
 
 export type RetryOptions = {
   // The number of retries made before declaring the process as failed.
@@ -197,6 +198,7 @@ export class ProcessWatcher implements vscode.Disposable {
     if (accessToken) {
       env.APPMAP_API_KEY = accessToken;
     }
+    env.APPMAP_API_URL = ExtensionSettings.apiUrl;
     return env;
   }
 

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -7,6 +7,8 @@ import IndexProcessWatcher from '../services/indexProcessWatcher';
 import { ProcessId } from '../services/processWatcher';
 import viewSource from './viewSource';
 import { Telemetry } from '../telemetry';
+import { getApiKey } from '../authentication';
+import ExtensionSettings from '../configuration/extensionSettings';
 
 export default class ChatSearchWebview {
   public readonly panels = new Set<vscode.WebviewPanel>();
@@ -93,6 +95,8 @@ export default class ChatSearchWebview {
             type: 'initChatSearch',
             appmapRpcPort,
             question,
+            apiUrl: ExtensionSettings.apiUrl,
+            apiKey: await getApiKey(false),
           });
 
           break;

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -15,6 +15,8 @@ export default function mountChatSearchView() {
           props: {
             appmapRpcPort: initialData.appmapRpcPort,
             question: initialData.question,
+            apiUrl: initialData.apiUrl,
+            apiKey: initialData.apiKey,
           },
         });
       },


### PR DESCRIPTION
This is necessary to make authenticated HTTP requests, such as providing message feedback.