### PR TITLE
Mimic new install in dev env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "env": {
-        "APPMAP_TELEMETRY_DEBUG": "1"
+        "APPMAP_TELEMETRY_DEBUG": "1",
+        "APPMAP_DEV_EXTENSION": "1"
       }
     },
     {

--- a/src/configuration/environment.ts
+++ b/src/configuration/environment.ts
@@ -8,4 +8,7 @@ export default class Environment {
   static get isSystemTest(): boolean {
     return process.env.APPMAP_SYSTEM_TEST !== undefined;
   }
+  static get isDevelopmentExtension(): boolean {
+    return process.env.APPMAP_DEV_EXTENSION !== undefined;
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,7 @@ import {
   ExecOptions as ProcessExecOptions,
 } from 'child_process';
 import * as vscode from 'vscode';
+import Environment from './configuration/environment';
 
 const REDIRECT_STATUS_CODES = [301, 302, 307, 308];
 
@@ -231,6 +232,8 @@ export async function chainPromises(
  * indicate that this is not a new user.
  */
 export function hasPreviouslyInstalledExtension(extensionPath: string): boolean {
+  if (Environment.isDevelopmentExtension) return false;
+
   const extensionDirectories = [
     ...new Set(
       vscode.extensions.all.map((extension) => path.dirname(extension.extensionUri.fsPath))


### PR DESCRIPTION
Fixes #660 

This was working as expected but it was difficult to mimic a new installation in our dev environment. This change makes it so that using `AppMap: Reset Usage State` will create a mimic of a new installation after reloading the Extension Host window.