### PR TITLE
fix: Add code block syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,6 +502,7 @@
     "bootstrap": "^4.5.3",
     "bootstrap-autocomplete": "^2.3.7",
     "diff": "^5.1.0",
+    "highlight.js": "^11.9.0",
     "jquery": "^3.5.1",
     "js-yaml": "^4.1.0",
     "popper.js": "^1.16.1",

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { VChatSearch } from '@appland/components';
 import MessagePublisher from './messagePublisher';
 import handleAppMapMessages from './handleAppMapMessages';
+import 'highlight.js/styles/base16/snazzy.css';
 
 export default function mountChatSearchView() {
   const vscode = window.acquireVsCodeApi();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,6 +3182,7 @@ __metadata:
     eslint-plugin-prettier: ^3.4.0
     fs-extra: ^10.1.0
     glob: ^7.2.3
+    highlight.js: ^11.9.0
     ignore: ^5.1.8
     jquery: ^3.5.1
     js-yaml: ^4.1.0


### PR DESCRIPTION
Before
![image](https://github.com/getappmap/vscode-appland/assets/8737782/7f6021b3-ee8a-40d7-a1d9-faa6a6537858)

After
![image](https://github.com/getappmap/vscode-appland/assets/8737782/f9b41809-08a9-4932-8793-d123f83b5145)

Resolves #863