### PR TITLE
fix: "New chat" button opens a new chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -588,7 +588,7 @@
   "dependencies": {
     "@appland/appmap": "^3.129.0",
     "@appland/client": "^1.14.1",
-    "@appland/components": "^4.30.0",
+    "@appland/components": "^4.30.1",
     "@appland/diagrams": "^1.8.0",
     "@appland/models": "^2.10.2",
     "@appland/rpc": "^1.7.0",

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -132,6 +132,9 @@ export default class ChatSearchWebview {
             suggestion,
           });
           break;
+        case 'open-new-chat':
+          void vscode.commands.executeCommand('appmap.explain');
+          break;
         case 'open-record-instructions':
           await vscode.commands.executeCommand('appmap.openInstallGuide', RecordAppMaps);
           break;

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -24,6 +24,9 @@ export default function mountChatSearchView() {
             appmapYmlPresent: this.appmapYmlPresent,
             targetAppmapData: initialData.targetAppmap,
             targetAppmapFsPath: initialData.targetAppmapFsPath,
+            openNewChat() {
+              vscode.postMessage({ command: 'open-new-chat' });
+            },
           },
         });
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,9 +181,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^4.30.0":
-  version: 4.30.0
-  resolution: "@appland/components@npm:4.30.0"
+"@appland/components@npm:^4.30.1":
+  version: 4.30.1
+  resolution: "@appland/components@npm:4.30.1"
   dependencies:
     "@appland/client": ^1.12.0
     "@appland/diagrams": ^1.7.0
@@ -207,7 +207,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.14
     vuex: ^3.6.0
-  checksum: 1e64ce3e8d6cac3f956b25247a1ad3717c9d461a4b5d23c6e0e8b24383c62026197027bd967d4b10aa3142f462158ce19e34eb8c0993bafabb2c20b739725ede
+  checksum: dac42f82d088e7a9c351ecff6b480ca0f51145f84fac4bc031638d2aa7000c25d7cec105966a75813e6496d39825e4917b70f93dafed9fac25c5a13122eac455
   languageName: node
   linkType: hard
 
@@ -3269,7 +3269,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.129.0
     "@appland/client": ^1.14.1
-    "@appland/components": ^4.30.0
+    "@appland/components": ^4.30.1
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.2
     "@appland/rpc": ^1.7.0


### PR DESCRIPTION
Instead of destructively clearing the current chat, "new chat" button opens a new tab instead.

Requires support in @appland/components provided by https://github.com/getappmap/appmap-js/pull/1925