### PR TITLE
Include Navie in VS Code extension description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "appland",
   "name": "appmap",
   "displayName": "AppMap",
-  "description": "Interactive maps of runtime code behavior",
+  "description": "Runtime diagrams + Navie AI Software Architect",
   "version": "0.112.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update the text that appears in the IDE when you search for AppMap:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/f4fec4df-23ef-46b1-b77d-91bb9d793920)

This is the old text, I'm not sure how to get a preview of the new text.