### PR TITLE
fix: Gracefully handle invalid line numbers in finding stack traces

### DIFF
--- a/src/services/resolvedFinding.ts
+++ b/src/services/resolvedFinding.ts
@@ -215,7 +215,7 @@ export class ResolvedFinding {
 
     const tokens = path.split(':', 2);
     const fileName = tokens[0];
-    let line: string | number = 1;
+    let line = 1;
     if (tokens.length > 1) {
       const parsedLine = parseInt(tokens[1], 10);
       if (!isNaN(parsedLine) && parsedLine > 0) {

--- a/src/services/resolvedFinding.ts
+++ b/src/services/resolvedFinding.ts
@@ -216,7 +216,14 @@ export class ResolvedFinding {
     const tokens = path.split(':', 2);
     const fileName = tokens[0];
     let line: string | number = 1;
-    if (tokens.length > 1) line = tokens[1];
+    if (tokens.length > 1) {
+      const parsedLine = parseInt(tokens[1], 10);
+      if (!isNaN(parsedLine) && parsedLine > 0) {
+        line = parsedLine;
+      } else {
+        console.warn(`Invalid line number in finding stack frame: ${tokens[1]}, falling back to 1`);
+      }
+    }
     const filePath = await resolveFilePath(folder.uri.fsPath, fileName);
     if (!filePath) return;
 


### PR DESCRIPTION
This PR addresses an issue where some AppMap findings were not appearing in the VSCode sidebar. The root cause was an "Illegal argument: line must be non-negative" error, which occurred when processing finding locations with invalid line numbers (e.g., filename:0, filename:, or filename:-1).

The resolvePathLocation function was attempting to use these invalid line numbers, leading to a rejected promise that prevented the associated findings from being displayed.

Changes:

Modified resolvePathLocation in src/services/resolvedFinding.ts to:

Explicitly parse the line number string to an integer.

Validate that the parsed line number is a positive integer (> 0).

If an invalid line number is detected (non-numeric, zero, or negative), it now defaults to line 1 and logs a warning to the console (e.g., Invalid line number in finding stack frame: <invalid_value>, falling back to 1).

This change ensures that all findings can be processed even if their stack trace contains improperly formatted line numbers, allowing them to appear correctly in the sidebar.
