### PR TITLE
fix: Use system node when spawning AppMap tools in development

### DIFF
--- a/src/services/nodeDependencyProcess.ts
+++ b/src/services/nodeDependencyProcess.ts
@@ -133,10 +133,9 @@ export function spawn(options: SpawnOptions): ChildProcess {
   const env = { ...process.env, ...(options.env || {}) };
   let newProcess: childProcess.ChildProcess;
   if (options.modulePath) {
-    newProcess = childProcess.fork(options.modulePath, options.args || [], {
+    newProcess = childProcess.spawn('node', [options.modulePath, ...(options.args ?? [])], {
       ...options,
       env,
-      execArgv: [],
       stdio: 'pipe',
     });
   } else if (options.binPath) {


### PR DESCRIPTION
When using the development option to provide path to appmap-js package childProcess.fork has been used which caused it to use VSCode node. This has worked well in the past but recently we've started using binary extensions which can't load across different Node versions. This has rendered this option all but unusable unless you used the same exact Node version that VSCode uses to compile the dependencies.

This change makes this flow use spawn('node') instead of fork(), using system node which presumably should be available in a development environment and has a better chance of being the correct version.

Note this should affect any users since unless this development config option is used they should be running precompiled CLI binaries.