### PR TITLE
feat: Navie prompts the user to choose a directory

### DIFF
--- a/src/actions/remoteRecording.ts
+++ b/src/actions/remoteRecording.ts
@@ -16,6 +16,10 @@ export default class RemoteRecording {
   private static readonly RECENT_REMOTE_URLS = 'APPMAP_RECENT_REMOTE_URLS';
   private readonly statusBar: vscode.StatusBarItem;
   private activeRecordingUrl: string | null;
+  // TODO: This does get disposed. However, when the recording is stopped it doesn't
+  // get cleared back to null or undefined. An active recording should be an instance
+  // variable that is only used once. This RemoteRecording class is used many times,
+  // so having instance variables that are utilized during a recording is not appropriate.
   private stopEmitter: vscode.EventEmitter<boolean> | null = null;
   onDidStop: vscode.Event<boolean> | undefined = this.stopEmitter?.event;
 

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -48,6 +48,8 @@ function enterLicenseKeyCommand(authProvider: AppMapServerAuthenticationProvider
 }
 
 export default class AppMapServerAuthenticationProvider implements vscode.AuthenticationProvider {
+  // vscode.AuthenticationProvider is not Disposable, therefore listeners on this event
+  // will not and apparently do not need to be disposed.
   private _onDidChangeSessions =
     new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
   readonly onDidChangeSessions = this._onDidChangeSessions.event;

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -28,7 +28,7 @@ interface WorkspaceFlagEvent {
   value: boolean;
 }
 
-export default class ExtensionState {
+export default class ExtensionState implements vscode.Disposable {
   private readonly _onWorkspaceFlag = new vscode.EventEmitter<WorkspaceFlagEvent>();
   public readonly onWorkspaceFlag = this._onWorkspaceFlag.event;
 
@@ -58,6 +58,7 @@ export default class ExtensionState {
 
       this.context.globalState.update(Keys.Global.INSTALL_TIMESTAMP, this._installTime.valueOf());
     }
+    context.subscriptions.push(this);
   }
 
   /** Adds a workspace to a set under a specific key. If value is truthy, the path is added. Otherwise, it is removed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     context.subscriptions.push(configWatcher);
 
     const configManager = new AppmapConfigManager(configWatcher);
-    context.subscriptions.push(configManager);
     await workspaceServices.enroll(configManager);
 
     const classMapIndex = new ClassMapIndex();

--- a/src/lib/selectIndexProcess.ts
+++ b/src/lib/selectIndexProcess.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+import IndexProcessWatcher from '../services/indexProcessWatcher';
+import { NodeProcessService } from '../services/nodeProcessService';
+import { workspaceServices } from '../services/workspaceServices';
+
+export type IndexProcess = {
+  configFolder: string;
+  rpcPort: number;
+};
+
+export enum ReasonCode {
+  NoIndexProcessWatchers = 1,
+  NoReadyIndexProcessWatchers = 2,
+  NoSelectionMade = 3,
+}
+
+export function readyProcessWatchers(
+  workspace?: vscode.WorkspaceFolder
+): IndexProcessWatcher[] | undefined {
+  const nodeProcessService = workspaceServices().getService(NodeProcessService);
+  if (!nodeProcessService) {
+    console.warn('No node process service found');
+    return;
+  }
+
+  const nodeProcessServices = workspaceServices().getServiceInstances(nodeProcessService);
+  if (nodeProcessServices.length === 0) {
+    console.log('No node process services found');
+    return;
+  }
+
+  const indexProcessWatchers = nodeProcessServices
+    .filter((service) => workspace === undefined || service.folder === workspace)
+    .flatMap(
+      (service) =>
+        service.processes.filter((process) => process.id === 'index') as IndexProcessWatcher[]
+    );
+
+  return indexProcessWatchers;
+}
+
+export default async function selectIndexProcess(
+  workspace?: vscode.WorkspaceFolder
+): Promise<IndexProcess | ReasonCode | undefined> {
+  const indexProcessWatchers = readyProcessWatchers(workspace);
+  if (!indexProcessWatchers) {
+    console.warn(`No index process watchers found for ${workspace?.name || 'your workspace'}`);
+    return;
+  }
+
+  if (indexProcessWatchers.length === 0) {
+    console.log('No index process watchers found');
+    return ReasonCode.NoIndexProcessWatchers;
+  }
+
+  const readyIndexProcessWatchers = indexProcessWatchers.filter((watcher) =>
+    watcher.isRpcAvailable()
+  );
+  if (readyIndexProcessWatchers.length === 0) {
+    console.log('No ready index process watchers found');
+    return ReasonCode.NoReadyIndexProcessWatchers;
+  }
+
+  let selectedWatcher: IndexProcessWatcher | undefined;
+  if (readyIndexProcessWatchers.length === 1) {
+    selectedWatcher = readyIndexProcessWatchers[0];
+  } else {
+    const pickResult = await vscode.window.showQuickPick(
+      readyIndexProcessWatchers.map((watcher) => ({
+        label: watcher.configFolder,
+        watcher,
+      })),
+      {
+        placeHolder: 'Select a project directory for your question',
+      }
+    );
+    if (!pickResult) return ReasonCode.NoSelectionMade;
+
+    selectedWatcher = pickResult.watcher;
+  }
+
+  if (!selectedWatcher.rpcPort) {
+    console.warn(`No RPC port available on index process watcher ${selectedWatcher.configFolder}`);
+    return;
+  }
+
+  return {
+    configFolder: selectedWatcher.configFolder,
+    rpcPort: selectedWatcher.rpcPort,
+  };
+}

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -3,10 +3,8 @@ import { AUTHN_PROVIDER_NAME, getApiKey } from '../authentication';
 import FindingsDiagnosticsProvider from '../diagnostics/findingsDiagnosticsProvider';
 import FindingsIndex from './findingsIndex';
 import openFinding from '../commands/openFinding';
-import { ProjectStateServiceInstance } from './projectStateService';
 import ExtensionState from '../configuration/extensionState';
 import { ResolvedFinding } from './resolvedFinding';
-import { WorkspaceServices } from './workspaceServices';
 import Environment from '../configuration/environment';
 import { debuglog } from 'util';
 import Watcher from './watcher';
@@ -23,9 +21,8 @@ export default class AnalysisManager {
   private static _findingsIndex?: FindingsIndex;
   private static findingsWatcher?: Watcher;
   private static findingsDiagnosticsProvider?: FindingsDiagnosticsProvider;
-  private static projectStates: ReadonlyArray<ProjectStateServiceInstance>;
   private static extensionState: ExtensionState;
-  private static workspaceServices: WorkspaceServices;
+  // TODO: It's unclear when and how to dispose of this, since everything in this class is static.
   private static readonly _onAnalysisToggled = new vscode.EventEmitter<AnalysisToggleEvent>();
   private static readonly contextKeyAnalysisEnabled = 'appmap.analysisEnabled';
   private static readonly contextKeyUserAuthenticated = 'appmap.userAuthenticated';
@@ -46,13 +43,9 @@ export default class AnalysisManager {
 
   public static async register(
     context: vscode.ExtensionContext,
-    projectStates: ReadonlyArray<ProjectStateServiceInstance>,
-    extensionState: ExtensionState,
-    workspaceServices: WorkspaceServices
+    extensionState: ExtensionState
   ): Promise<void> {
-    this.projectStates = projectStates;
     this.extensionState = extensionState;
-    this.workspaceServices = workspaceServices;
 
     await this.updateAnalysisState();
 

--- a/src/services/appmapCollectionFile.ts
+++ b/src/services/appmapCollectionFile.ts
@@ -10,6 +10,7 @@ import { basename, dirname, join } from 'path';
 import { CodeObject } from '@appland/models';
 
 export default class AppMapCollectionFile implements AppMapCollection, AppMapsService {
+  // TODO: Dispose of this event emitter.
   private _onUpdated: vscode.EventEmitter<vscode.WorkspaceFolder | undefined> =
     new ChangeEventDebouncer<vscode.WorkspaceFolder | undefined>();
   public readonly onUpdated: vscode.Event<vscode.WorkspaceFolder | undefined> =

--- a/src/services/appmapConfigManager.ts
+++ b/src/services/appmapConfigManager.ts
@@ -19,7 +19,6 @@ export type AppmapConfig = {
 
 type WorkspaceConfig = {
   configs: AppmapConfig[];
-  fileProvider: ConfigFileProviderImpl;
 };
 
 class ConfigFileProviderImpl implements ConfigFileProvider {
@@ -96,11 +95,8 @@ export class AppmapConfigManagerInstance implements WorkspaceServiceInstance {
     await this.makeAppmapDirs();
   }
 
-  public get workspaceConfig(): WorkspaceConfig {
-    return {
-      configs: this._configs,
-      fileProvider: this._configFileProvider,
-    };
+  public get workspaceConfigs(): AppmapConfig[] {
+    return this._configs;
   }
 
   public get isUsingDefaultConfig(): boolean {
@@ -112,7 +108,7 @@ export class AppmapConfigManagerInstance implements WorkspaceServiceInstance {
   }
 
   public async getAppmapConfig(): Promise<AppmapConfig | undefined> {
-    const { configs } = this.workspaceConfig;
+    const configs = this.workspaceConfigs;
     let configToUse: AppmapConfig | undefined;
 
     if (configs.length === 1) {

--- a/src/services/appmapUptodateService.ts
+++ b/src/services/appmapUptodateService.ts
@@ -176,6 +176,10 @@ export class AppmapUptodateService implements WorkspaceService<AppmapUptodateSer
     return uptodate;
   }
 
+  dispose(): void {
+    this._onUpdated.dispose();
+  }
+
   /**
    * Gets the list of test files, with line numbers if available, that are out of date.
    *

--- a/src/services/indexProcessWatcher.ts
+++ b/src/services/indexProcessWatcher.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
 import { ProcessId, ProcessWatcher, ProcessWatcherOptions } from './processWatcher';

--- a/src/services/indexProcessWatcher.ts
+++ b/src/services/indexProcessWatcher.ts
@@ -1,23 +1,13 @@
+import * as vscode from 'vscode';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
-import {
-  ConfigFileProvider,
-  ProcessId,
-  ProcessWatcher,
-  ProcessWatcherOptions,
-} from './processWatcher';
+import { ProcessId, ProcessWatcher, ProcessWatcherOptions } from './processWatcher';
 
 export default class IndexProcessWatcher extends ProcessWatcher {
   public rpcPort?: number;
   stdoutBuffer = '';
 
-  constructor(
-    configFileProvider: ConfigFileProvider,
-    modulePath: string,
-    appmapDir: string,
-    cwd: string,
-    env?: NodeJS.ProcessEnv
-  ) {
+  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
     const args = ['index', '--watch', '--port', '0', '--appmap-dir', appmapDir];
     const extraOptions = ExtensionSettings.appMapIndexOptions;
     if (extraOptions) args.push(...extraOptions.split(' '));
@@ -30,7 +20,7 @@ export default class IndexProcessWatcher extends ProcessWatcher {
       cwd,
       env,
     };
-    super(configFileProvider, options);
+    super(options);
   }
 
   public isRpcAvailable(): boolean {

--- a/src/services/lineInfoIndex.ts
+++ b/src/services/lineInfoIndex.ts
@@ -15,6 +15,7 @@ class LineInfo {
 }
 
 export default class LineInfoIndex {
+  // TODO: Dispose of this event emitter.
   private _onChanged = new vscode.EventEmitter<LineInfoIndex>();
   public readonly onChanged = this._onChanged.event;
 

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -95,8 +95,7 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
     );
     assert(appmapConfigManagerInstance);
 
-    const { configs: appmapConfigs, fileProvider: configFileProvider } =
-      appmapConfigManagerInstance.workspaceConfig;
+    const appmapConfigs = appmapConfigManagerInstance.workspaceConfigs;
 
     const env =
       Environment.isSystemTest || Environment.isIntegrationTest
@@ -122,7 +121,6 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       appmapConfigs.forEach((appmapConfig) => {
         services.push(
           new IndexProcessWatcher(
-            configFileProvider,
             appmapModulePath,
             appmapConfig.appmapDir,
             appmapConfig.configFolder,
@@ -137,7 +135,6 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       appmapConfigs.forEach((appmapConfig) => {
         services.push(
           new ScanProcessWatcher(
-            configFileProvider,
             scannerModulePath,
             appmapConfig.appmapDir,
             appmapConfig.configFolder,

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -31,6 +31,7 @@ export const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
   retryBackoff: (retryNumber: number) => Math.pow(2, retryNumber) * 1000,
 };
 
+// List appamp.yml files across all workspaces.
 export interface ConfigFileProvider {
   files(): Promise<vscode.Uri[]>;
   reset(): void;
@@ -202,6 +203,7 @@ export class ProcessWatcher implements vscode.Disposable {
   }
 
   dispose(): void {
+    // TODO: There's no await here, so onAbort and onError will not be fired.
     this.stop();
     this._onAbort.dispose();
     this._onError.dispose();

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 import { ChildProcess, OutputStream, spawn, SpawnOptions } from './nodeDependencyProcess';
 import { getApiKey } from '../authentication';
+import assert from 'assert';
+import { fileExists } from '../util';
+import { join } from 'path';
 
 export type RetryOptions = {
   // The number of retries made before declaring the process as failed.
@@ -51,6 +54,13 @@ export class ProcessWatcher implements vscode.Disposable {
   // A timeout period in which the crash count is to be reset if the timer is fulfilled.
   protected crashTimeout?: NodeJS.Timeout;
 
+  public get configFolder(): string {
+    const { cwd } = this.options;
+    assert(cwd, 'cwd is not defined');
+    const dir = cwd instanceof URL ? cwd.pathname : cwd.toString();
+    return dir;
+  }
+
   // Process errors are reported via this event emitter
   public get onError(): vscode.Event<Error> {
     return this._onError.event;
@@ -66,7 +76,7 @@ export class ProcessWatcher implements vscode.Disposable {
     return this.options.id;
   }
 
-  constructor(protected configFileProvider: ConfigFileProvider, options: ProcessWatcherOptions) {
+  constructor(options: ProcessWatcherOptions) {
     this.options = {
       ...DEFAULT_RETRY_OPTIONS,
       ...options,
@@ -110,11 +120,18 @@ export class ProcessWatcher implements vscode.Disposable {
     if (this.shouldRun) this.start();
   }
 
+  async isDirectoryConfigured(): Promise<boolean> {
+    return await fileExists(join(this.configFolder, 'appmap.yml'));
+  }
+
   async canStart(): Promise<{ enabled: boolean; reason?: string }> {
     if (this.hasAborted) return { enabled: false, reason: 'process has crashed too many times' };
 
-    const configFiles = await this.configFileProvider.files();
-    if (configFiles.length === 0) return { enabled: false, reason: 'appmap.yml does not exist' };
+    if (!(await this.isDirectoryConfigured()))
+      return {
+        enabled: false,
+        reason: `Project directory '${this.configFolder}' is not configured (does not have appmap.yml)`,
+      };
 
     if (!(await this.accessToken()))
       return { enabled: false, reason: 'User is not logged in to AppMap' };

--- a/src/services/scanProcessWatcher.ts
+++ b/src/services/scanProcessWatcher.ts
@@ -1,18 +1,12 @@
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
-import { ConfigFileProvider, ProcessId, ProcessWatcher } from './processWatcher';
+import { ProcessId, ProcessWatcher } from './processWatcher';
 
 export default class ScanProcessWatcher extends ProcessWatcher {
-  constructor(
-    configFileProvider: ConfigFileProvider,
-    modulePath: string,
-    appmapDir: string,
-    cwd: string,
-    env?: NodeJS.ProcessEnv
-  ) {
+  constructor(modulePath: string, appmapDir: string, cwd: string, env?: NodeJS.ProcessEnv) {
     const args = ['scan', '--watch', '--appmap-dir', appmapDir];
     if (ExtensionSettings.appMapCommandLineVerbose) args.push('--verbose');
-    super(configFileProvider, {
+    super({
       id: ProcessId.Analysis,
       modulePath: modulePath,
       log: NodeProcessService.outputChannel,

--- a/src/services/sourceFileWatcher.ts
+++ b/src/services/sourceFileWatcher.ts
@@ -14,6 +14,7 @@ export class SourceFileWatcher implements vscode.Disposable {
   }
 
   dispose() {
+    this._onChange.dispose();
     this.onChangedListener.dispose();
     this.watcher?.dispose();
   }

--- a/src/tree/appMapTreeDataProvider.ts
+++ b/src/tree/appMapTreeDataProvider.ts
@@ -48,6 +48,7 @@ export class AppMapTreeDataProvider implements vscode.TreeDataProvider<AppMapTre
   private appmaps: AppMapCollection;
   private appmapsUpToDate?: AppmapUptodateService;
 
+  // TreeDataProvider is not Disposable, so we can't dispose of this event emitter.
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 

--- a/src/tree/classMapTreeDataProvider.ts
+++ b/src/tree/classMapTreeDataProvider.ts
@@ -15,6 +15,7 @@ export interface CodeObjectTreeItem extends vscode.TreeItem {
 }
 
 export class ClassMapTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  // TreeDataProvider is not Disposable, so we can't dispose of this event emitter.
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -142,6 +142,7 @@ class FindingTreeItem extends vscode.TreeItem {
 export class FindingsTreeDataProvider
   implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable
 {
+  // TreeDataProvider is not Disposable, so we can't dispose of this event emitter.
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private findingsIndex?: FindingsIndex;

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -43,6 +43,7 @@ const icons = {
 
 export class InstructionsTreeDataProvider implements vscode.TreeDataProvider<DocPage> {
   public onDidChangeTreeData?: vscode.Event<void>;
+
   private projectState?: ProjectStateServiceInstance;
   private completion = new Map<DocPageId, boolean | undefined>();
 
@@ -52,9 +53,11 @@ export class InstructionsTreeDataProvider implements vscode.TreeDataProvider<Doc
   ) {
     if (projectStates.length === 1) {
       [this.projectState] = projectStates;
+      // TreeDataProvider is not Disposable, so we can't dispose of this event emitter.
       const emitter = new vscode.EventEmitter<void>();
       context.subscriptions.push(emitter);
       this.onDidChangeTreeData = emitter.event;
+      // TODO: Is this the same as adding the return value of this function to context.subscriptions?
       this.projectState.onStateChange(() => emitter.fire(), null, context.subscriptions);
       AnalysisManager.onAnalysisToggled(() => emitter.fire(), null, context.subscriptions);
     }

--- a/src/tree/linkTreeDataProvider.ts
+++ b/src/tree/linkTreeDataProvider.ts
@@ -15,6 +15,7 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
   private readonly context: vscode.ExtensionContext;
   private readonly linkDefinitions: LinkDefinitions;
 
+  // TreeDataProvider is not Disposable, so we can't dispose of this event emitter.
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
   public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 

--- a/src/uri/appmapServerAuthenticationHandler.ts
+++ b/src/uri/appmapServerAuthenticationHandler.ts
@@ -38,7 +38,8 @@ export default class AppMapServerAuthenticationHandler implements RequestHandler
   }
 
   dispose(): void {
-    // do nothing, we have nothing to dispose
+    this._onCreateSession.dispose();
+    this._onError.dispose();
   }
 
   static buildSession(email: string, licenseKey: string): vscode.AuthenticationSession {

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -1,13 +1,9 @@
 import * as vscode from 'vscode';
 import getWebviewContent from './getWebviewContent';
-import { workspaceServices } from '../services/workspaceServices';
-import { NodeProcessService } from '../services/nodeProcessService';
-import { warn } from 'console';
-import IndexProcessWatcher from '../services/indexProcessWatcher';
-import { ProcessId } from '../services/processWatcher';
 import appmapMessageHandler from './appmapMessageHandler';
 import FilterStore, { SavedFilter } from './filterStore';
 import WebviewList from './WebviewList';
+import selectIndexProcess, { IndexProcess, ReasonCode } from '../lib/selectIndexProcess';
 
 export default class ChatSearchWebview {
   private webviewList = new WebviewList();
@@ -27,54 +23,31 @@ export default class ChatSearchWebview {
     return this.webviewList.currentWebview;
   }
 
-  readyIndexProcess(workspace: vscode.WorkspaceFolder): IndexProcessWatcher | undefined {
-    const processServiceInstance = workspaceServices().getServiceInstanceFromClass(
-      NodeProcessService,
-      workspace
-    );
-    if (!processServiceInstance) return;
-
-    const indexProcess = processServiceInstance.processes.find(
-      (proc) => proc.id === ProcessId.Index
-    ) as IndexProcessWatcher;
-    if (!indexProcess) {
-      warn(`No ${ProcessId.Index} helper process found for workspace: ${workspace.name}`);
-      return;
-    }
-
-    if (!indexProcess.isRpcAvailable()) return;
-
-    return indexProcess;
-  }
-
-  isReady(workspace: vscode.WorkspaceFolder): boolean {
-    return !!this.readyIndexProcess(workspace);
-  }
-
   async explain(workspace?: vscode.WorkspaceFolder, question?: string) {
-    if (!workspace) {
-      const workspaces = vscode.workspace.workspaceFolders;
-      if (!workspaces) return;
+    const selectIndexProcessResult = await selectIndexProcess(workspace);
+    if (!selectIndexProcessResult) return;
 
-      if (workspaces.length === 1) {
-        workspace = workspaces[0];
-      } else {
-        workspace = await vscode.window.showWorkspaceFolderPick({
-          placeHolder: 'Select a workspace folder',
-        });
-      }
-      if (!workspace) return;
+    let selectedWatcher: IndexProcess | undefined;
+    switch (selectIndexProcessResult) {
+      case ReasonCode.NoIndexProcessWatchers:
+        vscode.window.showInformationMessage(
+          `${workspace?.name || 'Your workspace'} does not have AppMaps`
+        );
+        break;
+      case ReasonCode.NoReadyIndexProcessWatchers:
+        vscode.window.showInformationMessage(
+          `AppMap AI is not ready yet. Please try again in a few seconds.`
+        );
+        break;
+      case ReasonCode.NoSelectionMade:
+        break;
+      default:
+        selectedWatcher = selectIndexProcessResult;
+        break;
     }
+    if (!selectedWatcher) return;
 
-    const showError = async (message: string): Promise<string | undefined> => {
-      return vscode.window.showErrorMessage(message);
-    };
-
-    const indexProcess = this.readyIndexProcess(workspace);
-    if (!indexProcess)
-      return showError('AppMap Explain is not ready yet. Please try again in a few seconds.');
-
-    const { rpcPort: appmapRpcPort } = indexProcess;
+    const { rpcPort: appmapRpcPort } = selectedWatcher;
 
     const panel = vscode.window.createWebviewPanel(
       'chatSearch',

--- a/src/webviews/filterStore.ts
+++ b/src/webviews/filterStore.ts
@@ -13,6 +13,7 @@ export type FilterUpdateEvent = {
 };
 
 export default class FilterStore {
+  // TODO: This class should be Disposable and dispose of this event emitter.
   private _onDidChangeFilters = new vscode.EventEmitter<FilterUpdateEvent>();
   readonly onDidChangeFilters = this._onDidChangeFilters.event;
 

--- a/test/integration/appmapConfigManager/appmapConfigManager.test.ts
+++ b/test/integration/appmapConfigManager/appmapConfigManager.test.ts
@@ -27,7 +27,7 @@ const removeAppmapDirs = async (
   configManagerInstance: AppmapConfigManagerInstance
 ): Promise<void> => {
   await Promise.all(
-    configManagerInstance.workspaceConfig.configs.map(async (config) => {
+    configManagerInstance.workspaceConfigs.map(async (config) => {
       // NOTE: this assumes a two-level appmapDir like tmp/appmap or fake/dir
       try {
         await rm(dirname(join(config.configFolder, config.appmapDir)), { recursive: true });
@@ -92,7 +92,7 @@ describe('appmapConfigWatcher', () => {
 
   it('generates the correct config files', () => {
     const expected = expectedProjectConfigs.sort(sortByConfigFolder);
-    const actual = configManagerInstance.workspaceConfig.configs.sort(sortByConfigFolder);
+    const actual = configManagerInstance.workspaceConfigs.sort(sortByConfigFolder);
     assert.deepEqual(actual, expected);
   });
 
@@ -116,7 +116,7 @@ describe('appmapConfigWatcher', () => {
     await writeFile(filePath, '');
     await waitFor(
       'configManager to create a new config',
-      async () => configManagerInstance.workspaceConfig.configs.length === 4
+      async () => configManagerInstance.workspaceConfigs.length === 4
     );
 
     const expected = expectedProjectConfigs.slice();
@@ -127,7 +127,7 @@ describe('appmapConfigWatcher', () => {
     });
 
     assert.deepEqual(
-      configManagerInstance.workspaceConfig.configs.sort(sortByConfigFolder),
+      configManagerInstance.workspaceConfigs.sort(sortByConfigFolder),
       expected.sort(sortByConfigFolder)
     );
 
@@ -137,7 +137,7 @@ describe('appmapConfigWatcher', () => {
   it('detects a modified config file', async () => {
     await appendFile(join(projectMonorepo, 'sub-b', 'appmap.yml'), 'appmap_dir: new/one');
     await waitFor('update to configs', () =>
-      configManagerInstance.workspaceConfig.configs.some((config) => config.appmapDir === 'new/one')
+      configManagerInstance.workspaceConfigs.some((config) => config.appmapDir === 'new/one')
     );
 
     const expected = expectedProjectConfigs.slice();
@@ -150,7 +150,7 @@ describe('appmapConfigWatcher', () => {
     });
 
     assert.deepEqual(
-      configManagerInstance.workspaceConfig.configs.sort(sortByConfigFolder),
+      configManagerInstance.workspaceConfigs.sort(sortByConfigFolder),
       expected.sort(sortByConfigFolder)
     );
 

--- a/test/integration/explain/explain.test.ts
+++ b/test/integration/explain/explain.test.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { initializeWorkspace, waitFor, waitForExtension, withAuthenticatedUser } from '../util';
 import assert from 'assert';
+import { readyProcessWatchers } from '../../../src/lib/selectIndexProcess';
+import { initializeWorkspaceServices } from '../../../src/services/workspaceServices';
 
 describe('appmap.explain', () => {
   withAuthenticatedUser();
@@ -10,12 +12,17 @@ describe('appmap.explain', () => {
   afterEach(initializeWorkspace);
 
   it('opens a Chat + Search view', async () => {
+    initializeWorkspaceServices();
+
     const chatSearchWebview = (await waitForExtension()).chatSearchWebview;
 
     const workspace = vscode.workspace.workspaceFolders?.[0];
     assert(workspace);
 
-    await waitFor('Explain service is not ready', () => chatSearchWebview.isReady(workspace));
+    await waitFor(
+      'Explain service is not ready',
+      () => readyProcessWatchers(workspace)?.length !== 0
+    );
 
     await waitFor('Invoking appmap.explain opens a new text document', async () => {
       await vscode.commands.executeCommand('appmap.explain');

--- a/test/unit/lib/selectIndexProcess.test.ts
+++ b/test/unit/lib/selectIndexProcess.test.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import '../mock/vscode';
+import * as vscode from 'vscode';
+import * as workspaceServices from '../../../src/services/workspaceServices';
+import selectIndexProcess, { ReasonCode } from '../../../src/lib/selectIndexProcess';
+import { ProcessId } from '../../../src/services/processWatcher';
+import IndexProcessWatcher from '../../../src/services/indexProcessWatcher';
+
+describe('selectIndexProcess', () => {
+  let sandbox: sinon.SinonSandbox;
+  let processes: IndexProcessWatcher[];
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    processes = [];
+    const stubService = sandbox.stub();
+    sandbox.stub(workspaceServices, 'workspaceServices').returns({
+      getService: sandbox.stub().returns(stubService),
+      getServiceInstances: (service: unknown) => {
+        expect(service).to.eq(stubService);
+        return [{ processes }];
+      },
+    } as unknown as workspaceServices.WorkspaceServices);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('when there is no index process', () => {
+    it('returns undefined', async () => {
+      const result = await selectIndexProcess();
+      expect(result).to.eq(ReasonCode.NoIndexProcessWatchers);
+    });
+  });
+  describe('when there is one index process', () => {
+    describe('but the RPC port is not available', () => {
+      beforeEach(() => {
+        processes = [
+          {
+            id: ProcessId.Index,
+            isRpcAvailable: sandbox.stub().returns(false),
+          } as unknown as IndexProcessWatcher,
+        ];
+      });
+
+      it('returns undefined', async () => {
+        const result = await selectIndexProcess();
+        expect(result).to.eq(ReasonCode.NoReadyIndexProcessWatchers);
+      });
+    });
+    describe('and the RPC port is available', () => {
+      beforeEach(() => {
+        processes = [
+          {
+            id: ProcessId.Index,
+            isRpcAvailable: sandbox.stub().returns(true),
+            configFolder: './the-project',
+            rpcPort: 1234,
+          } as unknown as IndexProcessWatcher,
+        ];
+      });
+
+      it('returns the process', async () => {
+        const result = await selectIndexProcess();
+        expect(result).to.deep.equal({
+          configFolder: './the-project',
+          rpcPort: 1234,
+        });
+      });
+    });
+  });
+  describe('when there are multiple index processes', () => {
+    beforeEach(() => {
+      processes = [
+        {
+          id: ProcessId.Index,
+          isRpcAvailable: sandbox.stub().returns(true),
+          configFolder: './project-a',
+          rpcPort: 1,
+        } as unknown as IndexProcessWatcher,
+        {
+          id: ProcessId.Index,
+          isRpcAvailable: sandbox.stub().returns(true),
+          configFolder: './project-b',
+          rpcPort: 2,
+        } as unknown as IndexProcessWatcher,
+      ];
+    });
+
+    it('prompts the user to choose', async () => {
+      const quickPick = sandbox.stub(vscode.window, 'showQuickPick');
+      quickPick.onFirstCall().resolves({
+        label: './project-a',
+        watcher: processes[0],
+      } as unknown as vscode.QuickPickItem & { watcher: IndexProcessWatcher });
+
+      const result = await selectIndexProcess();
+      expect(result).to.deep.equal({
+        configFolder: './project-a',
+        rpcPort: 1,
+      });
+    });
+  });
+});

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -21,6 +21,7 @@ export default {
   showInputBox() {
     return '';
   },
+  showQuickPick: doNothing,
   showErrorMessage: doNothing,
   showInformationMessage: doNothing,
   workspaceFolders: [],

--- a/test/unit/services/processWatcher.test.ts
+++ b/test/unit/services/processWatcher.test.ts
@@ -5,9 +5,7 @@ import { join } from 'path';
 import ps from 'ps-node';
 import sinon from 'sinon';
 import { promisify } from 'util';
-import { Uri } from 'vscode';
 import {
-  ConfigFileProvider,
   ProcessId,
   ProcessWatcher,
   ProcessWatcherOptions,
@@ -18,18 +16,10 @@ import Sinon from 'sinon';
 const testModule = join(__dirname, 'support', 'simpleProcess.mjs');
 
 function makeWatcher(opts: Partial<ProcessWatcherOptions> = {}) {
-  const provider: ConfigFileProvider = {
-    files() {
-      return Promise.resolve([Uri.parse('test:///appmap.yml')]);
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    reset() {},
-  };
-
-  return new ProcessWatcher(provider, {
+  return new ProcessWatcher({
     id: 'test process' as unknown as ProcessId,
     modulePath: testModule,
+    cwd: '.',
     ...opts,
   });
 }


### PR DESCRIPTION
When there are multiple appmap.yml in a workspace, the user must be prompted to choose which one they want to use for their question. Each appmap.yml will correspond to a Navie RPC port, to which the question should be directed.

If there are no workspaces open with appmap.yml, then as before the Explain command won't run.

If there is exactly one index process with a ready RPC port, then this process is selected.

Otherwise, the user is prompted to choose which directory they want to run the Explain command in.

<img width="612" alt="Screen Shot 2024-01-23 at 4 36 59 PM" src="https://github.com/getappmap/vscode-appland/assets/86395/47154a85-c228-4dee-adb9-8ab46eec0c71">

Fixes #869 