### PR TITLE
feat: Allow use of VSCode LLM API

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,6 +294,10 @@
           "type": "string",
           "description": "Options to pass to the appmap index command"
         },
+        "appMap.navie.useVSCodeLM": {
+          "type": "boolean",
+          "description": "Use VSCode language model API for Navie AI if available.\nRequires a recent VSCode version and (currently) GitHub Copilot extension."
+        },
         "appMap.navie.rpcPort": {
           "type": "number",
           "description": "Port number to pass to the Navie UI (used for extension development and debugging only)"

--- a/package.json
+++ b/package.json
@@ -509,6 +509,7 @@
     "test:unit:some": "mocha",
     "test": "yarn test:unit && yarn test:web-client && yarn test:integration && yarn test:system",
     "compile": "NODE_ENV=production tsup --config tsup.config.ts",
+    "compile:dev": "tsup --config tsup.config.ts",
     "watch": "tsup --config tsup.config.ts --watch",
     "package": "vsce package",
     "publish": "vsce publish",

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -52,6 +52,12 @@ export default class ExtensionSettings {
     if (port && typeof port === 'number' && port > 0) return port;
   }
 
+  public static get useVsCodeLM(): boolean {
+    return [true, 'true'].includes(
+      vscode.workspace.getConfiguration('appMap').get('navie.useVSCodeLM') || false
+    );
+  }
+
   public static get scannerEnabled(): boolean {
     return [true, 'true'].includes(
       vscode.workspace.getConfiguration('appMap').get('scannerEnabled') || false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { resetUsageState } from './commands/resetUsageState';
 import AppMapCollectionFile from './services/appmapCollectionFile';
 import { AppmapUptodateService } from './services/appmapUptodateService';
 import { AppMapWatcher } from './services/appmapWatcher';
+import ChatCompletion from './services/chatCompletion';
 import ClassMapIndex from './services/classMapIndex';
 import LineInfoIndex from './services/lineInfoIndex';
 import { NodeProcessService } from './services/nodeProcessService';
@@ -230,6 +231,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     await workspaceServices.enroll(runConfigService);
 
+    initializeCopilotIntegration(context);
+
     AssetService.register(context);
     const dependenciesInstalled = AssetService.updateAll();
     const chatSearchWebview: Promise<ChatSearchWebview> = (async () => {
@@ -326,5 +329,65 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       errorCode: ErrorCode.InitializationFailure,
     });
     throw exception;
+  }
+}
+
+function initializeCopilotIntegration(context: vscode.ExtensionContext) {
+  // TODO: make the messages and handling generic for all LM extensions
+
+  const hasLM = 'lm' in vscode && 'selectChatModels' in vscode.lm;
+
+  if (ExtensionSettings.useVsCodeLM && checkAvailability())
+    context.subscriptions.push(new ChatCompletion());
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (e) => {
+      if (e.affectsConfiguration('appMap.navie.useVSCodeLM')) {
+        // Only suggest reloading if it's been disabled or if it's enabled and the extension is available
+        if (
+          (!ExtensionSettings.useVsCodeLM && (await ChatCompletion.instance)) ||
+          (ExtensionSettings.useVsCodeLM && checkAvailability())
+        )
+          notifyReload();
+      }
+    })
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let _onModelChange: vscode.Disposable;
+
+  function checkAvailability() {
+    if (!hasLM)
+      vscode.window.showErrorMessage(
+        'AppMap: VS Code LM backend for Navie is enabled, but the LanguageModel API is not available.\nPlease update your VS Code to the latest version.'
+      );
+    else if (!vscode.extensions.getExtension('github.copilot')) {
+      vscode.window
+        .showErrorMessage(
+          'AppMap: VS Code LM backend for Navie is enabled, but the GitHub Copilot extension is not installed.\nPlease install it from the marketplace and reload the window.',
+          'Install Copilot'
+        )
+        .then((selection) => {
+          if (selection === 'Install Copilot') {
+            vscode.commands.executeCommand(
+              'workbench.extensions.installExtension',
+              'github.copilot'
+            );
+            _onModelChange ||= vscode.lm.onDidChangeChatModels(
+              notifyReload,
+              undefined,
+              context.subscriptions
+            );
+          }
+        });
+    } else return true;
+  }
+
+  async function notifyReload() {
+    const result = await vscode.window.showInformationMessage(
+      'AppMap: The Copilot integration has been updated. Please reload the window to apply the changes.',
+      'Reload'
+    );
+    if (result === 'Reload') vscode.commands.executeCommand('workbench.action.reloadWindow');
   }
 }

--- a/src/services/chatCompletion.ts
+++ b/src/services/chatCompletion.ts
@@ -1,0 +1,255 @@
+import assert from 'node:assert';
+import { log, warn } from 'node:console';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { createServer } from 'node:http';
+import { debuglog } from 'node:util';
+import { isNativeError } from 'node:util/types';
+
+import {
+  CancellationTokenSource,
+  Disposable,
+  LanguageModelChat,
+  LanguageModelChatMessage,
+  LanguageModelChatResponse,
+  lm,
+} from 'vscode';
+
+const debug = debuglog('appmap-vscode:chat-completion');
+
+interface Message {
+  content: string;
+  role: 'system' | 'user' | 'assistant' | 'tool' | 'function';
+}
+
+let instance: Promise<ChatCompletion> | undefined;
+
+export default class ChatCompletion implements Disposable {
+  public readonly server: Server;
+
+  constructor(private portNumber = 0, public readonly key = randomKey()) {
+    this.server = createServer(async (req, res) => {
+      try {
+        await this.handleRequest(req, res);
+        if (debug.enabled || res.statusCode !== 200)
+          log(`Chat completion request: ${req.method} ${req.url} ${res.statusCode}`);
+      } catch (e) {
+        warn(`Error handling request: ${e}`);
+        if (isNativeError(e)) {
+          warn(e.stack);
+        }
+        res.writeHead(500);
+        res.end(isNativeError(e) && e.message);
+      }
+    });
+    this.server.listen(portNumber);
+    const listening = new Promise<ChatCompletion>((resolve, reject) =>
+      this.server
+        .on('listening', () => {
+          const address = this.server.address();
+          assert(address && typeof address !== 'string');
+          log(`Chat completion server listening on ${address.port}`);
+          this.portNumber ||= address.port;
+          resolve(this);
+        })
+        .on('error', reject)
+    );
+    this.server.on('error', (e) => warn(`Chat completion server error: ${e}`));
+    instance ??= listening;
+  }
+
+  get ready(): Promise<void> {
+    return this.server.listening
+      ? Promise.resolve()
+      : new Promise((resolve) => this.server.on('listening', resolve));
+  }
+
+  get port(): number {
+    return this.portNumber;
+  }
+
+  get url(): string {
+    return `http://localhost:${this.port}/vscode/copilot`;
+  }
+
+  static get instance(): Promise<ChatCompletion | undefined> {
+    if (!instance) return Promise.resolve(undefined);
+    return instance;
+  }
+
+  async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      res.end();
+      warn(`Invalid method: ${req.method}`);
+      return;
+    }
+
+    const bearer = req.headers.authorization?.split(' ')[1];
+    if (!bearer || !timingSafeEqual(Buffer.from(bearer), Buffer.from(this.key))) {
+      res.writeHead(401);
+      res.end();
+      warn('Invalid authorization');
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of req) chunks.push(chunk);
+
+    const body = Buffer.concat(chunks).toString('utf-8');
+    let request: unknown;
+    try {
+      request = JSON.parse(body);
+      assert(
+        request &&
+          typeof request === 'object' &&
+          'messages' in request &&
+          Array.isArray(request.messages)
+      );
+      assert(
+        request.messages.every(
+          (m: unknown) => m && typeof m === 'object' && 'content' in m && 'role' in m
+        )
+      );
+      assert('model' in request && typeof request.model === 'string');
+    } catch (e) {
+      res.writeHead(400);
+      res.end(isNativeError(e) && e.message);
+      warn(`Invalid request: ${e}`);
+      return;
+    }
+
+    const model =
+      (await lm.selectChatModels({ family: request.model }))[0] ??
+      (await lm.selectChatModels({ version: request.model }))[0];
+    if (!model) {
+      res.writeHead(404);
+      const availableModels = await lm.selectChatModels();
+      const message = `Model ${request.model} not found. Available models: ${JSON.stringify(
+        availableModels
+      )}`;
+      warn(message);
+      res.end(message);
+      return;
+    }
+
+    debug(`Processing request: ${JSON.stringify(request)}`);
+
+    let result: LanguageModelChatResponse;
+    try {
+      const cancellation = new CancellationTokenSource();
+      req.on('close', () => cancellation.cancel());
+      res.on('close', () => cancellation.cancel());
+      result = await model.sendRequest(toVSCodeMessages(request.messages), {}, cancellation.token);
+    } catch (e) {
+      res.writeHead(500);
+      res.end(isNativeError(e) && e.message);
+      warn(`Error processing request: ${e}`);
+      return;
+    }
+
+    if ('stream' in request && request.stream) streamChatCompletion(res, model, result);
+    else sendChatCompletionResponse(res, model, result);
+  }
+
+  async dispose(): Promise<void> {
+    if ((await instance) === this) instance = undefined;
+    this.server.close();
+  }
+}
+
+async function sendChatCompletionResponse(
+  res: ServerResponse<IncomingMessage>,
+  model: LanguageModelChat,
+  result: LanguageModelChatResponse
+) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  const compl = prepareChatCompletionChunk(model);
+  compl.object = 'chat.completion';
+  let content = '';
+  for await (const c of result.text) content += c;
+  compl.choices[0].delta.content = content;
+  compl.choices[0].delta.finish_reason = 'stop';
+  res.end(JSON.stringify(compl));
+}
+
+async function streamChatCompletion(
+  res: ServerResponse,
+  model: LanguageModelChat,
+  result: LanguageModelChatResponse
+) {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+  const chunk = prepareChatCompletionChunk(model);
+  res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  for await (const content of result.text) {
+    chunk.choices[0].delta = { content };
+    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    debug(`Sending chunk: ${content}`);
+  }
+  chunk.choices[0].delta = { finish_reason: 'stop' };
+  res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  res.write('data: [DONE]\n\n');
+  res.end();
+}
+
+interface ChatCompletionChunk {
+  id: string;
+  choices: {
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+      finish_reason?: string;
+    };
+  }[];
+  created: number;
+  model: string;
+  system_fingerprint: string;
+  object: string;
+}
+
+function prepareChatCompletionChunk(model: LanguageModelChat): ChatCompletionChunk {
+  return {
+    id: randomKey(),
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          content: '',
+        },
+      },
+    ],
+    created: new Date().getTime() / 1000,
+    model: model.version,
+    system_fingerprint: model.id,
+    object: 'chat.completion.chunk',
+  };
+}
+
+let seenSystem = false; // so we don't spam the console with warnings
+function toVSCodeMessages(messages: Message[]): LanguageModelChatMessage[] {
+  const result: LanguageModelChatMessage[] = [];
+  for (const { role, content } of messages)
+    switch (role) {
+      case 'system':
+        if (!seenSystem) warn("System messages are not supported directly, using 'user' instead.");
+        seenSystem = true;
+      // fallthrough
+      case 'user':
+        result.push(LanguageModelChatMessage.User(content));
+        break;
+      case 'assistant':
+        result.push(LanguageModelChatMessage.Assistant(content));
+        break;
+      default:
+        warn(`Unknown role: ${role}`);
+    }
+
+  return result;
+}
+
+function randomKey(): string {
+  return randomBytes(16).toString('hex');
+}

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -6,6 +6,7 @@ import { fileExists, sanitizeEnvironment } from '../util';
 import { join } from 'path';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { getOpenAIApiKey } from './navieConfigurationService';
+import ChatCompletion from './chatCompletion';
 
 export type RetryOptions = {
   // The number of retries made before declaring the process as failed.
@@ -57,7 +58,14 @@ export async function loadEnvironment(
   };
 
   const openAIApiKey = await getOpenAIApiKey(context);
-  if (openAIApiKey) {
+  const chat = await ChatCompletion.instance;
+  if (chat) {
+    env.OPENAI_API_KEY = chat.key;
+    env.OPENAI_BASE_URL = chat.url;
+    // TODO: set these dynamically based on the available models
+    env.APPMAP_NAVIE_TOKEN_LIMIT = '3925';
+    env.APPMAP_NAVIE_MODEL = 'gpt-4-turbo';
+  } else if (openAIApiKey) {
     if ('AZURE_OPENAI_API_VERSION' in env) env.AZURE_OPENAI_API_KEY = openAIApiKey;
     else env.OPENAI_API_KEY = openAIApiKey;
   }

--- a/test/unit/mock/vscode/CancellationTokenSource.ts
+++ b/test/unit/mock/vscode/CancellationTokenSource.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import type vscode from 'vscode';
+
+export default class CancellationTokenSource implements vscode.CancellationTokenSource {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  token: any;
+  cancel(): void {}
+  dispose(): void {}
+}

--- a/test/unit/mock/vscode/LanguageModelChatMessage.ts
+++ b/test/unit/mock/vscode/LanguageModelChatMessage.ts
@@ -1,0 +1,19 @@
+import type { LanguageModelChatMessage, LanguageModelChatMessageRole } from 'vscode';
+
+export default class MockLanguageModelChatMessage implements LanguageModelChatMessage {
+  role: LanguageModelChatMessageRole;
+  content: string;
+  name: string | undefined;
+
+  constructor(role: LanguageModelChatMessageRole, content: string, name?: string) {
+    this.role = role;
+    this.content = content;
+    this.name = name;
+  }
+
+  static User = (content: string, name?: string) =>
+    new MockLanguageModelChatMessage(1, content, name);
+
+  static Assistant = (content: string, name?: string) =>
+    new MockLanguageModelChatMessage(2, content, name);
+}

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -1,5 +1,7 @@
 import mockery from 'mockery';
 
+import CancellationTokenSource from './CancellationTokenSource';
+import LanguageModelChatMessage from './LanguageModelChatMessage';
 import TextDocument from './TextDocument';
 import Range from './Range';
 import Position from './Position';
@@ -10,6 +12,7 @@ import Terminal from './Terminal';
 import CodeAction from './CodeAction';
 import CodeActionKind from './CodeActionKind';
 import * as extensions from './extensions';
+import * as lm from './lm';
 import { URI, Utils } from 'vscode-uri';
 import workspace from './workspace';
 import window from './window';
@@ -36,7 +39,9 @@ enum ProgressLocation {
 const MockVSCode = {
   ProgressLocation,
   authentication,
+  CancellationTokenSource,
   EventEmitter,
+  LanguageModelChatMessage,
   Terminal,
   TextDocument,
   Range,
@@ -46,6 +51,7 @@ const MockVSCode = {
   CodeAction,
   CodeActionKind,
   extensions,
+  lm,
   Uri: { ...URI, ...Utils },
   workspace,
   window,

--- a/test/unit/mock/vscode/lm.ts
+++ b/test/unit/mock/vscode/lm.ts
@@ -1,0 +1,20 @@
+import type { LanguageModelChat, LanguageModelChatSelector } from 'vscode';
+
+const models: LanguageModelChat[] = [];
+
+export async function selectChatModels(
+  query?: LanguageModelChatSelector
+): Promise<LanguageModelChat[]> {
+  if (!query) return models;
+  return models.filter((model) =>
+    Object.entries(query).every(([key, value]) => model[key] === value)
+  );
+}
+
+export function addMockChatModel(model: LanguageModelChat): void {
+  models.push(model);
+}
+
+export function resetModelMocks() {
+  models.length = 0;
+}

--- a/test/unit/services/chatCompletion.test.ts
+++ b/test/unit/services/chatCompletion.test.ts
@@ -1,0 +1,187 @@
+import '../mock/vscode';
+
+import http from 'node:http';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { LanguageModelChat, LanguageModelChatResponse } from 'vscode';
+
+import ChatCompletion from '../../../src/services/chatCompletion';
+import { addMockChatModel } from '../mock/vscode/lm';
+import assert from 'node:assert';
+
+const mockModel: LanguageModelChat = {
+  id: 'test-model',
+  family: 'test-family',
+  version: 'test-model',
+  async countTokens(): Promise<number> {
+    return 0;
+  },
+  maxInputTokens: 325,
+  name: 'Test Model',
+  async sendRequest(messages): Promise<LanguageModelChatResponse> {
+    // say hello and echo the last message
+    const lastMessage = messages[messages.length - 1];
+    return { text: makeStream(`Hello, you said: ${lastMessage.content}`) };
+  },
+  vendor: 'Test Vendor',
+};
+
+addMockChatModel(mockModel);
+
+describe('ChatCompletion', () => {
+  let chatCompletion: ChatCompletion;
+  before(async () => {
+    chatCompletion = new ChatCompletion(0, 'test-key');
+    await chatCompletion.ready;
+  });
+  after(() => chatCompletion.dispose());
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should create a server and listen on a random port', async () => {
+    const instance = await ChatCompletion.instance;
+    expect(instance).to.equal(chatCompletion);
+
+    expect(chatCompletion.port).to.be.above(0);
+    expect(chatCompletion.url).to.match(/^http:\/\/localhost:\d+\/vscode\/copilot$/);
+
+    // make an actual HTTP request to the server
+    const res = await get(chatCompletion.url);
+    expect(res.statusCode).to.equal(405);
+  });
+
+  it('should handle invalid HTTP methods', async () => {
+    const res = await get(chatCompletion.url);
+    expect(res.statusCode).to.equal(405);
+  });
+
+  it('should handle invalid authorization', async () => {
+    const res = await request(chatCompletion.url, { method: 'POST' });
+    expect(res.statusCode).to.equal(401);
+  });
+
+  it('should handle invalid request', async () => {
+    const res = await postAuthorized(chatCompletion.url);
+    expect(res.statusCode).to.equal(400);
+  });
+
+  it('should handle model not found', async () => {
+    const res = await postAuthorized(chatCompletion.url, { model: 'non-existent', messages: [] });
+    expect(res.statusCode).to.equal(404);
+  });
+
+  it('should handle error processing request', async () => {
+    const res = await postAuthorized(chatCompletion.url, { model: 'test-model', messages: [] });
+    expect(res.statusCode).to.equal(500);
+  });
+
+  it('should send chat completion response', async () => {
+    const messages = [
+      { content: 'Hello', role: 'user' },
+      { content: 'How are you?', role: 'assistant' },
+      { content: 'I am good, thank you!', role: 'user' },
+    ];
+    const response = await postAuthorized(chatCompletion.url, { model: 'test-model', messages });
+    expect(response.statusCode).to.equal(200);
+    assert(typeof response.data === 'string');
+    const result = JSON.parse(response.data);
+    expect(result.choices[0].delta.content).to.equal('Hello, you said: I am good, thank you!');
+  });
+
+  it('should stream chat completion', async () => {
+    const messages = [
+      { content: 'Hello', role: 'user' },
+      { content: 'How are you?', role: 'assistant' },
+      { content: 'I am good, thank you!', role: 'user' },
+    ];
+    const response = await postAuthorized(
+      chatCompletion.url,
+      { model: 'test-model', messages, stream: true },
+      true
+    );
+    expect(response.statusCode).to.equal(200);
+    assert(typeof response.data !== 'string');
+    const contents: string[] = [];
+    for await (const chunk of readSSE(response.data)) {
+      if (chunk === 'data: [DONE]\n\n') break;
+      const result = JSON.parse(chunk.replace(/^data: /, ''));
+      contents.push(result.choices[0].delta.content);
+    }
+    expect(contents.join('')).to.equal('Hello, you said: I am good, thank you!');
+  });
+});
+
+interface Response {
+  statusCode?: number;
+  data: string | AsyncIterable<Buffer>;
+}
+
+function get(url: string): Promise<Response> {
+  return request(url, { method: 'GET' });
+}
+
+function postAuthorized(url: string, body?: unknown, stream = false): Promise<Response> {
+  return request(
+    url,
+    {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-key',
+      },
+      stream,
+    },
+    body
+  );
+}
+
+async function request(
+  url: string,
+  options: http.RequestOptions & { stream?: boolean },
+  body?: unknown
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, options, (res) => {
+      if (options.stream) return resolve({ statusCode: res.statusCode, data: res });
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode, data });
+      });
+    });
+    req.on('error', reject);
+
+    if (body) req.write(typeof body === 'string' ? body : JSON.stringify(body));
+
+    req.end();
+  });
+}
+
+// make an async iterable stream of words (including separating spaces) from a string
+async function* makeStream(text: string): AsyncIterable<string> {
+  const re = /\S+\s*/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text))) {
+    yield match[0];
+  }
+}
+
+// read an async iterable stream of SSE chunks
+async function* readSSE(stream: AsyncIterable<Buffer>): AsyncIterable<string> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let index: number;
+    while ((index = buffer.indexOf('\n\n')) >= 0) {
+      const chunk = buffer.slice(0, index + 2);
+      buffer = buffer.slice(index + 2);
+      yield chunk;
+    }
+  }
+  if (buffer.length) yield buffer;
+}


### PR DESCRIPTION
This adds a config option to use VSCode LLM API. Note it's hardcoded for Copilot for now for simplicity.

By implementing an OpenAI-compatible API on top of the VSCode LM API it can be used without any changes to CLI. 

Small cosmetic changes to components are in https://github.com/getappmap/appmap-js/pull/1881 , but they're not required for this to work. However, please don't merge this until that one is merged and the components version is bumped here.