### PR TITLE
Use `.appmapignore` to ignore certain directories

### DIFF
--- a/.appmapignore
+++ b/.appmapignore
@@ -1,0 +1,5 @@
+# This file instructs the AppMap extension & tool to ignore certain directores
+
+# Ignore all directories including 'test'
+
+test

--- a/src/lib/findFiles.ts
+++ b/src/lib/findFiles.ts
@@ -1,19 +1,23 @@
 import * as vscode from 'vscode';
 
 /* Find files taking files.watcherExclude into account. */
-export function findFiles(include: vscode.GlobPattern): Thenable<vscode.Uri[]> {
-  return vscode.workspace.findFiles(include, getExcludes());
+export function findFiles(
+  include: vscode.GlobPattern,
+  excludes: vscode.GlobPattern[] = []
+): Thenable<vscode.Uri[]> {
+  return vscode.workspace.findFiles(include, getExcludes(excludes));
 }
 
-function getExcludes(): vscode.GlobPattern | undefined {
-  const excludes = vscode.workspace
-    .getConfiguration('files')
-    .get<Record<string, boolean>>('watcherExclude');
-  if (!excludes) return;
-  const paths = Object.entries(excludes)
+function getExcludes(excludes: vscode.GlobPattern[]): vscode.GlobPattern | undefined {
+  const editorExcludes =
+    vscode.workspace.getConfiguration('files').get<Record<string, boolean>>('watcherExclude') || [];
+
+  if (editorExcludes.length === 0 && excludes.length === 0) return;
+
+  const editorExcludePaths = Object.entries(editorExcludes)
     .filter(([, enabled]) => enabled)
     .map(([path]) => path);
 
-  const result = `{${paths.join(',')}}`;
-  return result;
+  const workspaceExcludePaths = excludes.map((exclude) => exclude.toString());
+  return `{${editorExcludePaths.concat(workspaceExcludePaths).join(',')}}`;
 }

--- a/test/unit/services/appmapignoreManager.test.ts
+++ b/test/unit/services/appmapignoreManager.test.ts
@@ -1,0 +1,58 @@
+import '../mock/vscode';
+
+import assert from 'assert';
+import { SinonSandbox, createSandbox } from 'sinon';
+
+import { AppmapignoreManager } from '../../../src/services/appmapConfigManager';
+
+import { randomUUID } from 'crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+describe('AppmapignoreManager', () => {
+  let sinon: SinonSandbox;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockWorkspaceFolder: any;
+  let appmapignoreManager: AppmapignoreManager;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    sinon = createSandbox();
+    tmpDir = path.join(tmpdir(), randomUUID());
+    mkdirSync(tmpDir);
+
+    mockWorkspaceFolder = {
+      uri: {
+        fsPath: tmpDir,
+      },
+    };
+
+    appmapignoreManager = new AppmapignoreManager(mockWorkspaceFolder);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not add exclusions when no .appmapignore file is present', () => {
+    assert.deepStrictEqual(appmapignoreManager.getExclusions(), []);
+  });
+
+  it('adds exclusions when a .appmapignore file is present', () => {
+    const appmapignoreFileLines = ['test', 'test2/', '/test3', '/test4/'];
+    writeFileSync(path.join(tmpDir, '.appmapignore'), appmapignoreFileLines.join('\n'));
+
+    const expectedExclusions = ['**/test', '**/test2', 'test3', 'test4'];
+    assert.deepStrictEqual(appmapignoreManager.getExclusions(), expectedExclusions);
+  });
+
+  it('ignores empty lines and comments in .appmapignore file', () => {
+    const appmapignoreFileLines = ['test', '', '# test2', '/test3', '/test4/'];
+    writeFileSync(path.join(tmpDir, '.appmapignore'), appmapignoreFileLines.join('\n'));
+
+    const expectedExclusions = ['**/test', 'test3', 'test4'];
+    assert.deepStrictEqual(appmapignoreManager.getExclusions(), expectedExclusions);
+  });
+});


### PR DESCRIPTION
Adds the ability to specify directories to ignore using an `.appmapignore` file in the root of a project. It follows the same syntax for directories that `.gitignore` uses. So, a line containing `test` will ignore all directories containing `test`, while a line containing `/test` will ignore the `test` directory in the root folder of the project only.