### PR TITLE
CLI installer fix

### DIFF
--- a/src/commands/installAgent.ts
+++ b/src/commands/installAgent.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import os from 'os';
 import { join } from 'path';
+import semver from 'semver';
 import { INSTALL_BUTTON_ERROR, Telemetry } from '../telemetry';
 import { NodeProcessService } from '../services/nodeProcessService';
 import { Installer } from './installer';
@@ -48,7 +49,13 @@ function electronCommand(globalStorageDir: string, installLocation: string): str
   // This is the exact behavior we want to emulate in the terminal, so we'll use it here as well.
   const nodePath = escapePath(process.execPath);
   const cliPath = join(globalStorageDir, 'node_modules', '@appland', 'appmap', 'built', 'cli.js');
-  const flags = ['--ms-enable-electron-run-as-node', '-d', installLocation];
+  const flags = ['-d', installLocation];
+
+  // This flag was required in VS Code versions prior to 1.86.0
+  const vsCodeVersion = semver.coerce(vscode.version);
+  if (vsCodeVersion && semver.lt(vsCodeVersion, '1.86.0'))
+    flags.push('--ms-enable-electron-run-as-node');
+
   return `ELECTRON_RUN_AS_NODE=true ${nodePath} ${cliPath} install ${flags.join(' ')}`;
 }
 

--- a/test/integration/command/installAgent.test.ts
+++ b/test/integration/command/installAgent.test.ts
@@ -161,7 +161,7 @@ describe('generateInstallInfo function', () => {
         const expectedStart = 'ELECTRON_RUN_AS_NODE=true';
         const expectedEnd =
           '/home/user/.config/Code/user\\ folder/globalStorage/node_modules/@appland/appmap/built/cli.js install ' +
-          '--ms-enable-electron-run-as-node -d /home/user/projects/directory\\ with\\ spaces';
+          '-d /home/user/projects/directory\\ with\\ spaces';
         assert.deepStrictEqual(env, { ELECTRON_RUN_AS_NODE: 'true' });
         assert(command.startsWith(expectedStart));
         assert(command.includes(expectedEnd));
@@ -197,7 +197,7 @@ describe('generateInstallInfo function', () => {
         const expectedStart = 'ELECTRON_RUN_AS_NODE=true';
         const expectedEnd =
           '/home/user/.config/Code/folder/globalStorage/node_modules/@appland/appmap/built/cli.js install ' +
-          '--ms-enable-electron-run-as-node -d /home/user/projects/directory-without-spaces';
+          '-d /home/user/projects/directory-without-spaces';
         assert.deepStrictEqual(env, { ELECTRON_RUN_AS_NODE: 'true' });
         assert(command.startsWith(expectedStart));
         assert(command.includes(expectedEnd));


### PR DESCRIPTION
Fixes #913 

Only add the `--ms-enable-electron-run-as-node` flag for versions of VS Code prior to 1.86.0.