### PR TITLE
fix: Windows binaries properly use the .exe extension

### DIFF
--- a/src/assets/assetService.ts
+++ b/src/assets/assetService.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { AppMapCliDownloader, JavaAgentDownloader, ScannerDownloader } from '.';
+import { AppMapCliDownloader, JavaAgentDownloader, ScannerDownloader, binaryName } from '.';
 import AssetDownloader from './assetDownloader';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -52,9 +52,9 @@ export default class AssetService {
     // This could be a property on each AssetDownloader
     switch (assetId) {
       case AssetIdentifier.AppMapCli:
-        return join(homedir(), '.appmap', 'bin', 'appmap');
+        return join(homedir(), '.appmap', 'bin', binaryName('appmap'));
       case AssetIdentifier.ScannerCli:
-        return join(homedir(), '.appmap', 'bin', 'scanner');
+        return join(homedir(), '.appmap', 'bin', binaryName('scanner'));
       case AssetIdentifier.JavaAgent:
         return join(homedir(), '.appmap', 'lib', 'java', 'appmap.jar');
       default:

--- a/test/unit/assets/appmapCliDownloader.test.ts
+++ b/test/unit/assets/appmapCliDownloader.test.ts
@@ -1,0 +1,45 @@
+import '../mock/vscode';
+import Sinon from 'sinon';
+import os, { tmpdir } from 'os';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { default as chai, expect } from 'chai';
+import { default as chaiFs } from 'chai-fs';
+import { join } from 'path';
+import { AppMapCliDownloader } from '../../../src/assets';
+import { DownloadHooks } from '../../../src/assets/assetDownloader';
+
+chai.use(chaiFs);
+
+describe('AppMapCliDownloader', () => {
+  let homeDir: string;
+  const platform = 'win32';
+  const arch = 'x64';
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'vscode-appland-appmap-download-test-'));
+    Sinon.stub(os, 'homedir').returns(homeDir);
+    Sinon.stub(process, 'platform').value(platform);
+    Sinon.stub(process, 'arch').value(arch);
+  });
+
+  afterEach(async () => {
+    Sinon.restore();
+    await rm(homeDir, { recursive: true });
+  });
+
+  it('fixes missing symlinks', async () => {
+    // Private variable access
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { skippedDownload } = (AppMapCliDownloader as any).downloadHooks as DownloadHooks;
+
+    await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
+    await mkdir(join(homeDir, '.appmap', 'lib', 'appmap'), { recursive: true });
+    await writeFile(join(homeDir, '.appmap', 'lib', 'appmap', 'appmap-v0.0.0-TEST'), 'test');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await skippedDownload!('0.0.0-TEST');
+
+    // Upon skipping the download, the missing symlink should be restored
+    expect(join(homeDir, '.appmap', 'bin', 'appmap.exe')).to.be.a.file();
+  });
+});


### PR DESCRIPTION
Windows won't spawn a process unless it has the magical `exe` file extension. The secondary benefit of this pull request is it'll always restore missing symlinks, regardless of platform.