### PR TITLE
fix: File links can now be clicked in Navie responses

### DIFF
--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -180,7 +180,11 @@ export default class RpcProcessService implements Disposable {
       await configurationFn();
     } catch (e) {
       NodeProcessService.outputChannel.appendLine('Failed to sync AppMap configurations');
-      NodeProcessService.outputChannel.appendLine(String(e));
+      if (e instanceof AggregateError) {
+        e.errors.forEach((err) => NodeProcessService.outputChannel.appendLine(String(err)));
+      } else {
+        NodeProcessService.outputChannel.appendLine(String(e));
+      }
     }
   }
 

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -304,6 +304,15 @@ export default class ChatSearchWebview {
           break;
         }
 
+        case 'click-link': {
+          const location = await parseLocation(message.link);
+          if (location) {
+            const uri = location instanceof vscode.Location ? location.uri : location;
+            await vscode.commands.executeCommand('vscode.open', uri);
+          }
+          break;
+        }
+
         case 'fetch-pinned-files': {
           const { requests } = message;
           this.doPinFiles(panel, requests);

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -131,6 +131,10 @@ export default function mountChatSearchView() {
     app.$on('chat-search-loaded', () => {
       vscode.postMessage({ command: 'chat-search-loaded' });
     });
+
+    app.$on('click-link', (link) => {
+      vscode.postMessage({ command: 'click-link', link });
+    });
   });
 
   vscode.postMessage({ command: 'chat-search-ready' });


### PR DESCRIPTION
Using the event emit in the recent [`@appland/components` update](https://github.com/getappmap/appmap-js/blob/main/packages/components/CHANGELOG.md#applandcomponents-v4400-2024-10-28), links to files will now be opened from a Navie chat.