### PR TITLE
feat: Enable configuration of the Navie / JSON-RPC port

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,10 @@
         "appMap.indexOptions": {
           "type": "string",
           "description": "Options to pass to the appmap index command"
+        },
+        "appMap.navie.rpcPort": {
+          "type": "number",
+          "description": "Port number to pass to the Navie UI (used for extension development and debugging only)"
         }
       }
     },

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -42,4 +42,9 @@ export default class ExtensionSettings {
   public static get apiUrl(): string {
     return vscode.workspace.getConfiguration('appMap').get('apiUrl') || DefaultApiURL;
   }
+
+  public static get navieRpcPort(): number | undefined {
+    const port = vscode.workspace.getConfiguration('appMap').get('navie.rpcPort');
+    if (port && typeof port === 'number' && port > 0) return port;
+  }
 }

--- a/src/services/indexProcessWatcher.ts
+++ b/src/services/indexProcessWatcher.ts
@@ -27,6 +27,13 @@ export default class IndexProcessWatcher extends ProcessWatcher {
       env,
     };
     super(context, options);
+
+    this.rpcPort = ExtensionSettings.navieRpcPort;
+    if (this.rpcPort) {
+      this.options.log?.appendLine(
+        `Using RPC port assigned by extension setting appMap.navie.rpcPort: ${this.rpcPort}`
+      );
+    }
   }
 
   public isRpcAvailable(): boolean {
@@ -35,6 +42,13 @@ export default class IndexProcessWatcher extends ProcessWatcher {
 
   protected onStdout(data: string): void {
     super.onStdout(data);
+
+    if (this.rpcPort) {
+      this.options.log?.appendLine(
+        `Ignoring stdout from index process for purposes of obtaining the RPC port, because it's already configured as ${this.rpcPort}`
+      );
+      return;
+    }
 
     this.stdoutBuffer += data;
     const lines = this.stdoutBuffer.split('\n');


### PR DESCRIPTION
This is used for development, running byok Navie in a separate local process or debugger.