### PR TITLE
fix: Default applys to empty string in `copilot.preferredModel`

### DIFF
--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -84,7 +84,9 @@ export default class ExtensionSettings {
   }
 
   public static setPreferredCopilotModel(model: string | undefined): Thenable<void> {
-    return vscode.workspace.getConfiguration('appMap').update('copilot.preferredModel', model);
+    return vscode.workspace
+      .getConfiguration('appMap')
+      .update('copilot.preferredModel', model, true);
   }
 
   public static get useAnimation(): boolean {

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -80,7 +80,7 @@ export default class ExtensionSettings {
   }
 
   public static get preferredCopilotModel(): string | undefined {
-    return vscode.workspace.getConfiguration('appMap').get('copilot.preferredModel', 'gpt-4o');
+    return vscode.workspace.getConfiguration('appMap').get('copilot.preferredModel') || 'gpt-4o';
   }
 
   public static setPreferredCopilotModel(model: string | undefined): Thenable<void> {


### PR DESCRIPTION
This fixes an issue where the default model would not be applied if the preferred model was an empty string. It also writes the configuration to the global state, instead of workspace settings.