### PR TITLE
fix: Authentication provider timeouts

### DIFF
--- a/src/authentication/index.ts
+++ b/src/authentication/index.ts
@@ -10,8 +10,16 @@ export const AUTHN_PROVIDER_NAME = 'appmap.server';
 export async function getApiKey(createIfNone: boolean): Promise<string | undefined> {
   if (!createIfNone && Environment.appMapTestApiKey) return Environment.appMapTestApiKey;
 
-  const session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
-    createIfNone,
-  });
+  let session: vscode.AuthenticationSession | undefined;
+  try {
+    session = await vscode.authentication.getSession(AUTHN_PROVIDER_NAME, ['default'], {
+      createIfNone,
+    });
+  } catch (e) {
+    // VSCode may throw a string instead of an Error, e.g., if the authentication provider is not registered in time.
+    const err = e instanceof Error ? e : new Error(String(e));
+    console.error(err);
+  }
+
   return session?.accessToken;
 }


### PR DESCRIPTION
This change handles cases where `vscode.authentication.getSession` may time out waiting for the authentication provider to register. Upon initialization, we immediately request a session, however we don't initialize the authentication provider until we're halfway through activation.

Just handling this error is enough to fix the issue, however I've also moved the authentication provider's initialization to the top of activation to fix a cosmetic issue. On its own, this may have been enough to fix the issue, but catching the exception is a guarantee.