### PR TITLE
Implement AI-driven quick review command

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
         "icon": "$(history)"
       },
       {
+        "command": "appmap.navie.quickReview",
+        "title": "AppMap: Start Quick Review",
+        "icon": "$(law)"
+      },
+      {
         "command": "appmap.getAppmapState",
         "title": "AppMap: Copy Current AppMap State to Clipboard"
       },
@@ -373,7 +378,7 @@
       },
       {
         "view": "appmap.views.navie",
-        "contents": "Ask Navie a question about your application to get started.\n[New Navie Chat](command:appmap.explain)\nNavie uses AppMap data to improve the accuracy of Generative AI models. Navie searches through your locally stored AppMap data to identify the application behavior related to your question.",
+        "contents": "Ask Navie anything about your application, or get AI-driven code reviews.\n\n[$(comment) New Navie Chat](command:appmap.explain)\n\n[$(law) Review Your Code](command:appmap.navie.quickReview)\nNavie enhances Generative AI models by analyzing your locally stored AppMap data, ensuring highly accurate and context-aware responses specific to your application's behavior.\n[$(link-external) Learn more about AppMap](https://appmap.io/docs/)",
         "when": "appmap.initialized"
       },
       {
@@ -603,6 +608,11 @@
           "command": "appmap.navie.history",
           "when": "view == appmap.views.navie",
           "group": "navigation@0"
+        },
+        {
+          "command": "appmap.navie.quickReview",
+          "when": "view == appmap.views.navie",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/src/commands/quickReview.ts
+++ b/src/commands/quickReview.ts
@@ -1,0 +1,258 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import * as vscode from 'vscode';
+
+import type { GitExtension, Repository } from '../../types/vscode.git';
+
+const execPromise = promisify(exec);
+
+/**
+ * Workspace state key used to persist the last selected reference for quick review.
+ * This enables the extension to show the previously selected reference at the top
+ * of the quick pick list for improved user experience.
+ */
+const LAST_PICKED_STATE = 'appmap.quickReview.lastPicked';
+
+export default class QuickReviewCommand {
+  /**
+   * Executes the quick review command, allowing users to select a Git reference
+   * to use as the base for code review.
+   *
+   * The command:
+   * 1. Finds the current Git repository
+   * 2. Gets available references (branches, tags, commits)
+   * 3. Shows a quick pick UI to select a reference
+   * 4. Launches the Navie review command with the selected reference
+   *
+   * @param context - The extension context to access workspace state
+   * @returns A promise that resolves when the command completes
+   */
+  public static async execute(context: vscode.ExtensionContext): Promise<void> {
+    try {
+      const repo = await getCurrentRepository();
+      if (!repo) return;
+
+      const items = (async () => {
+        let items = await getItems(repo);
+        const head = repo.state.HEAD?.commit;
+
+        // Don't show "HEAD" items if there are no uncommitted changes
+        if (repo.state.workingTreeChanges.length === 0 && repo.state.indexChanges.length === 0) {
+          items = items.filter((item) => item.commit !== head);
+        }
+
+        const lastPickedRef = context.workspaceState.get<string>(LAST_PICKED_STATE);
+        let showFirstIdx = items.findIndex((item) => {
+          if (item.label === lastPickedRef) {
+            item.description = 'last used ⋅ ' + item.description;
+            return true;
+          } else return false;
+        });
+        if (showFirstIdx === -1)
+          // try to show common main branches, like "main" or "master" first
+          showFirstIdx = items.findIndex((item) => COMMON_MAIN_BRANCHES.includes(item.label));
+        if (showFirstIdx !== -1) {
+          const lastRef = items.splice(showFirstIdx, 1)[0];
+          lastRef.alwaysShow = true;
+          items.unshift(lastRef, {
+            ...lastRef,
+            kind: vscode.QuickPickItemKind.Separator,
+            alwaysShow: true,
+            label: '',
+          });
+        }
+
+        return items.map((item) => ({
+          ...item,
+          description: item.commit === head ? 'review uncommitted changes' : item.description,
+          iconPath:
+            COMMON_MAIN_BRANCH_ICONS[item.label] ||
+            ICONS[item.type] ||
+            new vscode.ThemeIcon('git-commit'),
+        }));
+      })();
+
+      // Show quick pick for ref selection
+      // note we pass items as promise, this will show a loading indicator
+      const selectedRef = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select base ref for review',
+        ignoreFocusOut: true,
+        matchOnDescription: true,
+      });
+
+      if (!selectedRef) {
+        return; // User cancelled
+      }
+
+      const baseRef = selectedRef.label;
+      // Store the last picked ref in workspace state
+      context.workspaceState.update(LAST_PICKED_STATE, baseRef);
+
+      // Open Navie chat with review command
+      const prompt = `@review /base=${baseRef}`;
+      await vscode.commands.executeCommand('appmap.explain', {
+        suggestion: {
+          label: prompt,
+          prompt,
+        },
+      });
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `Failed to start code review: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Registers the quick review command with VS Code.
+   *
+   * @param context - The extension context to register the command with
+   */
+  public static register(context: vscode.ExtensionContext): void {
+    const command = vscode.commands.registerCommand('appmap.navie.quickReview', () =>
+      QuickReviewCommand.execute(context)
+    );
+    context.subscriptions.push(command);
+  }
+}
+
+async function getGitExtension(): Promise<GitExtension | undefined> {
+  const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+  if (!gitExtension) {
+    vscode.window.showErrorMessage('Git extension not found.');
+    return undefined;
+  }
+  return gitExtension.isActive ? gitExtension.exports : await gitExtension.activate();
+}
+
+async function getCurrentRepository(): Promise<Repository | undefined> {
+  const git = (await getGitExtension())?.getAPI(1);
+  if (!git) return undefined;
+
+  // Get the first repository in the workspace.
+  // TODO what to do in a multi-root workspace? I don't think we should support that yet.
+  if (git.repositories.length === 0) {
+    vscode.window.showInformationMessage('No Git repositories found in the current workspace.');
+    return undefined;
+  }
+  return git.repositories[0];
+}
+
+/**
+ * Represents an item in the quick pick selection list for Git references.
+ * Extends VSCode's QuickPickItem with Git-specific properties.
+ */
+interface Item extends vscode.QuickPickItem {
+  /** The full Git commit hash associated with this reference */
+  commit: string;
+
+  /**
+   * The type of Git reference:
+   * - 'refs/heads' for local branches
+   * - 'refs/remotes' for remote branches
+   * - 'refs/tags' for tags
+   * - 'commit' for individual commits
+   */
+  type: string;
+}
+
+async function getRefs(repo: Repository): Promise<Item[]> {
+  try {
+    const dir = repo.rootUri.fsPath;
+    const { stdout: refsOutput } = await execPromise(
+      'git for-each-ref --format="%(objectname);%(if)%(HEAD)%(then)HEAD%(else)%(refname:short)%(end);%(refname:rstrip=-2);%(objectname:short) ⋅ %(creatordate:human)" --merged HEAD --sort=-creatordate',
+      {
+        cwd: dir,
+      }
+    );
+    return refsOutput
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const [commit, label, type, description] = line.split(';', 4);
+        return { commit, label, type, description };
+      });
+  } catch (error) {
+    console.error('Failed to get branches:', error);
+    // fallback to using the Git extension API
+    return (await repo.getBranches({ sort: 'committerdate' })).map((branch) => ({
+      label: branch.name ?? 'Unknown Branch',
+      description: branch.commit?.slice(0, 8),
+      commit: branch.commit ?? '',
+      type: 'refs/heads',
+    }));
+  }
+}
+
+async function getItems(repo: Repository): Promise<Item[]> {
+  const refs = await getRefs(repo);
+  const head = repo.state.HEAD?.commit;
+  const nextRefIdx = refs.findIndex((ref) => ref.commit !== head);
+  if (nextRefIdx !== -1)
+    try {
+      const { stdout: logOutput } = await execPromise(
+        `git log  --format="%H;%h;%ch ⋅ %s" ${refs[nextRefIdx].commit}...HEAD`,
+        {
+          cwd: repo.rootUri.fsPath,
+        }
+      );
+      const commits = logOutput
+        .trim()
+        .split('\n')
+        .filter((line) => line.trim() !== '')
+        .map((line) => {
+          const [commit, label, description] = line.split(';', 3);
+          return {
+            label,
+            description,
+            commit,
+            type: 'commit',
+          };
+        })
+        .filter(({ commit }) => commit !== head);
+      refs.splice(Math.max(nextRefIdx - 1, 0), 0, ...commits);
+    } catch (error) {
+      console.error('Failed to get commits:', error);
+    }
+
+  return refs;
+}
+
+const ICONS = {
+  'refs/heads': new vscode.ThemeIcon('git-branch'),
+  'refs/remotes': new vscode.ThemeIcon('cloud'),
+  'refs/tags': new vscode.ThemeIcon('tag'),
+};
+
+/**
+ * Common main branches that are frequently used across Git repositories.
+ * These branches are given priority in the quick pick UI by showing them first
+ * when no previously selected branch is available.
+ *
+ * The list includes:
+ * - main/master: Primary development branches
+ * - develop: Feature integration branch in GitFlow
+ * - release/staging/testing/qa: Various pre-production environments
+ * - prod: Production branch
+ */
+const COMMON_MAIN_BRANCHES = [
+  'main',
+  'master',
+  'develop',
+  'release',
+  'staging',
+  'testing',
+  'qa',
+  'prod',
+];
+const COMMON_MAIN_BRANCH_ICONS = {
+  main: new vscode.ThemeIcon('check'),
+  master: new vscode.ThemeIcon('check'),
+  develop: new vscode.ThemeIcon('sync'),
+  release: new vscode.ThemeIcon('rocket'),
+  staging: new vscode.ThemeIcon('play'),
+  testing: new vscode.ThemeIcon('beaker'),
+  qa: new vscode.ThemeIcon('shield'),
+  prod: new vscode.ThemeIcon('globe'),
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,8 @@ import registerSequenceDiagram from './commands/sequenceDiagram';
 import registerCompareSequenceDiagrams from './commands/compareSequenceDiagram';
 import openCodeObjectInAppMap from './commands/openCodeObjectInAppMap';
 import outOfDateTests from './commands/outOfDateTests';
+import PickCopilotModelCommand from './commands/pickCopilotModel';
+import QuickReviewCommand from './commands/quickReview';
 import ExtensionState from './configuration/extensionState';
 import AppMapEditorProvider from './editor/appmapEditorProvider';
 import appmapHoverProvider from './hover/appmapHoverProvider';
@@ -65,7 +67,6 @@ import CommandRegistry from './commands/commandRegistry';
 import AssetService from './assets/assetService';
 import clearNavieAiSettings from './commands/clearNavieAiSettings';
 import ExtensionSettings from './configuration/extensionSettings';
-import PickCopilotModelCommand from './commands/pickCopilotModel';
 import OpenNavieHistoryCommand from './commands/openNavieHistory';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
@@ -149,6 +150,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     const configWatcher = new Watcher('**/appmap.yml');
     context.subscriptions.push(configWatcher);
+
+    // Register Quick Review command
+    QuickReviewCommand.register(context);
 
     const configManager = new AppmapConfigManager(configWatcher);
     await workspaceServices.enroll(configManager);

--- a/test/unit/commands/quickReview.test.ts
+++ b/test/unit/commands/quickReview.test.ts
@@ -1,0 +1,257 @@
+import mockery from 'mockery';
+import '../mock/vscode';
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
+
+const execStub = sinon.stub();
+
+mockery.registerMock('node:util', { promisify: () => execStub });
+mockery.registerMock('node:child_process', { exec: {} });
+
+import QuickReviewCommand from '../../../src/commands/quickReview';
+import { RefType, type Repository } from '../../../types/vscode.git';
+import MockExtensionContext from '../../mocks/mockExtensionContext';
+
+mockery.deregisterMock('node:util');
+mockery.deregisterMock('node:child_process');
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe('quickReview', () => {
+  let context: vscode.ExtensionContext;
+  let showQuickPickStub: sinon.SinonStub;
+  let showErrorMessageStub: sinon.SinonStub;
+  let showInfoMessageStub: sinon.SinonStub;
+  let executeCommandStub: sinon.SinonStub;
+  let extensionStub: sinon.SinonStub;
+  let mockRepo: Partial<Repository>;
+
+  after(() => {
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  beforeEach(() => {
+    context = new MockExtensionContext();
+    showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick');
+    showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage');
+    showInfoMessageStub = sinon.stub(vscode.window, 'showInformationMessage');
+    executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+    execStub.resolves({ stdout: '' });
+    extensionStub = sinon.stub(vscode.extensions, 'getExtension').returns({
+      isActive: true,
+      exports: {
+        getAPI: () => ({
+          repositories: [mockRepo],
+        }),
+      },
+    } as never);
+
+    // Set up a mock repository
+    mockRepo = {
+      rootUri: vscode.Uri.file('/test/repo'),
+      state: {
+        HEAD: { commit: 'head-commit', type: RefType.Head },
+        workingTreeChanges: [],
+        indexChanges: [],
+      } as never,
+      getBranches: sinon.stub().resolves([
+        { name: 'main', commit: 'main-commit' },
+        { name: 'develop', commit: 'develop-commit' },
+      ]),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute', () => {
+    it('shows error when git extension is not found', async () => {
+      extensionStub.returns(undefined);
+      await QuickReviewCommand.execute(context);
+      expect(showErrorMessageStub.calledWith('Git extension not found.')).to.be.true;
+    });
+
+    it('shows error when no repositories are found', async () => {
+      extensionStub.returns({
+        isActive: true,
+        exports: {
+          getAPI: () => ({
+            repositories: [],
+          }),
+        },
+      });
+      await QuickReviewCommand.execute(context);
+      expect(showInfoMessageStub.calledWith('No Git repositories found in the current workspace.'))
+        .to.be.true;
+    });
+
+    it('shows refs using git for-each-ref command', async () => {
+      const refsOutput = [
+        'main-hash;main;refs/heads;abc123 ⋅ 2024-01-01',
+        'dev-hash;develop;refs/heads;def456 ⋅ 2024-01-02',
+      ].join('\n');
+      execStub.resolves({ stdout: refsOutput });
+
+      showQuickPickStub.resolves({ label: 'main', commit: 'main-hash' });
+
+      await QuickReviewCommand.execute(context);
+
+      expect(executeCommandStub.calledWith('appmap.explain')).to.be.true;
+      expect(executeCommandStub.firstCall.args[1]).to.deep.equal({
+        suggestion: {
+          label: '@review /base=main',
+          prompt: '@review /base=main',
+        },
+      });
+    });
+
+    it('shows HEAD item when there are uncommitted changes', async () => {
+      Object.defineProperty(mockRepo.state, 'workingTreeChanges', {
+        value: [{ path: 'file1.js' }],
+      });
+      const refsOutput = [
+        'head-commit;HEAD;refs/heads;abc123 ⋅ 2024-01-01',
+        'main-hash;main;refs/heads;abc123 ⋅ 2024-01-01',
+      ].join('\n');
+      execStub.callsFake((command) => {
+        if (command.includes('for-each-ref')) {
+          return Promise.resolve({ stdout: refsOutput });
+        }
+        return Promise.resolve({ stdout: '' });
+      });
+
+      showQuickPickStub.resolves({ label: 'HEAD' });
+
+      await QuickReviewCommand.execute(context);
+      const items = await showQuickPickStub.firstCall.args[0];
+
+      // at least one item should have the label 'HEAD'
+      expect(items.find((item: { label: string }) => item.label === 'HEAD')).to.be.ok;
+    });
+
+    it('does not show HEAD item when there are no uncommitted changes', async () => {
+      const refsOutput = [
+        'head-commit;HEAD;refs/heads;abc123 ⋅ 2024-01-01',
+        'main-hash;main;refs/heads;abc123 ⋅ 2024-01-01',
+      ].join('\n');
+      execStub.callsFake((command) => {
+        if (command.includes('for-each-ref')) {
+          return Promise.resolve({ stdout: refsOutput });
+        }
+        return Promise.resolve({ stdout: '' });
+      });
+
+      showQuickPickStub.resolves({ label: 'HEAD' });
+
+      await QuickReviewCommand.execute(context);
+      const items = await showQuickPickStub.firstCall.args[0];
+
+      // at least one item should have the label 'HEAD'
+      expect(items.find((item: { label: string }) => item.label === 'HEAD')).to.not.be.ok;
+    });
+
+    it('does not show commits if there are no commits between HEAD and the base ref', async () => {
+      const refsOutput = [
+        'head-commit;HEAD;refs/heads;abc123 ⋅ 2024-01-01',
+        'main-hash;main;refs/heads;abc123 ⋅ 2024-01-01',
+      ].join('\n');
+      execStub.callsFake((command) => {
+        if (command.includes('for-each-ref')) {
+          return Promise.resolve({ stdout: refsOutput });
+        }
+        return Promise.resolve({ stdout: '' });
+      });
+
+      showQuickPickStub.resolves({ label: 'HEAD' });
+
+      await QuickReviewCommand.execute(context);
+      const items = await showQuickPickStub.firstCall.args[0];
+
+      expect(items.find((item: { type: string }) => item.type === 'commit')).to.not.be.ok;
+    });
+
+    it('stores last picked reference in workspace state', async () => {
+      const refsOutput = ['main-hash;main;refs/heads;abc123 ⋅ 2024-01-01'].join('\n');
+      execStub.resolves({ stdout: refsOutput });
+
+      showQuickPickStub.resolves({ label: 'main' });
+
+      await QuickReviewCommand.execute(context);
+
+      expect(context.workspaceState.get('appmap.quickReview.lastPicked')).to.equal('main');
+    });
+
+    it('prioritizes last used reference', async () => {
+      context.workspaceState.update('appmap.quickReview.lastPicked', 'develop');
+
+      const refsOutput = [
+        'main-hash;main;refs/heads;abc123 ⋅ 2024-01-01',
+        'dev-hash;develop;refs/heads;def456 ⋅ 2024-01-02',
+      ].join('\n');
+      execStub.resolves({ stdout: refsOutput });
+
+      showQuickPickStub.resolves({ label: 'develop' });
+
+      await QuickReviewCommand.execute(context);
+
+      await expect(showQuickPickStub.firstCall.args[0]).to.eventually.satisfy(
+        (items: { description: string; label: string }[]) => {
+          return items[0].label === 'develop' && items[0].description.includes('last used');
+        }
+      );
+    });
+
+    it('falls back to git extension API when git command fails', async () => {
+      execStub.rejects(new Error('git command failed'));
+
+      showQuickPickStub.resolves({ label: 'main' });
+
+      await QuickReviewCommand.execute(context);
+
+      expect(mockRepo.getBranches).to.have.been.called;
+      expect(executeCommandStub.calledWith('appmap.explain')).to.be.true;
+    });
+
+    it('handles user cancellation', async () => {
+      showQuickPickStub.resolves(undefined);
+
+      await QuickReviewCommand.execute(context);
+
+      expect(executeCommandStub.called).to.be.false;
+      expect(context.workspaceState.get('appmap.quickReview.lastPicked')).to.be.undefined;
+    });
+
+    it('includes recent commits in the list', async () => {
+      const refsOutput = ['main-hash;main;refs/heads;abc123 ⋅ 2024-01-01'].join('\n');
+      const logOutput = ['commit1;abc;2024-01-01 ⋅ First commit'].join('\n');
+
+      execStub.onFirstCall().resolves({ stdout: refsOutput });
+      execStub.onSecondCall().resolves({ stdout: logOutput });
+
+      showQuickPickStub.resolves({ label: 'abc' });
+
+      await QuickReviewCommand.execute(context);
+
+      expect(executeCommandStub.calledWith('appmap.explain')).to.be.true;
+      expect(executeCommandStub.firstCall.args[1].suggestion.prompt).to.equal('@review /base=abc');
+    });
+  });
+
+  describe('register', () => {
+    it('registers the command with VS Code', () => {
+      const registerCommandStub = sinon.stub(vscode.commands, 'registerCommand');
+
+      QuickReviewCommand.register(context);
+
+      expect(registerCommandStub.calledWith('appmap.navie.quickReview')).to.be.true;
+      expect(context.subscriptions).to.have.length(1);
+    });
+  });
+});

--- a/test/unit/mock/vscode/commands.ts
+++ b/test/unit/mock/vscode/commands.ts
@@ -2,4 +2,11 @@ export default {
   executeCommand() {
     return;
   },
+  registerCommand() {
+    return {
+      dispose: () => {
+        /* no-op */
+      },
+    };
+  },
 };

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -36,6 +36,11 @@ enum ProgressLocation {
   Notification = 15,
 }
 
+enum QuickPickItemKind {
+  Default = 0,
+  Separator = 1,
+}
+
 const MockVSCode = {
   ProgressLocation,
   authentication,
@@ -47,6 +52,10 @@ const MockVSCode = {
   Range,
   Position,
   Location,
+  ThemeIcon: class {
+    constructor(public id: string) {}
+  },
+  QuickPickItemKind,
   Selection,
   CodeAction,
   CodeActionKind,

--- a/web/src/chatSearchView.js
+++ b/web/src/chatSearchView.js
@@ -50,15 +50,11 @@ export default function mountChatSearchView() {
         },
       },
       mounted() {
-        if (initialData.codeSelection) {
-          this.$root.$on('on-thread-subscription', () => {
+        this.$root.$once('on-thread-subscription', () => {
+          if (initialData.codeSelection)
             this.$refs.ui.includeCodeSelection(initialData.codeSelection);
-          });
-        }
-        if (initialData.suggestion) {
-          this.$refs.ui.$refs.vchat.addUserMessage(initialData.suggestion.label);
-          this.$refs.ui.sendMessage(initialData.suggestion.prompt);
-        }
+          if (initialData.suggestion) this.$refs.ui.sendMessage(initialData.suggestion.prompt);
+        });
       },
     });
 


### PR DESCRIPTION
Adds a new command `appmap.navie.quickReview` that allows users to select a Git reference (branch, tag, or commit) as a base and initiate an AI-driven code review of the changes relative to that base via Navie. Integrates the command into the Navie view and commands palette. Includes necessary mocking and unit tests for the new command.

![image](https://github.com/user-attachments/assets/4af3894a-5a10-44aa-8345-ce4592a2c3bc)

![image](https://github.com/user-attachments/assets/892f58b8-205b-488f-b945-a5ce5500149c)
