### PR TITLE
Fix a bug in ExtensionState caused by unknown first installed version

### DIFF
--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -124,7 +124,16 @@ export default class ExtensionState implements vscode.Disposable {
   }
 
   installedPriorTo(version: string): boolean {
-    return semver.lt(this.firstVersionInstalled, version);
+    if (!semver.valid(version)) {
+      console.warn(`Invalid version string provided to installedPriorTo: ${version}`);
+      return false;
+    }
+    const firstVersion = this.firstVersionInstalled;
+    if (firstVersion === 'unknown' || !semver.valid(firstVersion)) {
+      console.warn(`First installed version is invalid or unknown: ${firstVersion}`);
+      return true;
+    }
+    return semver.lt(firstVersion, version);
   }
 
   /** Returns whether or not the user has opened an AppMap from within the given workspace folder. */

--- a/test/unit/extensionState.test.ts
+++ b/test/unit/extensionState.test.ts
@@ -1,3 +1,5 @@
+import './mock/vscode';
+
 import assert from 'assert';
 import { SinonSandbox, createSandbox } from 'sinon';
 import ExtensionState, { Keys } from '../../src/configuration/extensionState';


### PR DESCRIPTION
`ExtenstionState.insalledPriorTo` uses `semver.lt(firstVersion, version)` to check if the extension was first installed before a given version (this is for the purposes of displaying walkthrough on start). The default value of `firstVersion` is `unknown`, which is not a valid version so causes semver to crash.

I changed it to verify the inputs and return `true` in case of `unknown` — this is on the assumption that if the version was too old to set the version it must have been older than any version we care about.