### PR TITLE
fix: show Navie instead of walkthrough

### DIFF
--- a/src/services/signInManager.ts
+++ b/src/services/signInManager.ts
@@ -57,7 +57,6 @@ export default class SignInManager {
       this.shouldShowSignIn()
     );
 
-    if (!this.shouldShowSignIn())
-      vscode.commands.executeCommand('workbench.action.openWalkthrough', 'navie.walkthrough');
+    if (this.shouldShowSignIn()) vscode.commands.executeCommand('appmap.explain');
   }
 }

--- a/src/tree/linkTreeDataProvider.ts
+++ b/src/tree/linkTreeDataProvider.ts
@@ -83,6 +83,14 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
       return treeItem;
     });
 
+    const walkthroughItem = new vscode.TreeItem('Walkthrough');
+    walkthroughItem.id = 'DOC_WALKTHROUGH' as string;
+    walkthroughItem.command = {
+      command: 'workbench.action.openWalkthrough',
+      arguments: ['appland.appmap#navie.walkthrough'],
+    } as vscode.Command;
+    items.push(walkthroughItem);
+
     return Promise.resolve(items);
   }
 


### PR DESCRIPTION
When sign in is required, open a Navie tab instead of showing the walkthrough. Also, include a link to the walkthrough at the bottom of the Documentation view.