### PR TITLE
fix: parse pinned file paths correctly

### DIFF
--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -72,7 +72,7 @@ export default class ChatSearchWebview {
         let contentLength = r.content?.length;
         if (!r.content) {
           assert(r.uri, `doPinFiles, ${r.name}: no content, no uri`);
-          const u: vscode.Uri = vscode.Uri.parse(r.uri);
+          const u: vscode.Uri = vscode.Uri.file(r.uri.toString().replace(/file:\/\//g, ''));
           const stat = await vscode.workspace.fs.stat(u);
           contentLength = stat.size;
           if (contentLength < maxPinnedFileSize) {


### PR DESCRIPTION
Use vscode.Uri.file to parse file paths, rather than vscode.Uri.path.

Fixes #1040 .