### PR TITLE
test: test command failures, too

### DIFF
--- a/test/integration/command/deleteAppMap.test.ts
+++ b/test/integration/command/deleteAppMap.test.ts
@@ -36,4 +36,14 @@ describe('deleteAppMap test', function () {
     );
     assert.isTrue(index === -1);
   });
+
+  it("doesn't delete other types of files", async () => {
+    const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage');
+    const uri: vscode.Uri = vscode.Uri.parse(`file://${appmapFilePath}`);
+    await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(vscode.Uri.file(uri.path));
+    await vscode.commands.executeCommand('appmap.context.deleteAppMap');
+
+    assert.equal(showErrorStub.callCount, 1);
+  });
 });

--- a/test/integration/command/openAsJson.test.ts
+++ b/test/integration/command/openAsJson.test.ts
@@ -36,4 +36,14 @@ describe('openAsJson test', function () {
     );
     assert.isTrue(index !== -1);
   });
+
+  it("doesn't open non-AppMap files", async () => {
+    const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage');
+    const uri: vscode.Uri = vscode.Uri.parse(`file://${appmapFilePath}`);
+    await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(vscode.Uri.file(uri.path));
+    await vscode.commands.executeCommand('appmap.context.openAsJson');
+
+    assert.equal(showErrorStub.callCount, 1);
+  });
 });


### PR DESCRIPTION
Add tests to ensure deleteAppMap and openAsJson fail if the active tab isn't an AppMap.