### PR TITLE
Retrieving saved filters always returns an array

### DIFF
--- a/src/webviews/filterStore.ts
+++ b/src/webviews/filterStore.ts
@@ -20,7 +20,7 @@ export default class FilterStore {
   constructor(private readonly context: vscode.ExtensionContext) {}
 
   getSavedFilters(): SavedFilter[] {
-    return this.context.workspaceState.get(SAVED_FILTERS) as SavedFilter[] | [];
+    return (this.context.workspaceState.get(SAVED_FILTERS) as SavedFilter[]) || [];
   }
 
   async setFilters(filters: SavedFilter[]): Promise<void> {


### PR DESCRIPTION
I noticed this error when I was working on something else recently:
```
stack trace: TypeError: Cannot read properties of undefined (reading 'map')
    at FilterStore.saveFilter (/home/ahtrotta/projects/appmap/vscode-appland/src/webviews/filterStore.ts:36:33)
    at w.value (/home/ahtrotta/projects/appmap/vscode-appland/src/webviews/appmapMessageHandler.ts:85:21)
    at n.y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:1902)
    at n.z (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:1972)
    at n.fire (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:2188)
    at E.$onMessage (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:142:14051)
    at s.S (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:147:5519)
    at s.Q (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:147:5285)
    at s.M (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:147:4375)
    at s.L (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:147:3593)
    at w.value (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:147:2241)
    at n.y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:1902)
    at n.fire (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:2119)
    at r.fire (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:105:14091)
    at w.value (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:173:8050)
    at n.y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:1902)
    at n.fire (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:80:2119)
    at r.fire (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:105:14091)
    at MessagePortMain.<anonymous> (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:173:6330)
    at MessagePortMain.emit (node:events:514:28)
    at Object.emit (node:electron/js2c/utility_init:2:2285)
    at Object.callbackTrampoline (node:internal/async_hooks:130:17)
```

When saved filters were being retrieved, if the user had never saved filters before, then `getSavedFilters` would return `undefined`, but it was supposed to be returning an empty array.