### PR TITLE
Users can activate with email

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,7 +507,7 @@
   "dependencies": {
     "@appland/appmap": "^3.121.0",
     "@appland/client": "^1.14.1",
-    "@appland/components": "^4.5.0",
+    "@appland/components": "^4.6.0",
     "@appland/diagrams": "^1.8.0",
     "@appland/models": "^2.10.0",
     "@appland/scanner": "^1.86.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,8 +174,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     );
     context.subscriptions.push(
       appmapServerAuthenticationProvider.onDidChangeSessions((e) => {
-        if (e.added?.length) vscode.window.showInformationMessage('Logged in to AppMap');
-        if (e.removed?.length) vscode.window.showInformationMessage('Logged out of AppMap');
+        if (e.added?.length) vscode.window.showInformationMessage('AppMap activated');
         AppMapServerConfiguration.updateAppMapClientConfiguration();
       })
     );

--- a/src/webviews/getWebviewContent.ts
+++ b/src/webviews/getWebviewContent.ts
@@ -9,13 +9,21 @@ type AppmapModule =
   | 'finding-info-view'
   | 'sign-in-view';
 
+type getWebviewContentOptions = {
+  htmlStyle?: string;
+  rpcPort?: number;
+  connectSrc?: string[];
+};
+
 export default function getWebviewContent(
   webview: vscode.Webview,
   context: vscode.ExtensionContext,
   title: string,
   appmapModule: AppmapModule,
-  { htmlStyle, rpcPort }: { htmlStyle?: string; rpcPort?: number } = {}
+  options: getWebviewContentOptions = {}
 ): string {
+  const { htmlStyle, rpcPort } = options;
+
   const scriptUri = webview.asWebviewUri(
     vscode.Uri.file(path.join(context.extensionPath, 'out', 'app.js'))
   );
@@ -24,6 +32,9 @@ export default function getWebviewContent(
     vscode.Uri.file(path.join(context.extensionPath, 'out', 'app.css'))
   );
 
+  const connectSrc = options.connectSrc ?? [];
+  if (rpcPort) connectSrc.push(`http://localhost:${rpcPort}`);
+
   return ` <!DOCTYPE html>
   <html style="${htmlStyle ?? ''}" lang="en">
   <head>
@@ -31,7 +42,7 @@ export default function getWebviewContent(
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="
       default-src 'none';
-      connect-src ${rpcPort ? `http://localhost:${rpcPort}` : "'none'"};
+      connect-src ${connectSrc.join(' ').trim()};
       img-src ${webview.cspSource} data:;
       script-src ${webview.cspSource} 'unsafe-eval';
       style-src ${webview.cspSource} 'unsafe-inline';

--- a/web/src/appmapView.js
+++ b/web/src/appmapView.js
@@ -92,4 +92,3 @@ export default function mountApp() {
 
   vscode.postMessage({ command: 'appmap-ready' });
 }
-``;

--- a/web/src/signInView.js
+++ b/web/src/signInView.js
@@ -8,20 +8,31 @@ export default function mountSignInView() {
   const vscode = window.acquireVsCodeApi();
   const messages = new MessagePublisher(vscode);
 
-  const app = new Vue({
-    el: '#app',
-    render(h) {
-      return h(VSidebarSignIn, {
-        ref: 'ui',
-      });
-    },
+  messages.on('init-sign-in', (initialData) => {
+    const app = new Vue({
+      el: '#app',
+      render(h) {
+        return h(VSidebarSignIn, {
+          ref: 'ui',
+          props: {
+            appmapServerUrl: initialData.appmapServerUrl,
+          },
+        });
+      },
+    });
+
+    app.$on('sign-in', () => {
+      messages.rpc('sign-in');
+    });
+
+    app.$on('activate', (apiKey) => {
+      messages.rpc('activate', apiKey);
+    });
+
+    app.$on('click-sign-in-link', (linkType) => {
+      messages.rpc('click-sign-in-link', linkType);
+    });
   });
 
-  app.$on('sign-in', () => {
-    messages.rpc('sign-in');
-  });
-
-  app.$on('click-sign-in-link', (linkType) => {
-    messages.rpc('click-sign-in-link', linkType);
-  });
+  vscode.postMessage({ command: 'sign-in-ready' });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,9 +175,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "@appland/components@npm:4.5.0"
+"@appland/components@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@appland/components@npm:4.6.0"
   dependencies:
     "@appland/client": ^1.12.0
     "@appland/diagrams": ^1.7.0
@@ -198,7 +198,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.14
     vuex: ^3.6.0
-  checksum: ed1f8ea871d39732c4ad3eb65dc6293049925d83cf4976f93c00ce060246f4b40eb05bf2278169cc3a6c02f955fd037908a188ed5faf7c9effc97fb64b413b57
+  checksum: c1c078d9700bb2f94b3376e1b76d405780da4f6799beb75cb133f340163740ddf7e58826ba40423fc550c49d20e00e3ca05ad823d00c40e728881bc4635d109f
   languageName: node
   linkType: hard
 
@@ -3164,7 +3164,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.121.0
     "@appland/client": ^1.14.1
-    "@appland/components": ^4.5.0
+    "@appland/components": ^4.6.0
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.0
     "@appland/scanner": ^1.86.0


### PR DESCRIPTION
This incorporates the new `Activate AppMap` webview in place of the `Sign In` webview from [this PR](https://github.com/getappmap/appmap-js/pull/1620). It also handles the `activate` message from the webview that activates a user based on their email.