### PR TITLE
feat: Allow configuring CLI environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,6 +260,13 @@
           "type": "boolean",
           "description": "Enable verbose output from AppMap command line tools"
         },
+        "appMap.commandLineEnvironment": {
+          "type": "object",
+          "description": "Environment variables to pass to AppMap command line tools. NOTE: Requires a restart to take effect.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "appMap.indexOptions": {
           "type": "string",
           "description": "Options to pass to the appmap index command"

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -35,6 +35,10 @@ export default class ExtensionSettings {
     );
   }
 
+  public static get appMapCommandLineEnvironment(): Readonly<Record<string, string>> | undefined {
+    return vscode.workspace.getConfiguration('appMap').get('commandLineEnvironment');
+  }
+
   public static get appMapIndexOptions(): string | undefined {
     return vscode.workspace.getConfiguration('appMap').get('indexOptions');
   }

--- a/test/unit/services/processWatcher.test.ts
+++ b/test/unit/services/processWatcher.test.ts
@@ -6,11 +6,13 @@ import { join } from 'path';
 import ps from 'ps-node';
 import sinon from 'sinon';
 import { promisify } from 'util';
+import type vscode from 'vscode';
 
 // To be stubbed
 import * as processWatcher from '../../../src/services/processWatcher';
 import * as navieConfigurationService from '../../../src/services/navieConfigurationService';
 import * as authentication from '../../../src/authentication';
+import ExtensionSettings from '../../../src/configuration/extensionSettings';
 
 // To be tested
 import {
@@ -112,6 +114,23 @@ describe('ProcessWatcher', () => {
           APPMAP_API_KEY: 'the-appmap-key',
           APPMAP_API_URL: 'https://api.getappmap.com',
           OPENAI_API_KEY: 'the-openai-key',
+        });
+      });
+
+      it('uses it as Azure OpenAI key if Azure OpenAI is configured', async () => {
+        Sinon.stub(ExtensionSettings, 'appMapCommandLineEnvironment').value({
+          AZURE_OPENAI_API_VERSION: '2024-02-01',
+          AZURE_OPENAI_API_INSTANCE_NAME: 'appmap-openai',
+          AZURE_OPENAI_API_DEPLOYMENT_NAME: 'navie-gpt-35-test',
+        });
+        const env = await processWatcher.loadEnvironment({} as vscode.ExtensionContext);
+        expect(env).to.deep.equal({
+          APPMAP_API_KEY: 'the-appmap-key',
+          APPMAP_API_URL: 'https://api.getappmap.com',
+          AZURE_OPENAI_API_KEY: 'the-openai-key',
+          AZURE_OPENAI_API_VERSION: '2024-02-01',
+          AZURE_OPENAI_API_INSTANCE_NAME: 'appmap-openai',
+          AZURE_OPENAI_API_DEPLOYMENT_NAME: 'navie-gpt-35-test',
         });
       });
     });


### PR DESCRIPTION
Also, if Azure OpenAI configuration is detected in the configured environment, use the OpenAI key from secrets storage for it.

![obraz](https://github.com/getappmap/vscode-appland/assets/823636/35297bca-f6dd-4d6d-8227-40fc6ed2cd1f)
