### PR TITLE
Don't hang on error when streaming Copilot response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
         with:
           node-version: 18
           cache: yarn
-      - run:
+      - run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+          dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:integration
         name: Run integration tests
 

--- a/package.json
+++ b/package.json
@@ -210,6 +210,10 @@
         "title": "AppMap: Ask Navie AI"
       },
       {
+        "command": "appmap.rpc.restart",
+        "title": "AppMap: Restart Navie"
+      },
+      {
         "command": "appmap.login",
         "title": "AppMap: Login"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,6 +242,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       );
 
       context.subscriptions.push(new EnvironmentVariableService(rpcService));
+      context.subscriptions.push(
+        vscode.commands.registerCommand('appmap.rpc.restart', async () => {
+          await rpcService.restartServer();
+          vscode.window.showInformationMessage('Navie restarted successfully.');
+        })
+      );
 
       const webview = ChatSearchWebview.register(
         context,

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -137,6 +137,10 @@ export default class RpcProcessService implements Disposable {
     this._onRpcPortChange.fire(port);
   }
 
+  public async restartServer(): Promise<void> {
+    return this.processWatcher.restart();
+  }
+
   protected waitForStartup(): Promise<void> {
     if (this.processWatcher.running) return Promise.resolve();
 

--- a/test/unit/services/chatCompletion.test.ts
+++ b/test/unit/services/chatCompletion.test.ts
@@ -4,7 +4,11 @@ import http from 'node:http';
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import type { LanguageModelChat, LanguageModelChatResponse } from 'vscode';
+import type {
+  LanguageModelChat,
+  LanguageModelChatMessage,
+  LanguageModelChatResponse,
+} from 'vscode';
 
 import ChatCompletion from '../../../src/services/chatCompletion';
 import { addMockChatModel } from '../mock/vscode/lm';
@@ -19,11 +23,7 @@ const mockModel: LanguageModelChat = {
   },
   maxInputTokens: 325,
   name: 'Test Model',
-  async sendRequest(messages): Promise<LanguageModelChatResponse> {
-    // say hello and echo the last message
-    const lastMessage = messages[messages.length - 1];
-    return { text: makeStream(`Hello, you said: ${lastMessage.content}`) };
-  },
+  sendRequest: sendRequestEcho,
   vendor: 'Test Vendor',
 };
 
@@ -32,6 +32,7 @@ addMockChatModel(mockModel);
 describe('ChatCompletion', () => {
   let chatCompletion: ChatCompletion;
   before(async () => {
+    mockModel.sendRequest = sendRequestEcho;
     chatCompletion = new ChatCompletion(0, 'test-key');
     await chatCompletion.ready;
   });
@@ -75,7 +76,7 @@ describe('ChatCompletion', () => {
 
   it('should handle error processing request', async () => {
     const res = await postAuthorized(chatCompletion.url, { model: 'test-model', messages: [] });
-    expect(res.statusCode).to.equal(500);
+    expect(res.statusCode).to.equal(422);
   });
 
   it('should send chat completion response', async () => {
@@ -111,6 +112,43 @@ describe('ChatCompletion', () => {
       contents.push(result.choices[0].delta.content);
     }
     expect(contents.join('')).to.equal('Hello, you said: I am good, thank you!');
+  });
+
+  describe('when streaming errors', () => {
+    beforeEach(() => {
+      mockModel.sendRequest = async () => {
+        return {
+          // eslint-disable-next-line require-yield
+          text: (async function* () {
+            throw new Error('test error');
+          })(),
+        };
+      };
+    });
+
+    it('reports errors when streaming', async () => {
+      const messages = [
+        { content: 'Hello', role: 'user' },
+        { content: 'How are you?', role: 'assistant' },
+        { content: 'I am good, thank you!', role: 'user' },
+      ];
+      const response = await postAuthorized(
+        chatCompletion.url,
+        { model: 'test-model', messages, stream: true },
+        true
+      );
+      expect(response.statusCode).to.equal(422);
+    });
+
+    it('reports errors when not streaming', async () => {
+      const messages = [
+        { content: 'Hello', role: 'user' },
+        { content: 'How are you?', role: 'assistant' },
+        { content: 'I am good, thank you!', role: 'user' },
+      ];
+      const response = await postAuthorized(chatCompletion.url, { model: 'test-model', messages });
+      expect(response.statusCode).to.equal(422);
+    });
   });
 });
 
@@ -168,6 +206,14 @@ async function* makeStream(text: string): AsyncIterable<string> {
   while ((match = re.exec(text))) {
     yield match[0];
   }
+}
+
+async function sendRequestEcho(
+  messages: LanguageModelChatMessage[]
+): Promise<LanguageModelChatResponse> {
+  // say hello and echo the last message
+  const lastMessage = messages[messages.length - 1];
+  return { text: makeStream(`Hello, you said: ${lastMessage.content}`) };
 }
 
 // read an async iterable stream of SSE chunks

--- a/test/unit/services/chatCompletion.test.ts
+++ b/test/unit/services/chatCompletion.test.ts
@@ -89,7 +89,7 @@ describe('ChatCompletion', () => {
     expect(response.statusCode).to.equal(200);
     assert(typeof response.data === 'string');
     const result = JSON.parse(response.data);
-    expect(result.choices[0].delta.content).to.equal('Hello, you said: I am good, thank you!');
+    expect(result.choices[0].message.content).to.equal('Hello, you said: I am good, thank you!');
   });
 
   it('should stream chat completion', async () => {


### PR DESCRIPTION
This addresses an issue where the application would hang if the Copilot service encountered an error during streaming. This could happen, for example, when a message is too long. The fix ensures that such errors are caught and reported correctly to the client, preventing a broken connection. Additionally, the HTTP status code for these errors has been changed to 422, indicating that the issue is likely non-recoverable and the client should not retry.

### Key Changes

1. **Error Handling in `streamChatCompletion`**:
   - Added a `try-catch` block to handle errors during streaming.
   - If an error occurs, it now sends a 422 status code and the error message to the client.

<!-- file: /home/divide/projects/vscode-appland/src/services/chatCompletion.ts -->
```typescript
async function streamChatCompletion(
  res: ServerResponse,
  model: LanguageModelChat,
  result: LanguageModelChatResponse
) {
  try {
    const chunk = prepareChatCompletionChunk(model);
    for await (const content of result.text) {
      if (!res.headersSent) res.writeHead(200, { 'Content-Type': 'text/event-stream' });
      chunk.choices[0].delta = { content };
      res.write(`data: ${JSON.stringify(chunk)}\n\n`);
      debug(`Sending chunk: ${content}`);
    }
    chunk.choices[0].delta = { finish_reason: 'stop' };
    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
    res.write('data: [DONE]\n\n');
    res.end();
  } catch (e) {
    warn(`Error streaming response: ${e}`);
    if (isNativeError(e)) warn(e.stack);
    if (!res.headersSent) {
      res.writeHead(422);
      res.end(isNativeError(e) && e.message);
    } else res.end(`data: ${JSON.stringify({ error: e })}`);
  }
}
```

2. **Change in Status Code for Processing Request Errors**:
   - Changed the status code from 500 to 422 when an error occurs while processing the request.

<!-- file: /home/divide/projects/vscode-appland/src/services/chatCompletion.ts -->
```typescript
try {
  res.on('close', () => cancellation.cancel());
  result = await model.sendRequest(toVSCodeMessages(request.messages), {}, cancellation.token);
} catch (e) {
  res.writeHead(422);
  res.end(isNativeError(e) && e.message);
  warn(`Error processing request: ${e}`);
  return;
}
```

3. **Unit Test Updates**:
   - Added a test case to verify that errors during streaming are reported correctly with a 422 status code.

<!-- file: /home/divide/projects/vscode-appland/test/unit/services/chatCompletion.test.ts -->
```typescript
it('should report errors when streaming', async () => {
  const messages = [
    { content: 'Hello', role: 'user' },
    { content: 'How are you?', role: 'assistant' },
    { content: 'I am good, thank you!', role: 'user' },
  ];
  mockModel.sendRequest = async () => {
    return {
      // eslint-disable-next-line require-yield
      text: (async function* () {
        throw new Error('test error');
      })(),
    };
  };
  const response = await postAuthorized(
    chatCompletion.url,
    { model: 'test-model', messages, stream: true },
    true
  );
  expect(response.statusCode).to.equal(422);
});
```

Note: this is related to https://github.com/getappmap/appmap-js/issues/1954 (but is not a full fix; currently, Navie will still retry the 422 so will still hang for a while).