### PR TITLE
feat: Enable Copilot by default if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -706,7 +706,7 @@
   "dependencies": {
     "@appland/appmap": "^3.129.0",
     "@appland/client": "^1.14.1",
-    "@appland/components": "^4.38.3",
+    "@appland/components": "^4.39.0",
     "@appland/diagrams": "^1.8.0",
     "@appland/models": "^2.10.2",
     "@appland/rpc": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,8 @@
         },
         "appMap.navie.useVSCodeLM": {
           "type": "boolean",
-          "description": "Use VSCode language model API for Navie AI if available.\nRequires a recent VSCode version and (currently) GitHub Copilot extension."
+          "description": "Use GitHub Copilot as Navie backend if available.\nRequires a recent VSCode version and GitHub Copilot extension.",
+          "default": true
         },
         "appMap.navie.rpcPort": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,7 +228,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     await ChatCompletion.initialize(context);
 
     AssetService.register(context);
-    const dependenciesInstalled = AssetService.updateAll();
+    const dependenciesInstalled = ExtensionSettings.appMapCommandLineToolsPath
+      ? // do not try to download if we're using local tools anyway
+        Promise.resolve()
+      : AssetService.updateAll();
     const chatSearchWebview: Promise<ChatSearchWebview> = (async () => {
       await dependenciesInstalled;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,7 +246,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
       context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((e) => {
-          if (e.affectsConfiguration('appMap.commandLineEnvironment')) rpcService.scheduleRestart();
+          if (e.affectsConfiguration('appMap.commandLineEnvironment'))
+            rpcService.debouncedRestart();
         }),
         vscode.commands.registerCommand('appmap.rpc.restart', async () => {
           await rpcService.restartServer();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,7 +225,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     const processService = new NodeProcessService(context);
 
-    ChatCompletion.initialize(context);
+    await ChatCompletion.initialize(context);
 
     AssetService.register(context);
     const dependenciesInstalled = AssetService.updateAll();
@@ -249,7 +249,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
           await rpcService.restartServer();
           vscode.window.showInformationMessage('Navie restarted successfully.');
         }),
-        ChatCompletion.onSettingsChanged(rpcService.scheduleRestart, rpcService)
+        ChatCompletion.onSettingsChanged(rpcService.debouncedRestart, rpcService)
       );
 
       const webview = ChatSearchWebview.register(

--- a/src/lib/once.ts
+++ b/src/lib/once.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+/**
+ * Returns true if the given key has not been shown before, and updates the global state accordingly.
+ * @param context
+ * @param key
+ */
+export default function once(context: vscode.ExtensionContext, key: string): boolean {
+  const hasBeenShown = context.globalState.get(key, false);
+
+  if (!hasBeenShown) {
+    context.globalState.update(key, true);
+    return true;
+  }
+
+  return false;
+}
+
+once.reset = function (context: vscode.ExtensionContext, key: string) {
+  context.globalState.update(key, undefined);
+};

--- a/src/services/chatCompletion.ts
+++ b/src/services/chatCompletion.ts
@@ -16,6 +16,7 @@ import vscode, {
 } from 'vscode';
 
 import ExtensionSettings from '../configuration/extensionSettings';
+import once from '../lib/once';
 
 const debug = debuglog('appmap-vscode:chat-completion');
 
@@ -57,7 +58,10 @@ export default class ChatCompletion implements Disposable {
         .on('error', reject)
     );
     this.server.on('error', (e) => warn(`Chat completion server error: ${e}`));
-    instance ??= listening;
+    if (!instance) {
+      instance = listening;
+      ChatCompletion.settingsChanged.fire();
+    }
   }
 
   get ready(): Promise<void> {
@@ -76,8 +80,9 @@ export default class ChatCompletion implements Disposable {
 
   get env(): Record<string, string> {
     const pref = ChatCompletion.preferredModel;
+    if (!pref) return {};
 
-    const modelTokenLimit = pref?.maxInputTokens ?? 3926;
+    const modelTokenLimit = pref.maxInputTokens;
     const tokenLimitSetting = ExtensionSettings.navieContextTokenLimit;
     const tokenLimits = [modelTokenLimit, tokenLimitSetting].filter(
       (limit) => limit && limit > 0
@@ -86,7 +91,8 @@ export default class ChatCompletion implements Disposable {
     const env: Record<string, string> = {
       OPENAI_API_KEY: this.key,
       OPENAI_BASE_URL: this.url,
-      APPMAP_NAVIE_MODEL: pref?.family ?? 'gpt-4o',
+      APPMAP_NAVIE_MODEL: pref.family,
+      APPMAP_NAVIE_COMPLETION_BACKEND: 'openai',
     };
 
     if (tokenLimits.length) {
@@ -102,16 +108,16 @@ export default class ChatCompletion implements Disposable {
     return ChatCompletion.models[0];
   }
 
-  static async refreshModels(): Promise<void> {
+  static async refreshModels(): Promise<boolean> {
     const previousBest = this.preferredModel?.id;
     ChatCompletion.models = (await vscode.lm.selectChatModels()).sort(
       (a, b) => b.maxInputTokens - a.maxInputTokens + b.family.localeCompare(a.family)
     );
-    if (this.preferredModel?.id !== previousBest) this.settingsChanged.fire();
+    return this.preferredModel?.id !== previousBest;
   }
 
-  static get instance(): Promise<ChatCompletion | undefined> {
-    if (!instance) return Promise.resolve(undefined);
+  static get instance(): Promise<ChatCompletion> | undefined {
+    if (!instance) return undefined;
     return instance;
   }
 
@@ -201,67 +207,112 @@ export default class ChatCompletion implements Disposable {
   }
 
   async dispose(): Promise<void> {
-    if ((await instance) === this) instance = undefined;
+    if ((await instance) === this) {
+      instance = undefined;
+      ChatCompletion.settingsChanged.fire();
+    }
     this.server.close();
   }
 
   private static settingsChanged = new vscode.EventEmitter<void>();
   static onSettingsChanged = ChatCompletion.settingsChanged.event;
 
-  static initialize(context: ExtensionContext) {
-    // TODO: make the messages and handling generic for all LM extensions
-    const hasLM = 'lm' in vscode && 'selectChatModels' in vscode.lm;
-
-    if (ExtensionSettings.useVsCodeLM && checkAvailability())
-      context.subscriptions.push(new ChatCompletion());
+  static async initialize(context: ExtensionContext) {
+    if (await this.checkConfiguration(context))
+      context.subscriptions.push(
+        vscode.lm.onDidChangeChatModels(() => this.checkConfiguration(context))
+      );
 
     context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration(async (e) => {
-        if (e.affectsConfiguration('appMap.navie.useVSCodeLM')) {
-          const instance = await ChatCompletion.instance;
-          if (!ExtensionSettings.useVsCodeLM && instance) await instance.dispose();
-          else if (ExtensionSettings.useVsCodeLM && checkAvailability())
-            context.subscriptions.push(new ChatCompletion());
-          this.settingsChanged.fire();
-        }
-      })
+      vscode.workspace.onDidChangeConfiguration(
+        (e) =>
+          e.affectsConfiguration('appMap.navie.useVSCodeLM') &&
+          this.checkConfiguration(context, true)
+      )
     );
+  }
 
-    if (hasLM) {
-      ChatCompletion.refreshModels();
-      vscode.lm.onDidChangeChatModels(
-        ChatCompletion.refreshModels,
-        undefined,
-        context.subscriptions
-      );
+  static async checkConfiguration(context: ExtensionContext, switched = false): Promise<boolean> {
+    // TODO: make the messages and handling generic for all LM extensions
+    const hasLM = 'lm' in vscode && 'selectChatModels' in vscode.lm;
+    const wantsLM = ExtensionSettings.useVsCodeLM;
+
+    if (!hasLM) {
+      if (wantsLM) {
+        if (switched)
+          vscode.window.showErrorMessage(
+            'AppMap: Copilot backend for Navie is enabled, but the LanguageModel API is not available.\nPlease update your VS Code to the latest version.'
+          );
+        else if (once(context, 'no-lm-api-available'))
+          vscode.window.showInformationMessage(
+            'AppMap: Navie can use Copilot, but the LanguageModel API is not available.\nPlease update your VS Code to the latest version if you want to use it.'
+          );
+      }
+      return hasLM;
+    }
+    once.reset(context, 'no-lm-api-available');
+
+    if (!wantsLM) {
+      if (instance) {
+        await instance.then((i) => i.dispose());
+        // must have been switched, so show message
+        vscode.window.showInformationMessage('AppMap: Copilot backend for Navie is disabled.');
+        once.reset(context, 'chat-completion-ready');
+        once.reset(context, 'chat-completion-no-models');
+      }
+      return hasLM;
     }
 
-    function checkAvailability() {
-      if (!hasLM)
-        vscode.window.showErrorMessage(
-          'AppMap: VS Code LM backend for Navie is enabled, but the LanguageModel API is not available.\nPlease update your VS Code to the latest version.'
+    // now it's hasLM and wantsLM
+    const changed = await this.refreshModels();
+    if (this.preferredModel) {
+      if (!instance) {
+        context.subscriptions.push(new this());
+        await this.instance;
+      } else if (changed) ChatCompletion.settingsChanged.fire();
+      if (switched)
+        vscode.window.showInformationMessage(
+          `AppMap: Copilot backend for Navie is enabled, using model: ${this.preferredModel.name}`
         );
-      else if (!vscode.extensions.getExtension('github.copilot')) {
+      else if (once(context, 'chat-completion-ready'))
+        vscode.window.showInformationMessage(
+          `AppMap: Copilot backend for Navie is ready. Model: ${this.preferredModel.name}`
+        );
+      once.reset(context, 'chat-completion-no-models');
+    } else {
+      if (instance) await instance.then((i) => i.dispose());
+      if (switched)
         vscode.window
           .showErrorMessage(
-            'AppMap: VS Code LM backend for Navie is enabled, but the GitHub Copilot extension is not installed.\nPlease install it from the marketplace and reload the window.',
+            'AppMap: Copilot backend for Navie is enabled, but no compatible models were found.\nInstall Copilot to continue.',
             'Install Copilot'
           )
-          .then((selection) => {
-            if (selection === 'Install Copilot') {
-              const odc = vscode.lm.onDidChangeChatModels(() => {
-                context.subscriptions.push(new ChatCompletion());
-                ChatCompletion.settingsChanged.fire();
-                odc.dispose();
-              });
+          .then(
+            (selection) =>
+              selection === 'Install Copilot' &&
               vscode.commands.executeCommand(
                 'workbench.extensions.installExtension',
                 'github.copilot'
-              );
-            }
-          });
-      } else return true;
+              )
+          );
+      else if (once(context, 'chat-completion-no-models'))
+        vscode.window
+          .showInformationMessage(
+            'AppMap: Navie can use Copilot, but no compatible models were found.\nYou can install Copilot to use this feature.',
+            'Install Copilot'
+          )
+          .then(
+            (selection) =>
+              selection === 'Install Copilot' &&
+              vscode.commands.executeCommand(
+                'workbench.extensions.installExtension',
+                'github.copilot'
+              )
+          );
+      once.reset(context, 'chat-completion-ready');
     }
+
+    return hasLM;
   }
 }
 

--- a/src/services/chatCompletion.ts
+++ b/src/services/chatCompletion.ts
@@ -30,7 +30,11 @@ let instance: Promise<ChatCompletion> | undefined;
 export default class ChatCompletion implements Disposable {
   public readonly server: Server;
 
-  constructor(private portNumber = 0, public readonly key = randomKey()) {
+  constructor(
+    private portNumber = 0,
+    public readonly key = randomKey(),
+    public readonly host = '127.0.0.1'
+  ) {
     this.server = createServer(async (req, res) => {
       try {
         await this.handleRequest(req, res);
@@ -45,7 +49,7 @@ export default class ChatCompletion implements Disposable {
         res.end(isNativeError(e) && e.message);
       }
     });
-    this.server.listen(portNumber);
+    this.server.listen(portNumber, host);
     const listening = new Promise<ChatCompletion>((resolve, reject) =>
       this.server
         .on('listening', () => {
@@ -75,7 +79,7 @@ export default class ChatCompletion implements Disposable {
   }
 
   get url(): string {
-    return `http://localhost:${this.port}/vscode/copilot`;
+    return `http://${this.host}:${this.port}/vscode/copilot`;
   }
 
   get env(): Record<string, string> {

--- a/src/services/navieConfigurationService.ts
+++ b/src/services/navieConfigurationService.ts
@@ -39,6 +39,15 @@ export default function navieConfigurationService(context: vscode.ExtensionConte
   );
 }
 
+export async function openAIApiKeyEquals(
+  extensionContext: vscode.ExtensionContext,
+  key: string | undefined
+): Promise<boolean> {
+  const { secrets } = extensionContext;
+  const storedKey = await secrets.get(OPENAI_API_KEY);
+  return key === storedKey;
+}
+
 export async function setOpenAIApiKey(
   extensionContext: vscode.ExtensionContext,
   key: string | undefined

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -76,7 +76,7 @@ export class ProcessWatcher implements vscode.Disposable {
 
   protected _onError: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
   protected _onAbort: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
-  protected _onRestart: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+  protected _onBeforeRestart: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 
   protected shouldRun = false;
   protected hasAborted = false;
@@ -103,8 +103,8 @@ export class ProcessWatcher implements vscode.Disposable {
   }
 
   // Fired when the process is restarted.
-  public get onRestart(): vscode.Event<void> {
-    return this._onRestart.event;
+  public get onBeforeRestart(): vscode.Event<void> {
+    return this._onBeforeRestart.event;
   }
 
   public get id(): ProcessId {
@@ -175,7 +175,7 @@ export class ProcessWatcher implements vscode.Disposable {
   }
 
   async restart(): Promise<void> {
-    this._onRestart.fire();
+    this._onBeforeRestart.fire();
     await this.stop();
     await this.start();
   }

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -76,6 +76,7 @@ export class ProcessWatcher implements vscode.Disposable {
 
   protected _onError: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
   protected _onAbort: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
+  protected _onRestart: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 
   protected shouldRun = false;
   protected hasAborted = false;
@@ -99,6 +100,11 @@ export class ProcessWatcher implements vscode.Disposable {
   // will not be retried.
   public get onAbort(): vscode.Event<Error> {
     return this._onAbort.event;
+  }
+
+  // Fired when the process is restarted.
+  public get onRestart(): vscode.Event<void> {
+    return this._onRestart.event;
   }
 
   public get id(): ProcessId {
@@ -169,6 +175,7 @@ export class ProcessWatcher implements vscode.Disposable {
   }
 
   async restart(): Promise<void> {
+    this._onRestart.fire();
     await this.stop();
     await this.start();
   }

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -82,8 +82,8 @@ export default class RpcProcessService implements Disposable {
     );
   }
 
-  get onRestart(): vscode.Event<void> {
-    return this.processWatcher.onRestart;
+  get onBeforeRestart(): vscode.Event<void> {
+    return this.processWatcher.onBeforeRestart;
   }
 
   // Provides some internal state access, primarily for testing purposes.

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -102,7 +102,7 @@ export default class RpcProcessService implements Disposable {
     }
   }
 
-  private debouncedRestart(): void {
+  public debouncedRestart(): void {
     if (this.restarting) this.scheduleRestart();
     else {
       this.debounce = undefined;

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -178,7 +178,7 @@ export default class ChatSearchWebview {
           type: 'navie-restarted',
         });
       }),
-      this.rpcService.onRestart(() => {
+      this.rpcService.onBeforeRestart(() => {
         panel.webview.postMessage({
           type: 'navie-restarting',
         });

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -44,7 +44,8 @@ export default class ChatSearchWebview {
   private constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly extensionState: ExtensionState,
-    private readonly dataService: ChatSearchDataService
+    private readonly dataService: ChatSearchDataService,
+    private readonly rpcService: RpcProcessService
   ) {
     this.filterStore = new FilterStore(context);
     this.filterStore.onDidChangeFilters((event) => {
@@ -171,6 +172,16 @@ export default class ChatSearchWebview {
           type: 'update',
           mostRecentAppMaps: appmaps,
         });
+      }),
+      this.rpcService.onRpcPortChange(() => {
+        panel.webview.postMessage({
+          type: 'navie-restarted',
+        });
+      }),
+      this.rpcService.onRestart(() => {
+        panel.webview.postMessage({
+          type: 'navie-restarting',
+        });
       })
     );
 
@@ -248,12 +259,36 @@ export default class ChatSearchWebview {
 
         case 'select-llm-option': {
           const { option } = message;
-          if (option === 'default') {
-            await vscode.commands.executeCommand('appmap.clearNavieAiSettings');
-          } else if (option === 'own-key') {
-            await vscode.commands.executeCommand('appmap.openAIApiKey.set');
-          } else {
-            console.error(`Unknown option: ${option}`);
+          switch (option) {
+            case 'default':
+              this.rpcService.updateSettings({
+                useCopilot: false,
+                openAIApiKey: '',
+                env: {
+                  OPENAI_BASE_URL: undefined,
+                  OPENAI_API_KEY: undefined,
+                  AZURE_OPENAI_API_KEY: undefined,
+                  ANTHROPIC_API_KEY: undefined,
+                },
+              });
+              break;
+
+            case 'copilot':
+              this.rpcService.updateSettings({ useCopilot: true });
+              break;
+
+            case 'own-key':
+              this.rpcService.updateSettings({
+                useCopilot: false,
+                openAIApiKey: await vscode.window.showInputBox({ placeHolder: 'OpenAI API Key' }),
+                env: {
+                  OPENAI_BASE_URL: undefined,
+                },
+              });
+              break;
+
+            default:
+              console.error(`Unknown option: ${option}`);
           }
           break;
         }
@@ -304,6 +339,6 @@ export default class ChatSearchWebview {
   ): ChatSearchWebview {
     const dataService = new ChatSearchDataService(rpcService, appmaps);
 
-    return new ChatSearchWebview(context, extensionState, dataService);
+    return new ChatSearchWebview(context, extensionState, dataService, rpcService);
   }
 }

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -35,7 +35,7 @@ export const EVENTS = {
   onDidChangeConfiguration: listener(),
 };
 
-class Configuration extends Map<string, unknown> {
+export class Configuration extends Map<string, unknown> {
   get(key: string, defaultValue?: unknown): unknown {
     return super.get(key) ?? defaultValue;
   }

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -35,9 +35,42 @@ export const EVENTS = {
   onDidChangeConfiguration: listener(),
 };
 
+class Configuration extends Map<string, unknown> {
+  get(key: string, defaultValue?: unknown): unknown {
+    return super.get(key) ?? defaultValue;
+  }
+
+  inspect(key: string): { workspaceValue?: unknown } | undefined {
+    return {};
+  }
+
+  update(key: string, value: unknown, target?: unknown): Promise<void> {
+    if (value === undefined || value === null) {
+      this.delete(key);
+    } else {
+      let filteredValue = value;
+      if (typeof value === 'object') {
+        // Undefined/null values are deleted
+        filteredValue = Object.entries(value).reduce((acc, [k, v]) => {
+          if (v !== undefined && v !== null) acc[k] = v;
+          return acc;
+        }, {});
+      }
+      this.set(key, filteredValue);
+    }
+    return Promise.resolve();
+  }
+}
+
+const configs = new Map<string, Configuration>();
+
 export default {
   fs,
-  getConfiguration: () => new Map<string, unknown>(),
+  getConfiguration: (key: string) => {
+    let config = configs.get(key);
+    if (!config) configs.set(key, (config = new Configuration()));
+    return config;
+  },
   workspaceFolders: [],
   onDidChangeConfiguration: EVENTS.onDidChangeConfiguration,
   onDidChangeWorkspaceFolders: EVENTS.onDidChangeWorkspaceFolders,

--- a/test/unit/services/chatCompletion.test.ts
+++ b/test/unit/services/chatCompletion.test.ts
@@ -65,6 +65,7 @@ describe('ChatCompletion', () => {
       OPENAI_BASE_URL: chatCompletion.url,
       APPMAP_NAVIE_TOKEN_LIMIT: '325',
       APPMAP_NAVIE_MODEL: 'test-family',
+      APPMAP_NAVIE_COMPLETION_BACKEND: 'openai',
     });
   });
 

--- a/test/unit/services/chatCompletion.test.ts
+++ b/test/unit/services/chatCompletion.test.ts
@@ -125,7 +125,7 @@ describe('ChatCompletion', () => {
     expect(instance).to.equal(chatCompletion);
 
     expect(chatCompletion.port).to.be.above(0);
-    expect(chatCompletion.url).to.match(/^http:\/\/localhost:\d+\/vscode\/copilot$/);
+    expect(chatCompletion.url).to.match(/^http:\/\/127.0.0.1:\d+\/vscode\/copilot$/);
 
     // make an actual HTTP request to the server
     const res = await get(chatCompletion.url);

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -84,6 +84,14 @@ export default function mountChatSearchView() {
         });
     });
 
+    messages
+      .on('navie-restarting', () => {
+        app.$refs.ui.onNavieRestarting();
+      })
+      .on('navie-restarted', () => {
+        app.$refs.ui.loadNavieConfig();
+      });
+
     app.$on('open-install-instructions', () => {
       vscode.postMessage({ command: 'open-install-instructions' });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,9 +182,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^4.38.3":
-  version: 4.38.3
-  resolution: "@appland/components@npm:4.38.3"
+"@appland/components@npm:^4.39.0":
+  version: 4.39.0
+  resolution: "@appland/components@npm:4.39.0"
   dependencies:
     "@appland/client": ^1.12.0
     "@appland/diagrams": ^1.7.0
@@ -210,7 +210,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.14
     vuex: ^3.6.0
-  checksum: 7b9f5529c75859a1a535cdcefa82c69b783fdfe629305d59bfc163c8fe6e36e6c52cb8bd20cf8561930a641b78c7f04ee43ed77e0e9fe511eabbc615037d7f7d
+  checksum: db2ce60dfa09e22356499a250d8b385fc2737361ce365be9c8a280023cf4d916ddd079b4bad259050b103ac91c4d774b10b634ccb19d52adab679050e8cde3c3
   languageName: node
   linkType: hard
 
@@ -3054,7 +3054,7 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.129.0
     "@appland/client": ^1.14.1
-    "@appland/components": ^4.38.3
+    "@appland/components": ^4.39.0
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.2
     "@appland/rpc": ^1.15.0


### PR DESCRIPTION
Changes the default to true and changes the flow a bit (this is executed on initialization and on state change):
- If Copilot backend is enabled:
  - if Copilot is available, use it;
    - when it becomes unavailable, switch to default;
  - if LM not available (old VSCode), fall back to default backend;
  - if Copilot is not available, suggest installation;
    - when it becomes available, switch to it;
- else:
  - show informational message if user manually disabled it.

Note for all these messages are shown only once, unless the state change is caused by user action.

Other changes:
- wording changes to reference Copilot instead of generic LM (we only really support it currently anyway),
- make sure to restart Navie backend as necessary and without debouncing (which is only really necessary when changing the environment variables manually),
- force OpenAI backend when using Copilot (to avoid issues with leftover environment variables when switching around).