### PR TITLE
Add a Navie section to the sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,13 +288,28 @@
     },
     "viewsWelcome": [
       {
+        "view": "appmap.views.instructions",
+        "contents": "AppMap is initializing...",
+        "when": "!appmap.initialized"
+      },
+      {
+        "view": "appmap.views.navie",
+        "contents": "AppMap is initializing...",
+        "when": "!appmap.initialized"
+      },
+      {
+        "view": "appmap.views.navie",
+        "contents": "Ask Navie a question about your application to get started.\n[New Navie Chat](command:appmap.explain)\nNavie uses AppMap data to improve the accuracy of Generative AI models. Navie searches through your locally stored AppMap data to identify the application behavior related to your question.",
+        "when": "appmap.initialized"
+      },
+      {
         "view": "appmap.views.appmaps",
         "contents": "AppMap is initializing...",
         "when": "!appmap.initialized"
       },
       {
         "view": "appmap.views.appmaps",
-        "contents": "All the AppMaps that are present in this workspace will be listed here.\n[Open Instructions](command:appmap.openInstallGuide)\n",
+        "contents": "Creating AppMap data for the areas of your application that interest you helps Navie answer very specific questions.\n[Create AppMap Data](command:appmap.openInstallGuide)\n",
         "when": "appmap.initialized"
       },
       {
@@ -311,6 +326,11 @@
         "view": "appmap.views.findings",
         "contents": "AppMap is initializing...",
         "when": "!appmap.initialized"
+      },
+      {
+        "view": "appmap.views.documentation",
+        "contents": "AppMap is initializing...",
+        "when": "!appmap.initialized"
       }
     ],
     "views": {
@@ -323,14 +343,20 @@
           "when": "appMap.showSignIn"
         },
         {
-          "id": "appmap.views.instructions",
-          "name": "Instructions",
+          "id": "appmap.views.navie",
+          "name": "Navie",
           "visibility": "visible",
           "when": "!appMap.showSignIn"
         },
         {
+          "id": "appmap.views.instructions",
+          "name": "AppMap Recording Instructions",
+          "visibility": "collapsed",
+          "when": "!appMap.showSignIn"
+        },
+        {
           "id": "appmap.views.appmaps",
-          "name": "AppMaps",
+          "name": "AppMap Data",
           "contextualTitle": "AppMap",
           "visibility": "visible",
           "icon": "images/logo.svg",
@@ -339,7 +365,7 @@
         {
           "id": "appmap.views.findings",
           "name": "Runtime Analysis",
-          "visibility": "visible",
+          "visibility": "collapsed",
           "when": "!appMap.showSignIn"
         },
         {

--- a/test/system/src/appMap.ts
+++ b/test/system/src/appMap.ts
@@ -32,7 +32,7 @@ export default class AppMap {
   }
 
   get instructionsTree(): Locator {
-    return this.page.locator('.pane:has(.title:text("Instructions"))');
+    return this.page.locator('.pane:has(.title:text("AppMap Recording Instructions"))');
   }
 
   get findingsTree(): Locator {
@@ -40,7 +40,7 @@ export default class AppMap {
   }
 
   get appMapTree(): Locator {
-    return this.page.locator('.pane:has(.title:text("AppMaps"))');
+    return this.page.locator('.pane:has(.title:text("AppMap Data"))');
   }
 
   public instructionsTreeItem(step: InstructionStep): Locator {
@@ -65,17 +65,21 @@ export default class AppMap {
     }
   }
 
-  public async openActionPanel(waitForAppMaps = false): Promise<void> {
-    await this.actionPanelButton.click();
-    await this.ready(waitForAppMaps);
+  public async expandInstructions(): Promise<void> {
+    if (await this.instructionsTree.locator('.pane-body').isHidden()) {
+      await this.instructionsTree.click();
+    }
   }
 
-  public async ready(waitForAppMaps = false): Promise<void> {
-    const welcomeView = await this.page.locator(
-      '.split-view-view:has(.title:text("AppMaps")) >> .welcome-view'
-    );
+  public async openActionPanel(): Promise<void> {
+    await this.actionPanelButton.click();
+  }
 
-    await welcomeView.first().waitFor({ state: waitForAppMaps ? 'hidden' : 'visible' });
+  public async ready(): Promise<void> {
+    const welcomeView = this.page.locator(
+      '.split-view-view:has(.title:text("AppMap Data")) >> .welcome-view'
+    );
+    await welcomeView.first().waitFor({ state: 'visible' });
   }
 
   public async openInstruction(step: InstructionStep): Promise<void> {

--- a/test/system/tests/findings.test.ts
+++ b/test/system/tests/findings.test.ts
@@ -19,7 +19,8 @@ describe('Findings and scanning', function () {
     await project.restoreFiles('**/*.appmap.json');
     await driver.waitForFile(path.join(project.workspacePath, 'tmp', '**', 'mtime')); // Wait for the indexer
 
-    await driver.appMap.openActionPanel(true);
+    await driver.appMap.openActionPanel();
+    await driver.appMap.ready();
     await driver.appMap.expandFindings();
     await driver.appMap.findingsTree.click();
     await driver.appMap.findingsTreeItem().waitFor();

--- a/test/system/tests/instructions.test.ts
+++ b/test/system/tests/instructions.test.ts
@@ -23,6 +23,7 @@ describe('Instructions tree view', function () {
   it('accurately depicts the installation state', async function () {
     const { driver, project } = this;
     await driver.appMap.openActionPanel();
+    await driver.appMap.expandInstructions();
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.InstallAppMapAgent,
       InstructionStepStatus.Pending
@@ -72,6 +73,7 @@ describe('Instructions tree view', function () {
     const { driver } = this;
 
     await driver.appMap.openActionPanel();
+    await driver.appMap.expandInstructions();
 
     const pages = [
       { step: InstructionStep.InstallAppMapAgent, title: 'Add AppMap to your project' },
@@ -99,6 +101,7 @@ describe('Instructions tree view', function () {
     };
 
     await driver.appMap.openActionPanel();
+    await driver.appMap.expandInstructions();
     await driver.appMap.openInstruction(InstructionStep.InstallAppMapAgent);
     await assertTabs(1);
 
@@ -114,6 +117,7 @@ describe('Instructions tree view', function () {
     const pidfile = path.join(project.workspacePath, '**', 'index.pid');
     await driver.waitForFile(pidfile);
     await driver.appMap.openActionPanel();
+    await driver.appMap.expandInstructions();
     await project.restoreFiles('**/*.appmap.json');
     await driver.appMap.openInstruction(InstructionStep.NavieIntroduction);
     await driver.appMap.pendingBadge.waitFor({ state: 'hidden' });
@@ -123,6 +127,7 @@ describe('Instructions tree view', function () {
     const { driver, project } = this;
 
     await driver.appMap.openActionPanel();
+    await driver.appMap.expandInstructions();
     await driver.appMap.ready();
 
     await driver.appMap.pendingBadge.waitFor({ state: 'visible' });
@@ -176,6 +181,7 @@ describe('Instructions tree view', function () {
     await driver.waitForReady();
     await driver.appMap.openActionPanel();
     await driver.appMap.ready();
+    await driver.appMap.expandInstructions();
 
     const expectProjectPicker = () =>
       waitFor(


### PR DESCRIPTION
* Add a `NAVIE` section to the sidebar containing a large blue button that opens the Navie chat interface.
* Rename `INSTRUCTIONS` to `APPMAP RECORDING INSTRUCTIONS`.
* Rename `APPMAPS` to `APPMAP DATA`.
* Change the text and button when there is no AppMap data.
* Make the instructions and runtime analysis sections collapsed by default.
* Show the same `AppMap is inititalizing...` message for all of the sidebar sections.

![image](https://github.com/getappmap/vscode-appland/assets/45714532/f1628059-487e-4723-bf0a-90da498e2485)

