### PR TITLE
feat: Enable configuration of the Navie / JSON-RPC port

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,10 @@
         "appMap.indexOptions": {
           "type": "string",
           "description": "Options to pass to the appmap index command"
+        },
+        "appMap.navie.rpcPort": {
+          "type": "number",
+          "description": "Port number to pass to the Navie UI (used for extension development and debugging only)"
         }
       }
     },

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -42,4 +42,9 @@ export default class ExtensionSettings {
   public static get apiUrl(): string {
     return vscode.workspace.getConfiguration('appMap').get('apiUrl') || DefaultApiURL;
   }
+
+  public static get navieRpcPort(): number | undefined {
+    const port = vscode.workspace.getConfiguration('appMap').get('navie.rpcPort');
+    if (port && typeof port === 'number' && port > 0) return port;
+  }
 }

--- a/src/services/appmapConfigManager.ts
+++ b/src/services/appmapConfigManager.ts
@@ -77,7 +77,8 @@ class ConfigFileProviderImpl implements ConfigFileProvider {
 
   public async files(): Promise<vscode.Uri[]> {
     if (this._files) return this._files;
-    this._files = await findFiles(this.pattern, this.exclusions);
+
+    this._files = this._files = await findFiles(this.pattern, this.exclusions);
     return this._files;
   }
 

--- a/src/services/rpcProcessWatcher.ts
+++ b/src/services/rpcProcessWatcher.ts
@@ -8,6 +8,7 @@ export default class RpcProcessWatcher extends ProcessWatcher {
     new vscode.EventEmitter<number>();
   public readonly onRpcPortChange = this._onRpcPortChange.event;
   public rpcPort?: number;
+  private configuredPortLogged = false;
   private stdoutBuffer = '';
 
   constructor(context: vscode.ExtensionContext, modulePath: string, env?: NodeJS.ProcessEnv) {
@@ -23,6 +24,13 @@ export default class RpcProcessWatcher extends ProcessWatcher {
       env,
     };
     super(context, options);
+
+    this.rpcPort = ExtensionSettings.navieRpcPort;
+    if (this.rpcPort) {
+      this.options.log?.appendLine(
+        `Using RPC port assigned by extension setting appMap.navie.rpcPort: ${this.rpcPort}`
+      );
+    }
   }
 
   // Override
@@ -38,21 +46,38 @@ export default class RpcProcessWatcher extends ProcessWatcher {
   protected onStdout(data: string): void {
     super.onStdout(data);
 
+    // Wait for the RPC port to be logged, and detect it.
+    // If a project setting overrides the port, report that port instead.
+
     this.stdoutBuffer += data;
     const lines = this.stdoutBuffer.split('\n');
     this.stdoutBuffer = this.stdoutBuffer.slice(-100);
 
-    const portStr = lines
-      .map((line) => {
-        const match = line.match(/^Running JSON-RPC server on port: (\d+)$/);
-        if (match) return match[1];
-      })
-      .find(Boolean);
-    if (portStr) {
-      this.options.log?.appendLine(`AppMap index process listening on port ${portStr}`);
-      this.rpcPort = parseInt(portStr);
+    const detectRpcPort = () =>
+      lines
+        .map((line) => {
+          const match = line.match(/^Running JSON-RPC server on port: (\d+)$/);
+          if (match) return match[1];
+        })
+        .find(Boolean);
+
+    const consumeRpcPort = (portStr: string) => {
+      this.options.log?.appendLine(`AppMap RPC process listening on port ${portStr}`);
+      if (this.rpcPort) {
+        if (!this.configuredPortLogged) {
+          this.options.log?.appendLine(
+            `Ignoring stdout from RPC process for purposes of obtaining the RPC port, because it's already configured as ${this.rpcPort}`
+          );
+          this.configuredPortLogged = true;
+        }
+      } else {
+        this.rpcPort = parseInt(portStr);
+      }
       this._onRpcPortChange.fire(this.rpcPort);
-    }
+    };
+
+    const portStr = detectRpcPort();
+    if (portStr) consumeRpcPort(portStr);
   }
 
   dispose(): void {

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -23,7 +23,7 @@ export default class Watcher extends FileChangeEmitter {
       debug('%s: onCreate(%s)', this.filePattern, uri);
       this._onCreate.fire(uri);
     });
-    debug('%s: finished initital scan', this.filePattern);
+    debug('%s: finished initial scan', this.filePattern);
   }
 
   async dispose() {


### PR DESCRIPTION
This is used for development, running byok Navie in a separate local process or debugger.

Run the command `appmap rpc` (e.g. in a debugger), then you can set the port as a VSCode option and "Ask Navie" windows will connect to your running `rpc` command instead of the `rpc` helper command managed by VSCode. 

<img width="638" alt="Screen Shot 2024-03-25 at 1 47 24 PM" src="https://github.com/getappmap/vscode-appland/assets/86395/f1861742-f0d8-49ed-b4c4-cc30b09169a7">
