### PR TITLE
fix: Fix an issue when opening sequence diagrams from Navie on Windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -419,5 +419,7 @@ export async function parseLocation(
       )
     );
   }
-  return vscode.Uri.parse(location);
+  // Remove any file:// prefix from the URI. Uri.file() will add it back. Otherwise, it'll be interpreted as
+  // part of the path, perhaps a drive letter.
+  return vscode.Uri.file(location.replace(/file:\/\//g, ''));
 }

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -94,10 +94,7 @@ describe('parseLocation', () => {
       const result = (await parseLocation('C:\\path\\to\\file.rb')) as URI;
 
       expect(result instanceof URI).to.be.true;
-
-      // TODO: This may have different behavior on Windows
-      //       i.e. it may be a URI with a drive letter
-      expect(result.fsPath).to.equal('\\path\\to\\file.rb');
+      expect(result.fsPath).to.equal('c:\\path\\to\\file.rb');
     });
 
     it('should parse a location with a line number', async () => {


### PR DESCRIPTION
When opening a sequence diagram from context, paths were being improperly handled on Windows.

![image](https://github.com/user-attachments/assets/01e3834a-3fc4-4431-8a87-c49fbf605aec)
