### PR TITLE
fix: Only migrate OpenAI API key once

### DIFF
--- a/src/services/navieConfigurationService.ts
+++ b/src/services/navieConfigurationService.ts
@@ -70,6 +70,9 @@ export async function migrateOpenAIApiKey(
   const value = await getOpenAIApiKey(extensionContext);
   if (value) {
     await setSecretEnvVars(extensionContext, { OPENAI_API_KEY: value });
+
+    // Remove the old key so it's not migrated again
+    await setOpenAIApiKey(extensionContext, undefined);
   }
 }
 


### PR DESCRIPTION
This addresses an issue where if the user had an old-style OpenAI API key stored in secrets, it'd overwrite the value in the secret env.