### PR TITLE
feat: Scanner is disabled by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,11 @@
         "appMap.navie.rpcPort": {
           "type": "number",
           "description": "Port number to pass to the Navie UI (used for extension development and debugging only)"
+        },
+        "appMap.scannerEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable AppMap scanner"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "qna": "https://appmap.io/docs/faq.html",
   "engines": {
-    "vscode": "^1.82.0"
+    "vscode": "^1.61.0"
   },
   "agents": {
     "ruby": ">=0.60.0"

--- a/package.json
+++ b/package.json
@@ -394,7 +394,7 @@
           "id": "appmap.views.findings",
           "name": "Runtime Analysis",
           "visibility": "collapsed",
-          "when": "!appMap.showSignIn"
+          "when": "!appMap.showSignIn && appmap.scannerEnabled"
         },
         {
           "id": "appmap.views.codeObjects",

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -51,4 +51,10 @@ export default class ExtensionSettings {
     const port = vscode.workspace.getConfiguration('appMap').get('navie.rpcPort');
     if (port && typeof port === 'number' && port > 0) return port;
   }
+
+  public static get scannerEnabled(): boolean {
+    return [true, 'true'].includes(
+      vscode.workspace.getConfiguration('appMap').get('scannerEnabled') || false
+    );
+  }
 }

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -57,4 +57,9 @@ export default class ExtensionSettings {
       vscode.workspace.getConfiguration('appMap').get('scannerEnabled') || false
     );
   }
+
+  // Perform any context bindings that are dependent on settings.
+  public static bindContext(): void {
+    vscode.commands.executeCommand('setContext', 'appmap.scannerEnabled', this.scannerEnabled);
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ import CommandRegistry from './commands/commandRegistry';
 import AssetService from './assets/assetService';
 import clearNavieAiSettings from './commands/clearNavieAiSettings';
 import EnvironmentVariableService from './services/environmentVariableService';
+import ExtensionSettings from './configuration/extensionSettings';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   CommandRegistry.setContext(context).addWaitAlias({
@@ -251,6 +252,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
       return webview;
     })();
+
+    ExtensionSettings.bindContext();
 
     const trees = registerTrees(
       context,

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import Environment from '../configuration/environment';
+import ExtensionSettings from '../configuration/extensionSettings';
 import IndexProcessWatcher from './indexProcessWatcher';
 import { getModulePath, ProgramName } from './nodeDependencyProcess';
 import NodeProcessServiceInstance from './nodeProcessServiceInstance';
@@ -82,20 +83,22 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
       );
     });
 
-    const scannerModulePath = getModulePath(ProgramName.Scanner);
-    const scannerBinPath = AssetService.getAssetPath(AssetIdentifier.ScannerCli);
-    appmapConfigs.forEach((appmapConfig) => {
-      services.push(
-        new ScanProcessWatcher(
-          this.context,
-          scannerModulePath,
-          scannerBinPath,
-          appmapConfig.appmapDir,
-          appmapConfig.configFolder,
-          env
-        )
-      );
-    });
+    if (ExtensionSettings.scannerEnabled) {
+      const scannerModulePath = getModulePath(ProgramName.Scanner);
+      const scannerBinPath = AssetService.getAssetPath(AssetIdentifier.ScannerCli);
+      appmapConfigs.forEach((appmapConfig) => {
+        services.push(
+          new ScanProcessWatcher(
+            this.context,
+            scannerModulePath,
+            scannerBinPath,
+            appmapConfig.appmapDir,
+            appmapConfig.configFolder,
+            env
+          )
+        );
+      });
+    }
 
     return services;
   }

--- a/test/fixtures/workspaces/project-a/.vscode/settings.json
+++ b/test/fixtures/workspaces/project-a/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "appMap.inspectEnabled": false
+  "appMap.inspectEnabled": false,
+  "appMap.scannerEnabled": true
 }

--- a/test/fixtures/workspaces/project-several-findings/.vscode/settings.json
+++ b/test/fixtures/workspaces/project-several-findings/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "appMap.inspectEnabled": false
+  "appMap.inspectEnabled": false,
+  "appMap.scannerEnabled": true
 }

--- a/test/fixtures/workspaces/project-system/.vscode/settings.json
+++ b/test/fixtures/workspaces/project-system/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "appMap.inspectEnabled": false,
+  "appMap.scannerEnabled": true
+}

--- a/test/integration/scanner/settingsDefault.test.ts
+++ b/test/integration/scanner/settingsDefault.test.ts
@@ -1,0 +1,22 @@
+// @project project-base
+// Use a different project because project-a has scannerEnabled: true setting
+import assert from 'assert';
+import { initializeWorkspace, waitForExtension, withAuthenticatedUser } from '../util';
+import ExtensionSettings from '../../../src/configuration/extensionSettings';
+import { getBackgroundProcesses } from '../nodeProcesses/util';
+import { ProcessId } from '../../../src/services/processWatcher';
+
+describe('Scanner', () => {
+  withAuthenticatedUser();
+
+  beforeEach(initializeWorkspace);
+  beforeEach(waitForExtension);
+  afterEach(initializeWorkspace);
+
+  it('is turned off by default', async () => {
+    assert.strictEqual(ExtensionSettings.scannerEnabled, false);
+
+    const processes = await getBackgroundProcesses();
+    assert(!Object.keys(processes).includes(ProcessId.Analysis));
+  });
+});


### PR DESCRIPTION
Fixes #973.

- Adds "Enable AppMap scanner" to the extension settings to enable/disable `scanner` process with the default value of `disabled`.
- Change is applied only after restart.
- Adds a test to verify the new setting.
- Adds `scannerEnabled: true` setting to the fixture projects which are used in the tests assuming `scanner` is running by default.