### PR TITLE
Restart RPC server when environment variables are modified

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "name": "Run extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--disable-extensions"],
+
       "env": {
         "APPMAP_TELEMETRY_DEBUG": "1",
         "APPMAP_DEV_EXTENSION": "1"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,6 +240,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
         context,
         workspaceServices.getServiceInstances(configManager)
       );
+
+      context.subscriptions.push(new EnvironmentVariableService(rpcService));
+
       const webview = ChatSearchWebview.register(
         context,
         extensionState,
@@ -273,8 +276,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     downloadLatestJavaJar(context);
     getAppmapDir(context, workspaceServices);
     clearNavieAiSettings(context);
-
-    context.subscriptions.push(new EnvironmentVariableService());
 
     // Use this notification to track when the extension is activated.
     if (Environment.isSystemTest) {

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -74,6 +74,10 @@ export default class RpcProcessService implements Disposable {
     return this.rpcPort;
   }
 
+  public restart(): Promise<void> {
+    return this.processWatcher.restart();
+  }
+
   protected async pushConfiguration() {
     if (!this.available) return;
 

--- a/src/services/rpcProcessWatcher.ts
+++ b/src/services/rpcProcessWatcher.ts
@@ -81,6 +81,29 @@ export default class RpcProcessWatcher extends ProcessWatcher {
     if (portStr) consumeRpcPort(portStr);
   }
 
+  async start(): Promise<void> {
+    const disposables: vscode.Disposable[] = [];
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Window,
+          cancellable: false,
+          title: 'Starting Navie…',
+        },
+        () =>
+          new Promise<void>((resolve, reject) => {
+            disposables.push(this.onRpcPortChange(() => resolve()));
+            disposables.push(this.onAbort(reject));
+            super.start();
+          })
+      );
+    } catch (e) {
+      vscode.window.showErrorMessage(`Navie failed to start: ${e}`);
+    } finally {
+      disposables.forEach((d) => d.dispose());
+    }
+  }
+
   dispose(): void {
     this._onRpcPortChange.dispose();
     super.dispose();

--- a/src/services/rpcProcessWatcher.ts
+++ b/src/services/rpcProcessWatcher.ts
@@ -12,7 +12,7 @@ export default class RpcProcessWatcher extends ProcessWatcher {
   private stdoutBuffer = '';
 
   constructor(context: vscode.ExtensionContext, modulePath?: string, env?: NodeJS.ProcessEnv) {
-    const args = ['rpc', '--port', '0'];
+    const args = makeArgs();
     const extraOptions = ExtensionSettings.appMapIndexOptions;
     if (extraOptions) args.push(...extraOptions.split(' '));
     if (ExtensionSettings.appMapCommandLineVerbose) args.push('--verbose');
@@ -72,6 +72,7 @@ export default class RpcProcessWatcher extends ProcessWatcher {
         );
       } else {
         this.rpcPort = parseInt(portStr);
+        this.options.args = makeArgs(this.rpcPort);
       }
       this._onRpcPortChange.fire(this.rpcPort);
     };
@@ -84,4 +85,8 @@ export default class RpcProcessWatcher extends ProcessWatcher {
     this._onRpcPortChange.dispose();
     super.dispose();
   }
+}
+
+function makeArgs(port = 0) {
+  return ['rpc', '--port', port.toFixed()];
 }


### PR DESCRIPTION
The pull request includes the following changes:

1. **Disable Extensions on Launch**: The launch configuration for the extension now includes the `--disable-extensions` argument, which disables other extensions when running the AppMap extension for development.

2. **Environment Variable Service Improvements**: The `EnvironmentVariableService` has been updated to handle configuration changes more efficiently. Instead of reloading the entire window, it now restarts the RPC server when the `appMap.commandLineEnvironment` configuration changes. The restart is debounced to prevent multiple restarts during rapid configuration changes.

3. **RPC Process Restart**: The `RpcProcessService` now includes a `restart` method, which allows restarting the RPC server process without reloading the entire window.

4. **RPC Process Watcher Improvements**: The `RpcProcessWatcher` has been updated to handle the RPC server restart more gracefully. It now shows a progress indicator while starting the RPC server and handles errors more robustly.

5. **Test Updates**: The test suite has been updated to include tests for the `restart` method of the `RpcProcessService`.

Overall, these changes aim to improve the handling of configuration changes, particularly for the `appMap.commandLineEnvironment` setting, by restarting the RPC server instead of reloading the entire window. This should provide a smoother experience for users when modifying environment variables.