### PR TITLE
feat: Integrate Navie history

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
     ],
     "commands": [
       {
+        "command": "appmap.navie.history",
+        "title": "AppMap: Open Navie History",
+        "icon": "$(history)"
+      },
+      {
         "command": "appmap.getAppmapState",
         "title": "AppMap: Copy Current AppMap State to Clipboard"
       },
@@ -593,6 +598,11 @@
           "command": "appmap.stopCurrentRemoteRecording",
           "when": "view == appmap.views.appmaps && appmap.recordingIsRunning",
           "group": "navigation@0"
+        },
+        {
+          "command": "appmap.navie.history",
+          "when": "view == appmap.views.navie",
+          "group": "navigation@0"
         }
       ],
       "view/item/context": [
@@ -719,10 +729,10 @@
   "dependencies": {
     "@appland/appmap": "^3.129.0",
     "@appland/client": "^1.23.0",
-    "@appland/components": "^4.45.0",
+    "@appland/components": "^4.46.1",
     "@appland/diagrams": "^1.8.0",
     "@appland/models": "^2.10.2",
-    "@appland/rpc": "^1.18.0",
+    "@appland/rpc": "^1.19.0",
     "@appland/scanner": "^1.86.0",
     "@appland/sequence-diagram": "^1.12.0",
     "@yarnpkg/parsers": "^3.0.0-rc.45",

--- a/src/commands/openNavieHistory.ts
+++ b/src/commands/openNavieHistory.ts
@@ -1,0 +1,62 @@
+import vscode from 'vscode';
+import RpcProcessService from '../services/rpcProcessService';
+
+interface Thread {
+  id: string;
+  path: string;
+  title?: string;
+  created_at: string;
+}
+
+interface SuccessResponse {
+  result: Thread[];
+}
+
+interface ErrorResponse {
+  error: {
+    code: number;
+    message: string;
+  };
+}
+
+export default class OpenNavieHistoryCommand {
+  public static readonly command = 'appmap.navie.history';
+  private static rpcService: RpcProcessService;
+
+  public static register(context: vscode.ExtensionContext, rpcService: RpcProcessService): void {
+    this.rpcService = rpcService;
+    context.subscriptions.push(
+      vscode.commands.registerCommand(OpenNavieHistoryCommand.command, () =>
+        OpenNavieHistoryCommand.execute()
+      )
+    );
+  }
+
+  private static async execute(): Promise<void> {
+    try {
+      const client = this.rpcService.rpcClient();
+      const response = (await client.request('v1.navie.thread.query', {
+        limit: 64,
+        orderBy: 'created_at',
+      })) as SuccessResponse | ErrorResponse;
+      if ('error' in response) {
+        throw new Error(response.error.message);
+      }
+      const selection = await vscode.window.showQuickPick(
+        response.result.map((m) => ({
+          label: m.title ?? 'Untitled',
+          description: m.created_at,
+          path: m.path,
+          threadId: m.id,
+        }))
+      );
+      if (!selection) return;
+      await vscode.commands.executeCommand('appmap.explain', {
+        threadId: selection.threadId,
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      vscode.window.showErrorMessage(`Failed to retrieve history: ${message}`);
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ import AssetService from './assets/assetService';
 import clearNavieAiSettings from './commands/clearNavieAiSettings';
 import ExtensionSettings from './configuration/extensionSettings';
 import PickCopilotModelCommand from './commands/pickCopilotModel';
+import OpenNavieHistoryCommand from './commands/openNavieHistory';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   CommandRegistry.setContext(context).addWaitAlias({
@@ -270,6 +271,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
         appmapCollectionFile,
         rpcService
       );
+
+      OpenNavieHistoryCommand.register(context, rpcService);
 
       return webview;
     })();

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -52,6 +52,7 @@ export default class RpcProcessService implements Disposable {
     this.processWatcher = new RpcProcessWatcher(this.context, this.modulePath, {
       APPMAP_CODE_EDITOR: 'vscode',
       APPMAP_NAVIE_MODEL_SELECTOR: '1',
+      APPMAP_NAVIE_THREAD_LOG: '1',
     });
     this.diposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(() => this.pushConfiguration()),
@@ -304,5 +305,11 @@ export default class RpcProcessService implements Disposable {
     if (secretEnvChanged) {
       this.debouncedRestart();
     }
+  }
+
+  rpcClient(): Client {
+    if (!this.available) throw new Error('RPC server is not available');
+    if (this.rpcPort === undefined) throw new Error('RPC port is not defined');
+    return this.rpcConnect(this.rpcPort);
   }
 }

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -24,6 +24,7 @@ type ExplainOpts = {
   targetAppmap?: any;
   targetAppmapFsPath?: string;
   suggestion?: { label: string; prompt: string };
+  threadId?: string;
 };
 
 export enum ExplainResponseStatus {
@@ -115,7 +116,7 @@ export default class ChatSearchWebview {
     });
 
     if (goodRequests.length > 0) {
-      const msg = { type: 'pin-files', requests: goodRequests.map((r) => new PinFileRequest(r)) };
+      const msg = { type: 'pin-files', requests: goodRequests.map(({ uri }) => uri) };
       panel.webview.postMessage(msg);
     }
   }
@@ -126,6 +127,7 @@ export default class ChatSearchWebview {
     targetAppmap,
     targetAppmapFsPath,
     suggestion,
+    threadId,
   }: ExplainOpts = {}): Promise<ExplainResponse> {
     const appmapRpcPort = this.dataService.appmapRpcPort;
     if (!appmapRpcPort) {
@@ -211,6 +213,7 @@ export default class ChatSearchWebview {
               .get<string>('selectedModel'),
             useAnimation: ExtensionSettings.useAnimation,
             editorType: 'vscode',
+            threadId,
           });
           break;
         case 'open-new-chat':
@@ -317,6 +320,7 @@ export default class ChatSearchWebview {
 
         case 'select-model': {
           const { model } = message;
+          if (!model) return;
           const modelId = `${model.provider.toLowerCase()}:${model.id.toLowerCase()}`;
           await vscode.workspace.getConfiguration('appMap').update('selectedModel', modelId, true);
           break;

--- a/src/webviews/getWebviewContent.ts
+++ b/src/webviews/getWebviewContent.ts
@@ -33,7 +33,7 @@ export default function getWebviewContent(
   );
 
   const connectSrc = options.connectSrc ?? [];
-  if (rpcPort) connectSrc.push(`http://localhost:${rpcPort}`);
+  if (rpcPort) connectSrc.push(`http://localhost:${rpcPort}`, `ws://localhost:${rpcPort}`);
 
   return ` <!DOCTYPE html>
   <html style="${htmlStyle ?? ''}" lang="en">

--- a/test/integration/chat/chat.test.ts
+++ b/test/integration/chat/chat.test.ts
@@ -1,18 +1,10 @@
 import assert from 'assert';
-import { promises as fs } from 'fs';
 import sinon from 'sinon';
 
-import path from 'path';
 import * as vscode from 'vscode';
 import { initializeWorkspaceServices } from '../../../src/services/workspaceServices';
 import ChatSearchWebview from '../../../src/webviews/chatSearchWebview';
-import { initializeWorkspace, waitForExtension, withAuthenticatedUser, withTmpDir } from '../util';
-
-type PinFileEvent = {
-  type: string;
-  location: string;
-  content: string;
-};
+import { initializeWorkspace, waitForExtension, withAuthenticatedUser } from '../util';
 
 describe('chat', () => {
   let sandbox: sinon.SinonSandbox;
@@ -37,84 +29,6 @@ describe('chat', () => {
     it('opens a Chat + Search view', async () => {
       await vscode.commands.executeCommand('appmap.explain');
       assert(chatSearchWebview.currentWebview);
-    });
-  });
-
-  describe('once the Chat is opened', () => {
-    let chatView: vscode.Webview;
-
-    beforeEach(async () => {
-      const p = new Promise<vscode.Webview>((resolve) => {
-        const waitForLoaded = (wv: vscode.Webview): void => {
-          wv.onDidReceiveMessage((msg) => {
-            if (msg.command === 'chat-search-loaded') {
-              resolve(wv);
-            }
-          });
-        };
-        chatSearchWebview.onWebview = waitForLoaded;
-      });
-      await vscode.commands.executeCommand('appmap.explain');
-      chatView = await p;
-    });
-
-    const waitForPin = () =>
-      new Promise<PinFileEvent>((resolve) => {
-        chatView.onDidReceiveMessage((msg) => {
-          if (msg.command === 'pin') {
-            resolve(msg.event);
-          }
-        });
-      });
-
-    const expectedContent = 'Hello World!';
-    const newTmpFiles = async (tmpDir: string) => {
-      const fullPath = path.join(tmpDir, 'hello-world.txt');
-      await fs.writeFile(fullPath, expectedContent, 'utf-8');
-      return [vscode.Uri.file(fullPath)];
-    };
-
-    const verifyPinEvent = (event: PinFileEvent, files: vscode.Uri[]) => {
-      assert.strictEqual(event.type, 'file');
-      assert.strictEqual(event.location, files[0].path);
-      assert.strictEqual(event.content, expectedContent);
-    };
-
-    describe('appmap.addToContext', () => {
-      it('pins a file', async () => {
-        await withTmpDir(async (tmpDir) => {
-          const files = await newTmpFiles(tmpDir);
-          sandbox.stub(chatSearchWebview, 'chooseFilesToPin').resolves(files);
-          const p = waitForPin();
-          await vscode.commands.executeCommand('appmap.addToContext');
-          const event = await p;
-          verifyPinEvent(event, files);
-        });
-      });
-    });
-
-    describe('appmap.explorer.addToContext', () => {
-      it('pins a file', async () => {
-        return withTmpDir(async (tmpDir) => {
-          const files = await newTmpFiles(tmpDir);
-          const p = waitForPin();
-          await vscode.commands.executeCommand('appmap.explorer.addToContext', null, files);
-          const event = await p;
-          verifyPinEvent(event, files);
-        });
-      });
-    });
-
-    describe('appmap.editor.title.addToContext', () => {
-      it('pins a file', async () => {
-        await withTmpDir(async (tmpDir) => {
-          const files = await newTmpFiles(tmpDir);
-          const p = waitForPin();
-          await vscode.commands.executeCommand('appmap.editor.title.addToContext', files[0]);
-          const event = await p;
-          verifyPinEvent(event, files);
-        });
-      });
     });
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -47,6 +47,7 @@ export default defineConfig([
         'socket.io-client': './node_modules/socket.io-client/dist/socket.io.js',
         vue: './node_modules/vue/dist/vue.esm.browser.js',
         vuex: './node_modules/vuex/dist/vuex.esm.browser.js',
+        uuid: './node_modules/uuid/dist/esm-browser/index.js',
       };
     },
     loader: {

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -27,6 +27,7 @@ export default function mountChatSearchView() {
             useAnimation: initialData.useAnimation,
             editorType: initialData.editorType,
             preselectedModelId: initialData.selectedModelId,
+            threadId: initialData.threadId,
             openNewChat() {
               vscode.postMessage({ command: 'open-new-chat' });
             },
@@ -50,7 +51,9 @@ export default function mountChatSearchView() {
       },
       mounted() {
         if (initialData.codeSelection) {
-          this.$refs.ui.includeCodeSelection(initialData.codeSelection);
+          this.$root.$on('on-thread-subscription', () => {
+            this.$refs.ui.includeCodeSelection(initialData.codeSelection);
+          });
         }
         if (initialData.suggestion) {
           this.$refs.ui.$refs.vchat.addUserMessage(initialData.suggestion.label);
@@ -142,10 +145,6 @@ export default function mountChatSearchView() {
 
     app.$on('fetch-pinned-files', (requests) => {
       vscode.postMessage({ command: 'fetch-pinned-files', requests });
-    });
-
-    app.$on('pin', (event) => {
-      vscode.postMessage({ command: 'pin', event });
     });
 
     app.$on('chat-search-loaded', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,14 +63,14 @@ __metadata:
   linkType: hard
 
 "@appland/appmap@npm:^3.129.0":
-  version: 3.186.0
-  resolution: "@appland/appmap@npm:3.186.0"
+  version: 3.188.1
+  resolution: "@appland/appmap@npm:3.188.1"
   dependencies:
     "@appland/client": ^1.17.0
     "@appland/components": ^4.12.0
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.2
-    "@appland/navie": ^1.42.1
+    "@appland/navie": ^1.42.3
     "@appland/openapi": ^1.8.0
     "@appland/rpc": ^1.13.0
     "@appland/scanner": ^1.86.0
@@ -96,6 +96,7 @@ __metadata:
     debug: ^4.3.6
     detect-indent: ^6.1.0
     diff: ^5.1.0
+    express: ^5.1.0
     fs-extra: ^10.1.0
     gitconfiglocal: ^2.1.0
     glob: ^7.2.3
@@ -122,18 +123,21 @@ __metadata:
     ps-node: ^0.1.6
     puppeteer: ^19.7.5
     read-pkg-up: ^7.0.1
+    reflect-metadata: ^0.2.2
     semver: ^7.3.5
     sql-formatter: ^4.0.2
     strip-ansi: ^6.0.0
+    tsyringe: ^4.8.0
     validator: ^13.7.0
     w3c-xmlserializer: ^2.0.0
+    ws: ^8.18.1
     yargs: ^17.1.1
   dependenciesMeta:
     puppeteer:
       optional: true
   bin:
     appmap: built/cli.js
-  checksum: 6aea8acb10b21498c40a25c772fedec6f47af3d4eb3f698300936e82dbed5e816645cfc3e253f8beb24fc8beaa2675d5882cc8ea9da1e6872f7050bcecdca9e6
+  checksum: 8ef369973f6149bb65027f0adfd8b6f209dad236dedb4a85c6534353793353d48e3df709de4bf267f91a0936dc8f4ee46c6aedc345fee2ad44be005c0fb1825a
   languageName: node
   linkType: hard
 
@@ -151,9 +155,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^4.12.0, @appland/components@npm:^4.45.0":
-  version: 4.45.0
-  resolution: "@appland/components@npm:4.45.0"
+"@appland/components@npm:^4.12.0, @appland/components@npm:^4.46.1":
+  version: 4.46.1
+  resolution: "@appland/components@npm:4.46.1"
   dependencies:
     "@appland/client": ^1.12.0
     "@appland/diagrams": ^1.7.0
@@ -179,7 +183,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.7.16
     vuex: ^3.6.0
-  checksum: 47b186d757b0726faf7ff3516a603508efaae80e1a4960888d86f7b6cefc9d3eee2c36e46205e6f13b3a000d29d7fd1136626ada9abdbfde529fe47c829d5291
+  checksum: 32b332d52a668df2e7f3af36c91048b931054dd2b44c58f98d97e8c8986a7b44e9435ff67d6ac466c82658d22d3e828e2158803411a2c811579e674913c16cdc
   languageName: node
   linkType: hard
 
@@ -208,9 +212,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/navie@npm:^1.42.1":
-  version: 1.43.0
-  resolution: "@appland/navie@npm:1.43.0"
+"@appland/navie@npm:^1.42.3":
+  version: 1.44.0
+  resolution: "@appland/navie@npm:1.44.0"
   dependencies:
     "@langchain/anthropic": ^0.3.1
     "@langchain/core": ^0.2.27
@@ -223,8 +227,9 @@ __metadata:
     mermaid: ^9
     openai: ^4.56.0
     p-retry: 4
+    uuid: ^11.0.5
     zod: ^3.23.8
-  checksum: 53dbfdc9229c6586d17f6a857aca0ef92b58a0605a3eabe116c8faea5a133ddd64091c1e3da3cfc48731fbd4e4fa292d0b94dbe0a0d0340e171453fd3b2b1a74
+  checksum: ca1514116d35b4cfe95734ad30db6ee159a8421095dd732b89721139a486303bcf8885d5a5b806578b33f1a63820b945c6a0147f7b4ac51e73d914e090d009b4
   languageName: node
   linkType: hard
 
@@ -238,12 +243,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/rpc@npm:^1.13.0, @appland/rpc@npm:^1.18.0":
-  version: 1.18.0
-  resolution: "@appland/rpc@npm:1.18.0"
+"@appland/rpc@npm:^1.13.0, @appland/rpc@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "@appland/rpc@npm:1.19.0"
   dependencies:
     "@appland/client": 1.23.0
-  checksum: b75dd14b4d5d178045e7c654969b76027c2ee92e8426b4ff527837c5ca3c318c04e30e72e4a18b91072ec641480b55e98925a5445e6b6f2e107245d71ba150e9
+  checksum: e1d670731b0a47e01d719e1d9503305da1e35423eb7422f54154d041112b9fbf6547ae7700b9c5c83d0e3eb48c2f5e7b0b35f81abad15fca70f002c1b2b19465
   languageName: node
   linkType: hard
 
@@ -285,8 +290,8 @@ __metadata:
   linkType: hard
 
 "@appland/search@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "@appland/search@npm:1.2.0"
+  version: 1.2.1
+  resolution: "@appland/search@npm:1.2.1"
   dependencies:
     cachedir: ^2.4.0
     isbinaryfile: ^5.0.4
@@ -294,7 +299,7 @@ __metadata:
     yargs: ^17.7.2
   bin:
     search: built/cli.js
-  checksum: d3f4ef4be590f5b0442083fbf7ab916c0a9dee06a38b90e10857cb1ede3902c647d617ba00a7388d7678f52da5531128f3c238dbcb8dc28d1d94b34e94a8d931
+  checksum: 687014b09b5b49e962eac4445fa263ad78296b5b054ace22bc4a782d50cb5ea937b4c72895468714f11460f75228300e4e69bc4cf879b79828d9224f21578bc7
   languageName: node
   linkType: hard
 
@@ -2829,6 +2834,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: ^3.0.0
+    negotiator: ^1.0.0
+  checksum: 49fe6c050cb6f6ff4e771b4d88324fca4d3127865f2473872e818dca127d809ba3aa8fdfc7acb51dd3c5bade7311ca6b8cfff7015ea6db2f7eb9c8444d223a4f
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -3179,10 +3194,10 @@ __metadata:
   dependencies:
     "@appland/appmap": ^3.129.0
     "@appland/client": ^1.23.0
-    "@appland/components": ^4.45.0
+    "@appland/components": ^4.46.1
     "@appland/diagrams": ^1.8.0
     "@appland/models": ^2.10.2
-    "@appland/rpc": ^1.18.0
+    "@appland/rpc": ^1.19.0
     "@appland/scanner": ^1.86.0
     "@appland/sequence-diagram": ^1.12.0
     "@playwright/test": ^1.22.2
@@ -3638,6 +3653,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "body-parser@npm:2.2.0"
+  dependencies:
+    bytes: ^3.1.2
+    content-type: ^1.0.5
+    debug: ^4.4.0
+    http-errors: ^2.0.0
+    iconv-lite: ^0.6.3
+    on-finished: ^2.4.1
+    qs: ^6.14.0
+    raw-body: ^3.0.0
+    type-is: ^2.0.0
+  checksum: 7fe3a2d288f0b632528d6ccb90052d1a9492c5b79d5716d32c8de1f5fb8237b0d31ee5050e1d0b7ff143a492ff151804612c6e2686a222a1d4c9e2e6531b8fb2
+  languageName: node
+  linkType: hard
+
 "boolbase@npm:^1.0.0":
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
@@ -3916,7 +3948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
@@ -3982,6 +4014,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+  checksum: b2863d74fcf2a6948221f65d95b91b4b2d90cfe8927650b506141e669f7d5de65cea191bf788838bc40d13846b7886c5bc5c84ab96c3adbcf88ad69a72fcdc6b
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind@npm:1.0.2"
@@ -4002,6 +4044,16 @@ __metadata:
     get-intrinsic: ^1.2.4
     set-function-length: ^1.2.1
   checksum: 295c0c62b90dd6522e6db3b0ab1ce26bdf9e7404215bda13cfee25b626b5ff1a7761324d58d38b1ef1607fc65aca2d06e44d2e18d0dfc6c14b465b00d8660029
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.2
+    get-intrinsic: ^1.3.0
+  checksum: 2f6399488d1c272f56306ca60ff696575e2b7f31daf23bc11574798c84d9f2759dceb0cb1f471a85b77f28962a7ac6411f51d283ea2e45319009a19b6ccab3b2
   languageName: node
   linkType: hard
 
@@ -4671,7 +4723,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.5":
+"content-disposition@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "content-disposition@npm:1.0.0"
+  dependencies:
+    safe-buffer: 5.2.1
+  checksum: b27e2579fefe0ecf78238bb652fbc750671efce8344f0c6f05235b12433e6a965adb40906df1ac1fdde23e8f9f0e58385e44640e633165420f3f47d830ae0398
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
@@ -4742,6 +4803,20 @@ __metadata:
   bin:
     conventional-commits-parser: cli.js
   checksum: 01b83c625ac3d8f9dca0510a5e21385c9bb410b80bcb60dcfdef20e1fa7fe7fad5a280aa5e1dff8ac32ea0aea5966fa973696557d38f831f8630d4fcf31756d5
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 1ad4f9b3907c9f3673a0f0a07c0a23da7909ac6c9204c5d80a0ec102fe50ccc45f27fdf496361840d6c132c5bb0037122c0a381f856d070183d1ebe3e5e041ff
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 9bf8555e33530affd571ea37b615ccad9b9a34febbf2c950c86787088eb00a8973690833b0f8ebd6b69b753c62669ea60cec89178c1fb007bf0749abed74f93e
   languageName: node
   linkType: hard
 
@@ -5533,6 +5608,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.5, debug@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
+  languageName: node
+  linkType: hard
+
 "debug@npm:^4.3.6":
   version: 4.3.6
   resolution: "debug@npm:4.3.6"
@@ -5759,7 +5846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0":
+"depd@npm:2.0.0, depd@npm:^2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: abbe19c768c97ee2eed6282d8ce3031126662252c58d711f646921c9623f9052e3e1906443066beec1095832f534e57c523b7333f8e7e0d93051ab6baef5ab3a
@@ -6052,6 +6139,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.1
+    es-errors: ^1.3.0
+    gopd: ^1.2.0
+  checksum: 149207e36f07bd4941921b0ca929e3a28f1da7bd6b6ff8ff7f4e2f2e460675af4576eeba359c635723dc189b64cdd4787e0255897d5b135ccc5d15cb8685fc90
+  languageName: node
+  linkType: hard
+
 "duplexer2@npm:~0.1.0":
   version: 0.1.4
   resolution: "duplexer2@npm:0.1.4"
@@ -6133,6 +6231,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 8487182da74aabd810ac6d6f1994111dfc0e331b01271ae01ec1eb0ad7b5ecc2bbbbd2f053c05cb55a1ac30449527d819bbfbf0e3de1023db308cbcb47f86601
+  languageName: node
+  linkType: hard
+
+"encodeurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
   languageName: node
   linkType: hard
 
@@ -6289,6 +6394,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 0512f4e5d564021c9e3a644437b0155af2679d10d80f21adaf868e64d30efdfbd321631956f20f42d655fedb2e3a027da479fad3fa6048f768eb453a80a5f80a
+  languageName: node
+  linkType: hard
+
 "es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
@@ -6309,6 +6421,15 @@ __metadata:
     is-string: ^1.0.5
     isarray: ^2.0.5
   checksum: f75e66acb6a45686fa08b3ade9c9421a70d36a0c43ed4363e67f4d7aab2226cb73dd977cb48abbaf75721b946d3cd810682fcf310c7ad0867802fbf929b17dcf
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: ^1.3.0
+  checksum: 214d3767287b12f36d3d7267ef342bbbe1e89f899cfd67040309fc65032372a8e60201410a99a1645f2f90c1912c8c49c8668066f6bdd954bcd614dda2e3da97
   languageName: node
   linkType: hard
 
@@ -6423,7 +6544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:~1.0.3":
+"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -6727,6 +6848,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"etag@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "etag@npm:1.8.1"
+  checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
+  languageName: node
+  linkType: hard
+
 "event-target-shim@npm:^5.0.0":
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
@@ -6819,6 +6947,41 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 3d21519a4f8207c99f7457287291316306255a328770d320b401114ec8481986e4e467e854cb9914dd965e0a1ca810a23ccb559c642c88f4c7f55c55778a9b48
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "express@npm:5.1.0"
+  dependencies:
+    accepts: ^2.0.0
+    body-parser: ^2.2.0
+    content-disposition: ^1.0.0
+    content-type: ^1.0.5
+    cookie: ^0.7.1
+    cookie-signature: ^1.2.1
+    debug: ^4.4.0
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    etag: ^1.8.1
+    finalhandler: ^2.1.0
+    fresh: ^2.0.0
+    http-errors: ^2.0.0
+    merge-descriptors: ^2.0.0
+    mime-types: ^3.0.0
+    on-finished: ^2.4.1
+    once: ^1.4.0
+    parseurl: ^1.3.3
+    proxy-addr: ^2.0.7
+    qs: ^6.14.0
+    range-parser: ^1.2.1
+    router: ^2.2.0
+    send: ^1.1.0
+    serve-static: ^2.2.0
+    statuses: ^2.0.1
+    type-is: ^2.0.1
+    vary: ^1.1.2
+  checksum: 06e6141780c6c4780111f971ce062c83d4cf4862c40b43caf1d95afcbb58d7422c560503b8c9d04c7271511525d09cbdbe940bcaad63970fd4c1b9f6fd713bdb
   languageName: node
   linkType: hard
 
@@ -7019,6 +7182,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "finalhandler@npm:2.1.0"
+  dependencies:
+    debug: ^4.4.0
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    on-finished: ^2.4.1
+    parseurl: ^1.3.3
+    statuses: ^2.0.1
+  checksum: 27ca9cc83b1384ba37959eb95bc7e62bc0bf4d6f6af63f6d38821cf7499b113e34b23f96a2a031616817f73986f94deea67c2f558de9daf406790c181a2501df
+  languageName: node
+  linkType: hard
+
 "find-up@npm:5.0.0":
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
@@ -7171,6 +7348,20 @@ __metadata:
     node-domexception: 1.0.0
     web-streams-polyfill: 4.0.0-beta.3
   checksum: d91d4f667cfed74827fc281594102c0dabddd03c9f8b426fc97123eedbf73f5060ee43205d89284d6854e2fc5827e030cd352ef68b93beda8decc2d72128c576
+  languageName: node
+  linkType: hard
+
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: fd27e2394d8887ebd16a66ffc889dc983fbbd797d5d3f01087c020283c0f019a7d05ee85669383d8e0d216b116d720fc0cef2f6e9b7eb9f4c90c6e0bc7fd28e6
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 38b9828352c6271e2a0dd8bdd985d0100dbbc4eb8b6a03286071dd6f7d96cfaacd06d7735701ad9a95870eb3f4555e67c08db1dcfe24c2e7bb87383c72fae1d2
   languageName: node
   linkType: hard
 
@@ -7361,10 +7552,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
+  dependencies:
+    call-bind-apply-helpers: ^1.0.2
+    es-define-property: ^1.0.1
+    es-errors: ^1.3.0
+    es-object-atoms: ^1.1.1
+    function-bind: ^1.1.2
+    get-proto: ^1.0.1
+    gopd: ^1.2.0
+    has-symbols: ^1.1.0
+    hasown: ^2.0.2
+    math-intrinsics: ^1.1.0
+  checksum: 301008e4482bb9a9cb49e132b88fee093bff373b4e6def8ba219b1e96b60158a6084f273ef5cafe832e42cd93462f4accb46a618d35fe59a2b507f2388c5b79d
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: ^1.0.1
+    es-object-atoms: ^1.0.0
+  checksum: 4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -7543,6 +7762,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: cc6d8e655e360955bdccaca51a12a474268f95bb793fc3e1f2bdadb075f28bfd1fd988dab872daf77a61d78cbaf13744bc8727a17cfb1d150d76047d805375f3
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.8":
   version: 4.2.8
   resolution: "graceful-fs@npm:4.2.8"
@@ -7699,6 +7925,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: b2316c7302a0e8ba3aaba215f834e96c22c86f192e7310bdf689dd0e6999510c89b00fbc5742571507cebf25764d68c988b3a0da217369a73596191ac0ce694b
+  languageName: node
+  linkType: hard
+
 "has-tostringtag@npm:^1.0.0":
   version: 1.0.0
   resolution: "has-tostringtag@npm:1.0.0"
@@ -7745,7 +7978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.0":
+"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
@@ -7839,7 +8072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0":
+"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
   version: 2.0.0
   resolution: "http-errors@npm:2.0.0"
   dependencies:
@@ -7942,7 +8175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6, iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -8192,6 +8425,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ipaddr.js@npm:1.9.1":
+  version: 1.9.1
+  resolution: "ipaddr.js@npm:1.9.1"
+  checksum: f88d3825981486f5a1942414c8d77dd6674dd71c065adcfa46f578d677edcb99fda25af42675cb59db492fdf427b34a5abfcde3982da11a8fd83a500b41cfe77
+  languageName: node
+  linkType: hard
+
 "is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.0":
   version: 1.1.1
   resolution: "is-arguments@npm:1.1.1"
@@ -8432,6 +8672,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: ced7bbbb6433a5b684af581872afe0e1767e2d1146b2207ca0068a648fb5cab9d898495d1ac0583524faaf24ca98176a7d9876363097c2d14fee6dd324f3a1ab
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 0b46517ad47b00b6358fd6553c83ec1f6ba9acd7ffb3d30a0bf519c5c69e7147c132430452351b8a9fc198f8dd6c4f76f8e6f5a7f100f8c77d57d9e0f4261a8a
   languageName: node
   linkType: hard
 
@@ -9981,6 +10228,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 0e513b29d120f478c85a70f49da0b8b19bc638975eca466f2eeae0071f3ad00454c621bf66e16dd435896c208e719fc91ad79bbfba4e400fe0b372e7c1c9c9a2
+  languageName: node
+  linkType: hard
+
 "md5.js@npm:^1.3.4":
   version: 1.3.5
   resolution: "md5.js@npm:1.3.5"
@@ -10035,6 +10289,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: a58dd60804df73c672942a7253ccc06815612326dc1c0827984b1a21704466d7cde351394f47649e56cf7415e6ee2e26e000e81b51b3eebb5a93540e8bf93cbd
+  languageName: node
+  linkType: hard
+
 "meow@npm:^8.0.0":
   version: 8.1.2
   resolution: "meow@npm:8.1.2"
@@ -10051,6 +10312,13 @@ __metadata:
     type-fest: ^0.18.0
     yargs-parser: ^20.2.3
   checksum: bc23bf1b4423ef6a821dff9734406bce4b91ea257e7f10a8b7f896f45b59649f07adc0926e2917eacd8cf1df9e4cd89c77623cf63dfd0f8bf54de07a32ee5a85
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: e383332e700a94682d0125a36c8be761142a1320fc9feeb18e6e36647c9edf064271645f5669b2c21cf352116e561914fd8aa831b651f34db15ef4038c86696a
   languageName: node
   linkType: hard
 
@@ -10399,12 +10667,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: e99aaf2f23f5bd607deb08c83faba5dd25cf2fec90a7cc5b92d8260867ee08dab65312e1a589e60093dc7796d41e5fae013268418482f1db4c7d52d0a0960ac9
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12":
   version: 2.1.32
   resolution: "mime-types@npm:2.1.32"
   dependencies:
     mime-db: 1.49.0
   checksum: 4487dfd2f872126d2c219ec731ad47a6169a438d5a4cce6ecef7594ce08eaefaf0d85429485a76ec005f095016c7ec488a24cf8bfcc0ea06de0355e23395746f
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
+  dependencies:
+    mime-db: ^1.54.0
+  checksum: 8d497ad5cb2dd1210ac7d049b5de94af0b24b45a314961e145b44389344604d54752f03bc00bf880c0da60a214be6fb6d423d318104f02c28d95dd8ebeea4fb4
   languageName: node
   linkType: hard
 
@@ -10797,7 +11081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.2":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.2, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -10900,6 +11184,13 @@ __metadata:
   version: 0.6.4
   resolution: "negotiator@npm:0.6.4"
   checksum: 7ded10aa02a0707d1d12a9973fdb5954f98547ca7beb60e31cb3a403cc6e8f11138db7a3b0128425cf836fc85d145ec4ce983b2bdf83dca436af879c2d683510
+  languageName: node
+  linkType: hard
+
+"negotiator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "negotiator@npm:1.0.0"
+  checksum: 20ebfe79b2d2e7cf9cbc8239a72662b584f71164096e6e8896c8325055497c96f6b80cd22c258e8a2f2aa382a787795ec3ee8b37b422a302c7d4381b0d5ecfbb
   languageName: node
   linkType: hard
 
@@ -11396,6 +11687,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-inspect@npm:^1.13.3":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 582810c6a8d2ef988ea0a39e69e115a138dad8f42dd445383b394877e5816eb4268489f316a6f74ee9c4e0a984b3eab1028e3e79d62b1ed67c726661d55c7a8b
+  languageName: node
+  linkType: hard
+
 "object-is@npm:^1.1.4, object-is@npm:^1.1.5":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
@@ -11489,7 +11787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -11969,7 +12267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.3, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
@@ -12041,6 +12339,13 @@ __metadata:
   dependencies:
     isarray: 0.0.1
   checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: 56e13e45962e776e9e7cd72e87a441cfe41f33fd539d097237ceb16adc922281136ca12f5a742962e33d8dda9569f630ba594de56d8b7b6e49adf31803c5e771
   languageName: node
   linkType: hard
 
@@ -12501,6 +12806,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-addr@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
+  dependencies:
+    forwarded: 0.2.0
+    ipaddr.js: 1.9.1
+  checksum: 29c6990ce9364648255454842f06f8c46fcd124d3e6d7c5066df44662de63cdc0bad032e9bf5a3d653ff72141cc7b6019873d685708ac8210c30458ad99f2b74
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
@@ -12654,6 +12969,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
+  dependencies:
+    side-channel: ^1.1.0
+  checksum: 189b52ad4e9a0da1a16aff4c58b2a554a8dad9bd7e287c7da7446059b49ca2e33a49e570480e8be406b87fccebf134f51c373cbce36c8c83859efa0c9b71d635
+  languageName: node
+  linkType: hard
+
 "qs@npm:^6.9.1":
   version: 6.10.1
   resolution: "qs@npm:6.10.1"
@@ -12710,6 +13034,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"range-parser@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "range-parser@npm:1.2.1"
+  checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
+  languageName: node
+  linkType: hard
+
 "raw-body@npm:2.5.2":
   version: 2.5.2
   resolution: "raw-body@npm:2.5.2"
@@ -12719,6 +13050,18 @@ __metadata:
     iconv-lite: 0.4.24
     unpipe: 1.0.0
   checksum: ba1583c8d8a48e8fbb7a873fdbb2df66ea4ff83775421bfe21ee120140949ab048200668c47d9ae3880012f6e217052690628cf679ddfbd82c9fc9358d574676
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "raw-body@npm:3.0.0"
+  dependencies:
+    bytes: 3.1.2
+    http-errors: 2.0.0
+    iconv-lite: 0.6.3
+    unpipe: 1.0.0
+  checksum: 25b7cf7964183db322e819050d758a5abd0f22c51e9f37884ea44a9ed6855a1fb61f8caa8ec5b61d07e69f54db43dbbc08ad98ef84556696d6aa806be247af0e
   languageName: node
   linkType: hard
 
@@ -12950,6 +13293,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reflect-metadata@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "reflect-metadata@npm:0.2.2"
+  checksum: a66c7b583e4efdd8f3c3124fbff33da2d0c86d8280617516308b32b2159af7a3698c961db3246387f56f6316b1d33a608f39bb2b49d813316dfc58f6d3bf3210
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.3.0":
   version: 1.3.1
   resolution: "regexp.prototype.flags@npm:1.3.1"
@@ -13177,6 +13527,19 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: ^4.4.0
+    depd: ^2.0.0
+    is-promise: ^4.0.0
+    parseurl: ^1.3.3
+    path-to-regexp: ^8.0.0
+  checksum: 4c3bec8011ed10bb07d1ee860bc715f245fff0fdff991d8319741d2932d89c3fe0a56766b4fa78e95444bc323fd2538e09c8e43bfbd442c2a7fab67456df7fa5
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -13227,7 +13590,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -13425,12 +13788,43 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "send@npm:1.2.0"
+  dependencies:
+    debug: ^4.3.5
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    etag: ^1.8.1
+    fresh: ^2.0.0
+    http-errors: ^2.0.0
+    mime-types: ^3.0.1
+    ms: ^2.1.3
+    on-finished: ^2.4.1
+    range-parser: ^1.2.1
+    statuses: ^2.0.1
+  checksum: 7557ee6c1c257a1c53b402b4fba8ed88c95800b08abe085fc79e0824869274f213491be2efb2df3de228c70e4d40ce2019e5f77b58c42adb97149135420c3f34
+  languageName: node
+  linkType: hard
+
 "serialize-javascript@npm:5.0.1":
   version: 5.0.1
   resolution: "serialize-javascript@npm:5.0.1"
   dependencies:
     randombytes: ^2.1.0
   checksum: bb45a427690c3d2711e28499de0fbf25036af1e23c63c6a9237ed0aa572fd0941fcdefe50a2dccf26d9df8c8b86ae38659e19d8ba7afd3fbc1f1c7539a2a48d2
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "serve-static@npm:2.2.0"
+  dependencies:
+    encodeurl: ^2.0.0
+    escape-html: ^1.0.3
+    parseurl: ^1.3.3
+    send: ^1.2.0
+  checksum: 74f39e88f0444aa6732aae3b9597739c47552adecdc83fa32aa42555e76f1daad480d791af73894655c27a2d378275a461e691cead33fb35d8b976f1e2d24665
   languageName: node
   linkType: hard
 
@@ -13520,6 +13914,41 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "side-channel-list@npm:1.0.0"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.3
+  checksum: 603b928997abd21c5a5f02ae6b9cc36b72e3176ad6827fab0417ead74580cc4fb4d5c7d0a8a2ff4ead34d0f9e35701ed7a41853dac8a6d1a664fcce1a044f86f
+  languageName: node
+  linkType: hard
+
+"side-channel-map@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-map@npm:1.0.1"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+  checksum: 42501371cdf71f4ccbbc9c9e2eb00aaaab80a4c1c429d5e8da713fd4d39ef3b8d4a4b37ed4f275798a65260a551a7131fd87fe67e922dba4ac18586d6aab8b06
+  languageName: node
+  linkType: hard
+
+"side-channel-weakmap@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "side-channel-weakmap@npm:1.0.2"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.5
+    object-inspect: ^1.13.3
+    side-channel-map: ^1.0.1
+  checksum: a815c89bc78c5723c714ea1a77c938377ea710af20d4fb886d362b0d1f8ac73a17816a5f6640f354017d7e292a43da9c5e876c22145bac00b76cfb3468001736
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.3, side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -13540,6 +13969,19 @@ resolve@^2.0.0-next.3:
     get-intrinsic: ^1.2.4
     object-inspect: ^1.13.1
   checksum: bfc1afc1827d712271453e91b7cd3878ac0efd767495fd4e594c4c2afaa7963b7b510e249572bfd54b0527e66e4a12b61b80c061389e129755f34c493aad9b97
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "side-channel@npm:1.1.0"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.3
+    side-channel-list: ^1.0.0
+    side-channel-map: ^1.0.1
+    side-channel-weakmap: ^1.0.2
+  checksum: bf73d6d6682034603eb8e99c63b50155017ed78a522d27c2acec0388a792c3ede3238b878b953a08157093b85d05797217d270b7666ba1f111345fbe933380ff
   languageName: node
   linkType: hard
 
@@ -13868,7 +14310,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"statuses@npm:2.0.1":
+"statuses@npm:2.0.1, statuses@npm:^2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
@@ -14631,7 +15073,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
+"tslib@npm:^1.8.1, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -14696,6 +15138,15 @@ resolve@^2.0.0-next.3:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tsyringe@npm:^4.8.0":
+  version: 4.9.1
+  resolution: "tsyringe@npm:4.9.1"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 2ed169500b6835ea506af9bcf170c30b26bf6ef1d9be0068cf361abe9dd0b80997ea26ac09f3802263f755ad4f8304a37af0bf43e26f94e65b5f70bf1ce8e3fa
   languageName: node
   linkType: hard
 
@@ -14786,6 +15237,17 @@ resolve@^2.0.0-next.3:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.0.0, type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: ^1.0.5
+    media-typer: ^1.1.0
+    mime-types: ^3.0.0
+  checksum: 0266e7c782238128292e8c45e60037174d48c6366bb2d45e6bd6422b611c193f83409a8341518b6b5f33f8e4d5a959f38658cacfea77f0a3505b9f7ac1ddec8f
   languageName: node
   linkType: hard
 
@@ -15084,6 +15546,15 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"uuid@npm:^11.0.5":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 840f19758543c4631e58a29439e51b5b669d5f34b4dd2700b6a1d15c5708c7a6e0c3e2c8c4a2eae761a3a7caa7e9884d00c86c02622ba91137bd3deade6b4b4a
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
@@ -15156,7 +15627,7 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
-"vary@npm:^1":
+"vary@npm:^1, vary@npm:^1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
@@ -15577,6 +16048,21 @@ typescript@^3.9.3:
     utf-8-validate:
       optional: true
   checksum: 5c1f669a166fb57560b4e07f201375137fa31d9186afde78b1508926345ce546332f109081574ddc4e38cc474c5406b5fc71c18d71eb75f6e2d2245576976cba
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "ws@npm:8.18.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 4658357185d891bc45cc2d42a84f9e192d047e8476fb5cba25b604f7d75ca87ca0dd54cd0b2cc49aeee57c79045a741cb7d0b14501953ac60c790cd105c42f23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces the ability for users to access and reopen their past Navie chat conversations.

**Changes:**

*   **New Command:** Adds a new command, `AppMap: Open Navie History`, accessible via the command palette.
*   **History Retrieval:** When invoked, the new command communicates with the backend RPC service (`v1.navie.thread.query`) to fetch a list of recent Navie conversation threads.
*   **User Interaction:** The fetched history is presented to the user in a Quick Pick list, showing conversation titles (or "Untitled") and creation dates.
*   **Reopening Conversations:** Selecting a conversation from the list triggers the existing `appmap.explain` command, passing the selected `threadId`.
*   **Webview Integration:** The chat search webview (`chatSearchWebview`) has been updated to accept an optional `threadId` during initialization, allowing it to load and display the specific historical conversation selected by the user.
*   **RPC Service:**
    *   The `RpcProcessService` now includes an environment variable (`APPMAP_NAVIE_THREAD_LOG`) to enable event log usage in the RPC service.
    *   A helper method was added to the `RpcProcessService` for easier access to the RPC client.