### PR TITLE
fix: Wait for lm models to settle when initializing

### DIFF
--- a/test/unit/mock/vscode/lm.ts
+++ b/test/unit/mock/vscode/lm.ts
@@ -1,5 +1,7 @@
 import type { LanguageModelChat, LanguageModelChatSelector } from 'vscode';
 
+import EventEmitter from './EventEmitter';
+
 const models: LanguageModelChat[] = [];
 
 export async function selectChatModels(
@@ -11,10 +13,17 @@ export async function selectChatModels(
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const didChangeChatModelsEvent = new EventEmitter<void>();
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const onDidChangeChatModels = didChangeChatModelsEvent.event;
+
 export function addMockChatModel(model: LanguageModelChat): void {
   models.push(model);
+  didChangeChatModelsEvent.fire();
 }
 
 export function resetModelMocks() {
   models.length = 0;
+  didChangeChatModelsEvent.fire();
 }

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -5,8 +5,9 @@ import Terminal from './Terminal';
 import type * as vscode from 'vscode';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const doNothing = (..._args: unknown[]) => {
-  // nop
+const doNothing = (..._args: unknown[]): unknown => {
+  // nop, but return a promise in case the caller is expecting one
+  return Promise.resolve(undefined);
 };
 
 export const EmitOnDidChangeTerminalState = new EventEmitter<vscode.Terminal>();


### PR DESCRIPTION
This pull request introduces several changes to improve the initialization and testing of the `ChatCompletion` class in the `src/services/chatCompletion.ts` file. The most important changes include adding an initialization flag, modifying the configuration check to wait for models to settle, and enhancing the mock and unit test files to support these changes.

Improvements to `ChatCompletion` class initialization:

* Added a static `initialized` flag to the `ChatCompletion` class to track whether the initialization process has completed. (`src/services/chatCompletion.ts`)
* Modified the `checkConfiguration` method to wait for models to settle if the `initialized` flag is not set, allowing the extension to load correctly even if it starts before Copilot. (`src/services/chatCompletion.ts`)

Enhancements to mock files:

* Added `EventEmitter` to the mock `vscode/lm.ts` file to simulate model change events, and updated the `addMockChatModel` and `resetModelMocks` functions to trigger these events. (`test/unit/mock/vscode/lm.ts`) [[1]](diffhunk://#diff-b0b8e9194a99adfbc13237f1ed12960474f41e3360624ccacfb2e0c8d2e42003R3-R4) [[2]](diffhunk://#diff-b0b8e9194a99adfbc13237f1ed12960474f41e3360624ccacfb2e0c8d2e42003R16-R28)
* Modified the `doNothing` function in the mock `vscode/window.ts` file to return a resolved promise, ensuring compatibility with callers expecting a promise. (`test/unit/mock/vscode/window.ts`)

Enhancements to unit tests:

* Added a new test suite for the `ChatCompletion.initialize` method to verify that it waits for models to settle before completing initialization. (`test/unit/services/chatCompletion.test.ts`) [[1]](diffhunk://#diff-15ff1d180f3053060d904256e55a9bc811fa446792568aef0a9225a8d2766367R3) [[2]](diffhunk://#diff-15ff1d180f3053060d904256e55a9bc811fa446792568aef0a9225a8d2766367R270-R291)
* Updated the existing `ChatCompletion` test suite to reset model mocks after each test, ensuring test isolation. (`test/unit/services/chatCompletion.test.ts`)

Fixes #1068