### PR TITLE
fix: Do not hardcode vscode: scheme

### DIFF
--- a/src/authentication/authenticationStrategy/vscodeProtocolRedirect.ts
+++ b/src/authentication/authenticationStrategy/vscodeProtocolRedirect.ts
@@ -22,7 +22,9 @@ export default class VscodeProtocolRedirect implements AuthenticationStrategy {
       }, new URLSearchParams())
       .toString();
 
-    const uri = vscode.Uri.parse(`vscode://appland.appmap/authn-appmap-server`).with({ query });
+    const uri = vscode.Uri.parse(
+      `${vscode.env.uriScheme}://appland.appmap/authn-appmap-server`
+    ).with({ query });
     const externalUri = await vscode.env.asExternalUri(uri);
     return externalUri.toString();
   }

--- a/test/unit/authentication/authenticationStrategy/vscodeProtocolRedirect.test.ts
+++ b/test/unit/authentication/authenticationStrategy/vscodeProtocolRedirect.test.ts
@@ -35,7 +35,9 @@ describe('VscodeProtocolRedirect', () => {
   it('should redirect to the correct URL', async () => {
     const queryParams = { client_id: '123' };
     const redirectUrl = await vscodeProtocolRedirect.redirectUrl(Object.entries(queryParams));
-    expect(redirectUrl).to.equal('vscode://appland.appmap/authn-appmap-server?client_id%3D123');
+    expect(redirectUrl).to.equal(
+      'vscode-test://appland.appmap/authn-appmap-server?client_id%3D123'
+    );
   });
 
   it('should return the correct auth URL', () => {

--- a/test/unit/authentication/authenticationStrategy/vscodeProtocolRedirect.test.ts
+++ b/test/unit/authentication/authenticationStrategy/vscodeProtocolRedirect.test.ts
@@ -1,0 +1,47 @@
+import '../../mock/vscode';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import * as vscode from 'vscode';
+
+import VscodeProtocolRedirect from '../../../../src/authentication/authenticationStrategy/vscodeProtocolRedirect';
+import ExtensionSettings from '../../../../src/configuration/extensionSettings';
+import AppMapServerAuthenticationHandler from '../../../../src/uri/appmapServerAuthenticationHandler';
+import UriHandler from '../../../../src/uri/uriHandler';
+
+describe('VscodeProtocolRedirect', () => {
+  let uriHandler: UriHandler;
+  let authnHandler: AppMapServerAuthenticationHandler;
+  let vscodeProtocolRedirect: VscodeProtocolRedirect;
+
+  beforeEach(() => {
+    uriHandler = new UriHandler();
+    authnHandler = new AppMapServerAuthenticationHandler('your-nonce-value');
+    vscodeProtocolRedirect = new VscodeProtocolRedirect(uriHandler, authnHandler);
+    sinon
+      .stub(ExtensionSettings, 'appMapServerURL')
+      .get(() => vscode.Uri.parse('https://server.appmap.test'));
+  });
+
+  afterEach(() => {
+    vscodeProtocolRedirect.dispose();
+  });
+
+  it('should have the correct authnPath', () => {
+    expect(vscodeProtocolRedirect.authnPath).to.equal('authn_provider/vscode');
+  });
+
+  it('should redirect to the correct URL', async () => {
+    const queryParams = { client_id: '123' };
+    const redirectUrl = await vscodeProtocolRedirect.redirectUrl(Object.entries(queryParams));
+    expect(redirectUrl).to.equal('vscode://appland.appmap/authn-appmap-server?client_id%3D123');
+  });
+
+  it('should return the correct auth URL', () => {
+    const authUrl = vscodeProtocolRedirect.getAuthUrl();
+    expect(authUrl).to.deep.equal(
+      vscode.Uri.parse('https://server.appmap.test/authn_provider/vscode')
+    );
+  });
+});

--- a/test/unit/mock/vscode/env.ts
+++ b/test/unit/mock/vscode/env.ts
@@ -1,3 +1,9 @@
+import { Uri } from 'vscode';
+
 export function isTelemetryEnabled() {
   return false;
+}
+
+export async function asExternalUri(uri: Uri) {
+  return uri;
 }

--- a/test/unit/mock/vscode/env.ts
+++ b/test/unit/mock/vscode/env.ts
@@ -7,3 +7,6 @@ export function isTelemetryEnabled() {
 export async function asExternalUri(uri: Uri) {
   return uri;
 }
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const uriScheme = 'vscode-test';


### PR DESCRIPTION
The scheme is not always `vscode:`; for example in insiders it's `vscode-insiders:`. This problem prevented login from working on insiders; it's possible Codium would have the same issue.