### PR TITLE
Open Navie from an appmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -516,7 +516,7 @@
   "dependencies": {
     "@appland/appmap": "^3.129.0",
     "@appland/client": "^1.14.1",
-    "@appland/components": "^4.11.0",
+    "@appland/components": "^4.12.0",
     "@appland/diagrams": "^1.8.0",
     "@appland/models": "^2.10.0",
     "@appland/rpc": "latest",

--- a/src/commands/commandRegistry.ts
+++ b/src/commands/commandRegistry.ts
@@ -71,7 +71,7 @@ export default class CommandRegistry {
     const disposable = vscode.commands.registerCommand(options.command, async (...args: any[]) => {
       const commands = await vscode.commands.getCommands(true);
       if (commands.includes(options.target)) {
-        return vscode.commands.executeCommand(options.target, args);
+        return vscode.commands.executeCommand(options.target, ...args);
       }
 
       return vscode.window.withProgress(
@@ -93,7 +93,7 @@ export default class CommandRegistry {
             disposable = this.onCommandRegistered((command) => {
               if (command === options.target) {
                 cleanup();
-                resolve(vscode.commands.executeCommand(options.target, args));
+                resolve(vscode.commands.executeCommand(options.target, ...args));
               }
             });
 

--- a/src/commands/quickSearch.ts
+++ b/src/commands/quickSearch.ts
@@ -68,7 +68,7 @@ export default function quickSearch(context: vscode.ExtensionContext) {
       'appmap.quickExplain',
       (workspaceUri: vscode.Uri, codeSelection: string) => {
         const workspace = vscode.workspace.getWorkspaceFolder(workspaceUri);
-        vscode.commands.executeCommand('appmap.explain.impl', { workspace, codeSelection });
+        vscode.commands.executeCommand('appmap.explain', { workspace, codeSelection });
       }
     )
   );

--- a/src/commands/quickSearch.ts
+++ b/src/commands/quickSearch.ts
@@ -66,9 +66,9 @@ export default function quickSearch(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'appmap.quickExplain',
-      (workspaceUri: vscode.Uri, selectedCode: string) => {
+      (workspaceUri: vscode.Uri, codeSelection: string) => {
         const workspace = vscode.workspace.getWorkspaceFolder(workspaceUri);
-        vscode.commands.executeCommand('appmap.explain', workspace, selectedCode);
+        vscode.commands.executeCommand('appmap.explain.impl', { workspace, codeSelection });
       }
     )
   );

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -319,7 +319,7 @@ export default class AppMapEditorProvider
           try {
             const appmapString = fs.readFileSync(mapFsPath, 'utf-8');
             const appmap = JSON.parse(appmapString);
-            vscode.commands.executeCommand('appmap.explain.impl', {
+            vscode.commands.executeCommand('appmap.explain', {
               targetAppmap: appmap,
               targetAppmapFsPath: mapFsPath,
             });

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -308,11 +308,25 @@ export default class AppMapEditorProvider
             shareEnabled: false,
             defaultView: extensionSettings.defaultDiagramView || 'viewSequence',
             savedFilters: this.filterStore.getSavedFilters(),
+            appmapFsPath: document.uri.fsPath,
           });
           break;
         case 'onLoadComplete':
           this.documents.push(document);
           break;
+        case 'ask-navie-about-map': {
+          const mapFsPath = message.mapFsPath;
+          try {
+            const appmapString = fs.readFileSync(mapFsPath, 'utf-8');
+            const appmap = JSON.parse(appmapString);
+            vscode.commands.executeCommand('appmap.explain.impl', {
+              targetAppmap: appmap,
+              targetAppmapFsPath: mapFsPath,
+            });
+          } catch (e) {
+            console.error('Error reading appmap file: ', e);
+          }
+        }
       }
     });
 

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -13,6 +13,14 @@ import RpcProcessService from '../services/rpcProcessService';
 import { NodeProcessService } from '../services/nodeProcessService';
 import CommandRegistry from '../commands/commandRegistry';
 
+type ExplainOpts = {
+  workspace?: vscode.WorkspaceFolder;
+  codeSelection?: CodeSelection;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  targetAppmap?: any;
+  targetAppmapFsPath?: string;
+};
+
 export default class ChatSearchWebview {
   private webviewList = new WebviewList();
   private filterStore: FilterStore;
@@ -36,7 +44,7 @@ export default class ChatSearchWebview {
     return this.webviewList.currentWebview;
   }
 
-  async explain(workspace?: vscode.WorkspaceFolder, codeSelection?: CodeSelection) {
+  async explain({ workspace, codeSelection, targetAppmap, targetAppmapFsPath }: ExplainOpts = {}) {
     const appmapRpcPort = await this.rpcService.port();
     if (!appmapRpcPort) {
       const optionViewLog = 'View output log';
@@ -111,6 +119,8 @@ export default class ChatSearchWebview {
             mostRecentAppMaps,
             apiUrl: ExtensionSettings.apiUrl,
             apiKey: await getApiKey(false),
+            targetAppmap,
+            targetAppmapFsPath,
           });
           break;
         case 'open-record-instructions':

--- a/web/src/appmapView.js
+++ b/web/src/appmapView.js
@@ -11,11 +11,12 @@ export default function mountApp() {
   const messages = new MessagePublisher(vscode);
 
   messages.on('init-appmap', (initialData) => {
-    const { shareEnabled, defaultView, savedFilters } = initialData;
+    const { shareEnabled, defaultView, savedFilters, appmapFsPath } = initialData;
     const props = {
       appMapUploadable: shareEnabled,
       defaultView,
       savedFilters,
+      appmapFsPath,
     };
 
     const app = new Vue({
@@ -80,6 +81,10 @@ export default function mountApp() {
         default:
           break;
       }
+    });
+
+    app.$on('ask-navie-about-map', (mapFsPath) => {
+      vscode.postMessage({ command: 'ask-navie-about-map', mapFsPath });
     });
 
     // Webviews are normally torn down when not visible and re-created when they become visible again.

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -21,6 +21,8 @@ export default function mountChatSearchView() {
             apiKey: initialData.apiKey,
             mostRecentAppMaps: this.mostRecentAppMaps,
             appmapYmlPresent: this.appmapYmlPresent,
+            targetAppmapData: initialData.targetAppmap,
+            targetAppmapFsPath: initialData.targetAppmapFsPath,
           },
         });
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,7 +149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^4.0.0, @appland/components@npm:^4.11.0":
+"@appland/components@npm:^4.0.0":
   version: 4.11.0
   resolution: "@appland/components@npm:4.11.0"
   dependencies:
@@ -173,6 +173,33 @@ __metadata:
     vue: ^2.7.14
     vuex: ^3.6.0
   checksum: 2f8b2d24e541133f7928e60b13e0d1001bd6b90ddde2fd9b813badb800dc5b26a56d1b3bbcc5b5131c05bb417968a54180ae325ae1fd060911fc8d428fc83a0a
+  languageName: node
+  linkType: hard
+
+"@appland/components@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "@appland/components@npm:4.12.0"
+  dependencies:
+    "@appland/client": ^1.12.0
+    "@appland/diagrams": ^1.7.0
+    "@appland/models": ^2.10.0
+    "@appland/rpc": ^1.1.0
+    "@appland/sequence-diagram": ^1.11.0
+    buffer: ^6.0.3
+    d3: ^7.8.4
+    d3-flame-graph: ^4.1.3
+    diff: ^5.1.0
+    dom-to-svg: ^0.12.2
+    dompurify: ^3.0.6
+    events: ^3.3.0
+    highlight.js: ^11.9.0
+    jayson: ^4.1.0
+    marked: ^10.0.0
+    marked-highlight: ^2.0.7
+    sql-formatter: ^4.0.2
+    vue: ^2.7.14
+    vuex: ^3.6.0
+  checksum: ffec2fd93894c02c5ba3492fcd382cce0aedc8a1e8a4265e57d24f8fb2a8165fc5c0ddd4e69ecc9f95da8f616b68eb4e76d5d8e7803c2396e8b99a8f45ea5843
   languageName: node
   linkType: hard
 
@@ -3154,7 +3181,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.129.0
     "@appland/client": ^1.14.1
-    "@appland/components": ^4.11.0
+    "@appland/components": ^4.12.0
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.0
     "@appland/rpc": latest


### PR DESCRIPTION
Fixes getappmap/board#316

Handles messages and props related to [this PR](https://github.com/getappmap/appmap-js/pull/1636) so that users can open Navie from within an AppMap and ask about it.

## Changes to AppMap webview

### New prop

`appmapFsPath`: Pass this prop to the AppMap webview when opening. It is the file system path of the AppMap. This is required for this feature to work correctly.

### New message

`ask-navie-about-map`: This is emitted when a user clicks on the `Ask Navie` button in an AppMap. It will have one parameter `mapFsPath`, which is the file system path of the appmap. To handle this message:

1. Read the AppMap data from the specified file path.
2. Open Navie, passing the props `targetAppmapData` and `targetAppmapFsPath`. `targetAppmapData` is the AppMap data that was just read from the file and `targetAppmapFsPath` is `mapFsPath`.



## Changes to Navie webview

### New props

`targetAppmapData`: This is an optional prop that should be set when handling the `ask-navie-about-map` event from above. It is the raw AppMap data of the target AppMap.

`targetAppmapFsPath`: This is an optional prop that should be set when handling the `ask-navie-about-map` event from above. It is the file system path of the target AppMap.


