### PR TITLE
feat: Send active code editor selection to Navie

### DIFF
--- a/resources/versions.json
+++ b/resources/versions.json
@@ -1,5 +1,5 @@
 {
-  "appmap": "3.135.1",
+  "appmap": "3.136.0",
   "scanner": "1.86.0",
-  "appmap-java.jar": "1.26.5"
+  "appmap-java.jar": "1.26.7"
 }

--- a/src/services/chatSearchDataService.ts
+++ b/src/services/chatSearchDataService.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import RpcProcessService from './rpcProcessService';
+import AppMapCollection from './appmapCollection';
+import { CodeSelection } from '../commands/quickSearch';
+
+export type ChatSearchData = {
+  appmapRpcPort: number | undefined;
+  codeSelection?: CodeSelection;
+  apiKey: string | undefined;
+  apiUrl: string;
+  mostRecentAppMaps: Array<{ [key: string]: unknown }>;
+  appmapYmlPresent: boolean;
+};
+
+export type LatestAppMap = {
+  name: string | undefined;
+  recordingMethod: string | undefined;
+  createdAt: string;
+  path: string;
+};
+
+export default class ChatSearchDataService {
+  private _onAppMapsUpdated = new vscode.EventEmitter<LatestAppMap[]>();
+
+  constructor(private rpcService: RpcProcessService, private appmaps: AppMapCollection) {
+    appmaps.onUpdated(() => this._onAppMapsUpdated.fire(this.latestAppMaps()));
+  }
+
+  onAppMapsUpdated(listener: (appmaps: LatestAppMap[]) => void): vscode.Disposable {
+    return this._onAppMapsUpdated.event(listener);
+  }
+
+  get appmapRpcPort(): number | undefined {
+    return this.rpcService.port();
+  }
+
+  async codeSelection(): Promise<CodeSelection | undefined> {
+    const activeEditor = vscode.window.activeTextEditor;
+    const selection = activeEditor?.selection;
+    if (selection) {
+      const text = activeEditor.document.getText(selection);
+      if (text) {
+        return {
+          path: activeEditor.document.fileName,
+          lineStart: selection.start.line,
+          lineEnd: selection.end.line,
+          code: text,
+          language: activeEditor.document.languageId,
+        };
+      }
+    }
+  }
+
+  public latestAppMaps(count = 10): LatestAppMap[] {
+    return this.appmaps
+      .allAppMaps()
+      .sort((a, b) => b.descriptor.timestamp - a.descriptor.timestamp)
+      .slice(0, count)
+      .map((appmap) => ({
+        name: appmap.descriptor.metadata?.name,
+        recordingMethod: appmap.descriptor.metadata?.recorder?.type,
+        createdAt: new Date(appmap.descriptor.timestamp).toISOString(),
+        path: appmap.descriptor.resourceUri.fsPath,
+      }));
+  }
+}

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -47,7 +47,7 @@ export default class RpcProcessService implements Disposable {
     return Boolean(this.rpcPort) && Boolean(this.processWatcher.running);
   }
 
-  public async port(): Promise<number | undefined> {
+  public port(): number | undefined {
     return this.rpcPort;
   }
 

--- a/test/unit/mock/vscode/Selection.ts
+++ b/test/unit/mock/vscode/Selection.ts
@@ -1,0 +1,5 @@
+import Position from './Position';
+
+export default class Selection {
+  constructor(public readonly start: Position, public readonly end: Position) {}
+}

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -3,6 +3,7 @@ import mockery from 'mockery';
 import TextDocument from './TextDocument';
 import Range from './Range';
 import Position from './Position';
+import Selection from './Selection';
 import EventEmitter from './EventEmitter';
 import Terminal from './Terminal';
 import CodeAction from './CodeAction';
@@ -32,6 +33,7 @@ const MockVSCode = {
   TextDocument,
   Range,
   Position,
+  Selection,
   CodeAction,
   CodeActionKind,
   extensions,

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -38,4 +38,5 @@ export default {
     return new Terminal(options);
   },
   onDidChangeTerminalState: EmitOnDidChangeTerminalState.event,
+  activeTextEditor: undefined,
 };

--- a/test/unit/services/chatSearchData.test.ts
+++ b/test/unit/services/chatSearchData.test.ts
@@ -1,0 +1,145 @@
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import '../mock/vscode';
+import * as vscode from 'vscode';
+
+import AppMapCollection from '../../../src/services/appmapCollection';
+import RpcProcessService from '../../../src/services/rpcProcessService';
+import ChatSearchDataService, { LatestAppMap } from '../../../src/services/chatSearchDataService';
+
+type AppMapListener = (appmaps: LatestAppMap[]) => void;
+
+describe('ChatSearchData', () => {
+  let sinon: Sinon.SinonSandbox;
+  let chatSearchData: ChatSearchDataService;
+  let port: Sinon.SinonStub;
+  let onUpdatedStub: Sinon.SinonStub;
+  let allAppMapsStub: Sinon.SinonStub;
+  let appmapListeners: Array<AppMapListener>;
+  let appmaps: AppMapCollection;
+
+  beforeEach(async () => {
+    sinon = Sinon.createSandbox();
+    port = sinon.stub();
+    appmapListeners = [];
+    onUpdatedStub = sinon.stub().callsFake((listener: AppMapListener) => {
+      appmapListeners.push(listener);
+    });
+    allAppMapsStub = sinon.stub();
+    appmaps = {
+      allAppMaps: allAppMapsStub,
+      onUpdated: onUpdatedStub,
+    } as any;
+    const rpcService: RpcProcessService = { port } as any;
+    chatSearchData = new ChatSearchDataService(rpcService, appmaps);
+  });
+
+  describe('when no port is available', () => {
+    it('appmapRpcPort is undefined', () => {
+      expect(chatSearchData.appmapRpcPort).to.be.undefined;
+    });
+  });
+
+  describe('when a port is available', () => {
+    beforeEach(() => port.returns(1234));
+
+    it('appmapRpcPort returns the port', () => {
+      expect(chatSearchData.appmapRpcPort).to.equal(1234);
+    });
+  });
+
+  describe('when an active text editor is available', () => {
+    // Mock activeTextEditor to simulate a user code selection
+    const mockTextSelection = new vscode.Selection(
+      new vscode.Position(5, 0), // Start line 5
+      new vscode.Position(7, 10) // End line 7, character 10
+    );
+    const mockTextDocument: Partial<vscode.TextDocument> = {
+      fileName: '/path/to/file.js',
+      getText: () => 'const selectedCode = true;',
+      languageId: 'javascript',
+    };
+
+    describe('but no code selection is made', () => {
+      it('codeSelection returns undefined', async () => {
+        const mockTextEditor: Partial<vscode.TextEditor> = {
+          document: mockTextDocument as vscode.TextDocument,
+        };
+
+        sinon
+          .stub(vscode.window, 'activeTextEditor')
+          .get(() => mockTextEditor as vscode.TextEditor);
+
+        const selection = await chatSearchData.codeSelection();
+        expect(selection).to.be.undefined;
+      });
+    });
+
+    describe('and a code selection is made', () => {
+      it('codeSelection returns details about the selection', async () => {
+        const mockTextEditor: Partial<vscode.TextEditor> = {
+          selection: mockTextSelection,
+          document: mockTextDocument as vscode.TextDocument,
+        };
+
+        sinon
+          .stub(vscode.window, 'activeTextEditor')
+          .get(() => mockTextEditor as vscode.TextEditor);
+
+        const selection = await chatSearchData.codeSelection();
+        const code = mockTextDocument.getText
+          ? mockTextDocument.getText(mockTextSelection)
+          : undefined;
+
+        expect(selection).to.deep.equal({
+          path: mockTextDocument.fileName,
+          lineStart: mockTextSelection.start.line,
+          lineEnd: mockTextSelection.end.line,
+          code,
+          language: mockTextDocument.languageId,
+        });
+      });
+    });
+  });
+
+  describe('latestAppMaps', () => {
+    // Mock appmaps with timestamps
+    const mockAppMaps = [...Array(20).keys()].map((i) => ({
+      descriptor: {
+        timestamp: Date.now() - i * 1000, // Assure descending order by timestamp
+        metadata: { name: `AppMap ${i}` },
+        resourceUri: { fsPath: `path/to/appmap${i}.json` },
+      },
+    }));
+
+    beforeEach(() => allAppMapsStub.returns(mockAppMaps));
+
+    it('provides the latest 10 appmaps based on timestamp', async () => {
+      const latestAppMaps = chatSearchData.latestAppMaps();
+
+      expect(latestAppMaps).to.have.lengthOf(10);
+      expect(latestAppMaps[0].name).to.equal('AppMap 0'); // Most recent
+      expect(latestAppMaps[9].name).to.equal('AppMap 9'); // 10th recent
+    });
+
+    describe('onAppMapsUpdated event', () => {
+      it('should fire when appmaps are updated, providing the latest appmaps', (done) => {
+        chatSearchData.onAppMapsUpdated((latestAppMaps) => {
+          try {
+            expect(latestAppMaps).to.be.an('array').that.is.not.empty;
+            done();
+          } catch (error) {
+            done(error);
+          }
+        });
+
+        // Trigger the update
+        expect(appmapListeners).to.have.lengthOf(1);
+        for (const listener of appmapListeners) {
+          listener([sinon.stub() as unknown as LatestAppMap]);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Propagate code selection to Navie. 

## Example

Select code:

<img width="805" alt="Screen Shot 2024-04-19 at 1 43 41 PM" src="https://github.com/getappmap/vscode-appland/assets/86395/1def10d9-a826-4803-b7c8-0f7b64982d09">

Open Navie, the code selection is populated the same way as if you'd used the light bulb:

<img width="620" alt="Screen Shot 2024-04-19 at 1 44 09 PM" src="https://github.com/getappmap/vscode-appland/assets/86395/250a9424-506e-4c71-a9e0-af3d3bea0546">

- [x] Test latest appmaps event
- [x] Pass AppMaps as the event argument
