### PR TITLE
fix: Log errors that would prevent Navie from servicing requests

### DIFF
--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -8,7 +8,12 @@ import * as Metrics from './metrics';
  */
 export const DEBUG_EXCEPTION = new Event({
   name: 'debug/exception',
-  properties: [Properties.DEBUG_EXCEPTION, Properties.DEBUG_ERROR_CODE, Properties.DEBUG_LOG],
+  properties: [
+    Properties.DEBUG_EXCEPTION,
+    Properties.DEBUG_ERROR_CODE,
+    Properties.DEBUG_LOG,
+    Properties.DEBUG_VERSION,
+  ],
 });
 
 export const PROJECT_OPEN = new Event({

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -32,6 +32,13 @@ export const DEBUG_LOG = new TelemetryDataProvider({
   },
 });
 
+export const DEBUG_VERSION = new TelemetryDataProvider({
+  id: 'appmap.debug.version',
+  value({ version }: { version?: string }) {
+    return version;
+  },
+});
+
 export const AGENT_CONFIG_PRESENT = new TelemetryDataProvider({
   id: 'appmap.agent.config_present',
   async value({ uri }: { uri: vscode.Uri }) {


### PR DESCRIPTION
E.g.:
```
{
  "event": "appland.appmap/debug/exception",
  "properties": {
    "appmap.debug.exception": "Error: appmap rpc --port 0 exited with code 1",
    "appmap.debug.error_code": "ProcessFailure",
    "appmap.debug.log": "Stderr: --navie-provider option not provided, and none of OPENAI_API_KEY AZURE_OPENAI_API_KEY ANTHROPIC_API_KEY are available. Using remote Navie provider.\n\nStderr: Detected code editor: vscode\nSetting RPC configuration: {\"projectDirectories\":[\"\"],\"appmapConfigFiles\":[\"\"]}\n\nStderr: [Error: ENOENT: no such file or directory, scandir '.appmap/navie/history'] {\n  errno: -2,\n  code: 'ENOENT',\n  syscall: 'scandir',\n  path: '.appmap/navie/history'\n}\n",
    "appmap.debug.version": "3.163.4"
  }
}
```