### PR TITLE
Select Copilot model and default to `gpt-4o`

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,10 @@
         "title": "AppMap: Restart Navie"
       },
       {
+        "command": "appmap.copilot.selectModel",
+        "title": "AppMap: Select Copilot Model"
+      },
+      {
         "command": "appmap.login",
         "title": "AppMap: Login"
       },
@@ -335,6 +339,10 @@
           "type": "boolean",
           "default": true,
           "description": "Use animations"
+        },
+        "appMap.copilot.preferredModel": {
+          "type": "string",
+          "description": "Preferred Copilot model to use"
         }
       }
     },

--- a/src/commands/pickCopilotModel.ts
+++ b/src/commands/pickCopilotModel.ts
@@ -1,0 +1,32 @@
+import ExtensionSettings from '../configuration/extensionSettings';
+import ChatCompletion from '../services/chatCompletion';
+import vscode from 'vscode';
+
+export default class PickCopilotModelCommand {
+  public static readonly command = 'appmap.copilot.selectModel';
+
+  public static register(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        PickCopilotModelCommand.command,
+        PickCopilotModelCommand.execute
+      )
+    );
+  }
+
+  public static async execute(): Promise<void> {
+    await ChatCompletion.refreshModels();
+    if (ChatCompletion.models.length === 0) {
+      vscode.window.showErrorMessage('No Copilot models are available.');
+      return;
+    }
+
+    const model = await vscode.window.showQuickPick(
+      ChatCompletion.models.map((m) => ({ label: m.name, details: m.id }))
+    );
+    if (!model) return;
+
+    await ExtensionSettings.setPreferredCopilotModel(model.details);
+    return vscode.commands.executeCommand('appmap.rpc.restart');
+  }
+}

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -79,6 +79,14 @@ export default class ExtensionSettings {
     return ret !== undefined ? ret : 20000;
   }
 
+  public static get preferredCopilotModel(): string | undefined {
+    return vscode.workspace.getConfiguration('appMap').get('copilot.preferredModel', 'gpt-4o');
+  }
+
+  public static setPreferredCopilotModel(model: string | undefined): Thenable<void> {
+    return vscode.workspace.getConfiguration('appMap').update('copilot.preferredModel', model);
+  }
+
   public static get useAnimation(): boolean {
     return [true, 'true'].includes(
       vscode.workspace.getConfiguration('appMap').get('useAnimation') || false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ import CommandRegistry from './commands/commandRegistry';
 import AssetService from './assets/assetService';
 import clearNavieAiSettings from './commands/clearNavieAiSettings';
 import ExtensionSettings from './configuration/extensionSettings';
+import PickCopilotModelCommand from './commands/pickCopilotModel';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   CommandRegistry.setContext(context).addWaitAlias({
@@ -226,6 +227,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     const processService = new NodeProcessService(context);
 
     await ChatCompletion.initialize(context);
+    PickCopilotModelCommand.register(context);
 
     AssetService.register(context);
     const dependenciesInstalled = ExtensionSettings.appMapCommandLineToolsPath

--- a/src/services/chatCompletion.ts
+++ b/src/services/chatCompletion.ts
@@ -106,7 +106,10 @@ export default class ChatCompletion implements Disposable {
     return env;
   }
 
-  private static models: vscode.LanguageModelChat[] = [];
+  private static _models: vscode.LanguageModelChat[] = [];
+  public static get models(): ReadonlyArray<vscode.LanguageModelChat> {
+    return this._models;
+  }
 
   static get preferredModel(): vscode.LanguageModelChat | undefined {
     return ChatCompletion.models[0];
@@ -114,7 +117,7 @@ export default class ChatCompletion implements Disposable {
 
   static async refreshModels(): Promise<boolean> {
     const previousBest = this.preferredModel?.id;
-    ChatCompletion.models = (await vscode.lm.selectChatModels()).sort(
+    this._models = (await vscode.lm.selectChatModels()).sort(
       (a, b) => b.maxInputTokens - a.maxInputTokens + b.family.localeCompare(a.family)
     );
     return this.preferredModel?.id !== previousBest;

--- a/src/services/chatCompletion.ts
+++ b/src/services/chatCompletion.ts
@@ -112,7 +112,12 @@ export default class ChatCompletion implements Disposable {
   }
 
   static get preferredModel(): vscode.LanguageModelChat | undefined {
-    return ChatCompletion.models[0];
+    const modelId = ExtensionSettings.preferredCopilotModel;
+    if (modelId) {
+      const model = this.models.find((m) => m.id === modelId);
+      if (model) return model;
+    }
+    return this.models[0];
   }
 
   static async refreshModels(): Promise<boolean> {

--- a/test/unit/commands/pickCopilotModel.test.ts
+++ b/test/unit/commands/pickCopilotModel.test.ts
@@ -1,0 +1,67 @@
+import vscode from '../mock/vscode';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import PickCopilotModelCommand from '../../../src/commands/pickCopilotModel';
+
+describe('pickCopilotModel', () => {
+  describe('execute', () => {
+    let models: Record<string, unknown>[];
+    let executeCommandStub: sinon.SinonStub;
+    let showQuickPickStub: sinon.SinonStub;
+    let showErrorMessageStub: sinon.SinonStub;
+    const chosenModel = 'claude-3.5-sonnet';
+    beforeEach(() => {
+      models = [
+        { id: 'gpt-4o', name: 'GPT-4o', maxInputTokens: 325, family: 'copilot' },
+        {
+          id: 'claude-3.5-sonnet',
+          name: 'Claude 3.5 Sonnet',
+          maxInputTokens: 325,
+          family: 'copilot',
+        },
+      ];
+      showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').callsFake(() => ({
+        details: chosenModel,
+      }));
+      showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage').resolves();
+      executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves();
+      sinon.stub(vscode.lm, 'selectChatModels').callsFake(() => models as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    const setPreferredModel = (model: string | undefined) =>
+      vscode.workspace.getConfiguration('appMap').update('copilot.preferredModel', model);
+    const getPreferredModel = () =>
+      vscode.workspace.getConfiguration('appMap').get('copilot.preferredModel');
+
+    it('sets the appMap.copilot.preferredModel setting', async () => {
+      setPreferredModel(undefined);
+      await PickCopilotModelCommand.execute();
+      expect(getPreferredModel()).to.equal(chosenModel);
+    });
+
+    it('shows an error message if no models are available', async () => {
+      models = [];
+      await PickCopilotModelCommand.execute();
+      expect(showErrorMessageStub.called).to.be.true;
+      expect(showQuickPickStub.called).to.be.false;
+      expect(executeCommandStub.called).to.be.false;
+    });
+
+    it('restarts the RPC server', async () => {
+      await PickCopilotModelCommand.execute();
+      expect(executeCommandStub.calledWith('appmap.rpc.restart')).to.be.true;
+    });
+
+    it('does nothing if the user cancels the quick pick', async () => {
+      showQuickPickStub.resolves(undefined);
+      setPreferredModel(chosenModel);
+      await PickCopilotModelCommand.execute();
+      expect(getPreferredModel()).to.equal(chosenModel);
+      expect(executeCommandStub.called).to.be.false;
+    });
+  });
+});

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -4,7 +4,8 @@ import EventEmitter from './EventEmitter';
 import Terminal from './Terminal';
 import type * as vscode from 'vscode';
 
-const doNothing = () => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const doNothing = (..._args: unknown[]) => {
   // nop
 };
 


### PR DESCRIPTION
This PR adds a new command `AppMap: Select Copilot Model` that allows users to change their preferred Copilot model. The default model is set to `gpt-4o`.

## Changes
- Added a new command `appmap.copilot.selectModel` that lets users pick from available Copilot models
- Added configuration setting `appMap.copilot.preferredModel` to store the user's model preference
- Set default model to `gpt-4o`
- The RPC server restarts after model selection to apply changes
- Added unit tests to verify the model selection functionality

## Testing
The changes have been tested to verify:
- Model selection UI works correctly
- Setting is saved properly
- RPC server restarts after model change
- Error handling for when no models are available
- Cancellation handling for the model picker

## Notes
The command can be accessed via:
- Command palette: `AppMap: Select Copilot Model`
- Default model is `gpt-4o` if no preference is set

Opening for review - please let me know if any questions or changes needed.