### PR TITLE
Overhaul tool asset management and add Splunk telemetry support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,30 @@ jobs:
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:integration
         name: Run integration tests
 
+  build-vsix:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: cache-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-modules-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn compile
+      - run: yarn package
+        name: Build VSIX package
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vscode-appland.vsix
+          path: '*.vsix'
+
   release:
     runs-on: ubuntu-latest
     needs: [unit, integration]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,3 +114,15 @@ running in the background.
 
 By downloading and using AppMap you agree to the
 [Terms and Conditions](https://appmap.io/community/terms-and-conditions).
+
+## Customizing the VSIX package
+
+The VSIX package can be customized with a `site-config.json` file. This is useful for pre-configuring the extension for a specific environment. The `build/bundleConfig.ps1` script is provided for this purpose.
+
+### Usage
+
+```powershell
+./build/bundleConfig.ps1 -VsixPath <path/to/your.vsix> -SiteConfigPath <path/to/your/site-config.json>
+```
+
+This will create a new VSIX file with the `-mod` suffix, which includes the configuration from the `site-config.json` file.

--- a/build/bundleConfig.md
+++ b/build/bundleConfig.md
@@ -1,0 +1,57 @@
+# bundleConfig Script Documentation
+
+## Overview
+
+`bundleConfig.ps1` is a PowerShell script for updating a VSIX extension package with configuration
+values from a `site-config.json` file. It injects configuration defaults and repacks the VSIX.
+
+## Prerequisites
+
+- PowerShell
+- A VSIX file to modify
+- A `site-config.json` file with configuration values
+
+## Usage
+
+```powershell
+./build/bundleConfig.ps1 -VsixPath <path/to/your.vsix> -SiteConfigPath <path/to/your/site-config.json> [-PlatformIdentifier <platform>] [-Binaries <path/to/binary1>,<path/to/binary2>]
+```
+
+- `<path/to/your.vsix>`: Path to the VSIX file to modify.
+- `<path/to/your/site-config.json>`: Path to the configuration file.
+- `-PlatformIdentifier`: (Optional) The platform identifier for which to download tools (e.g.,
+  `win-x64`, `linux-x64`, `macos-arm64`). If provided, the script will download the `appmap` and
+  `scanner` tools from GitHub.
+- `-Binaries`: (Optional) A comma-separated list of paths to binary files to include in the VSIX
+  under `/extension/resources`.
+
+## Example
+
+Suppose you have:
+
+- VSIX file: `my-extension.vsix`
+- Config file: `site-config.json`
+
+To download the tools for Windows x64 and bundle them into the VSIX, run:
+
+```powershell
+./build/bundleConfig.ps1 -VsixPath my-extension.vsix -SiteConfigPath site-config.json -PlatformIdentifier win-x64
+```
+
+This will download the latest versions of the `appmap` and `scanner` tools for Windows x64 to the
+current directory, and then bundle them into a new VSIX file named `my-extension-mod.vsix`.
+
+## What it does
+
+- If a `-PlatformIdentifier` is provided, it downloads the `appmap` and `scanner` tools from GitHub
+  for the specified platform.
+- Extracts the VSIX to a temporary directory.
+- Updates `extension/package.json` with values from `site-config.json`.
+- Adds `site-config.json` to the VSIX for reference.
+- Adds any provided or downloaded binaries to `/extension/resources` in the VSIX.
+- Repackages the VSIX into a new file with a `-mod.vsix` suffix.
+
+## Troubleshooting
+
+- Ensure both input files exist and are readable
+- Errors will be printed to the console if the process fails

--- a/build/bundleConfig.ps1
+++ b/build/bundleConfig.ps1
@@ -1,0 +1,211 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$VsixPath,
+
+    [Parameter(Mandatory=$true)]
+    [string]$SiteConfigPath,
+
+    [Parameter(Mandatory=$false)]
+    [string]$PlatformIdentifier,
+
+    [Parameter(Mandatory=$false)]
+    [string[]]$Binaries
+)
+
+# --- Hardcoded tool information ---
+$ToolsOwner = 'getappmap'
+$ToolsRepo = 'appmap-js'
+$ToolsToDownload = @('appmap', 'scanner')
+# --------------------------------
+
+# Initialize Binaries as an empty array if not provided
+if (-not $Binaries) {
+    $Binaries = @()
+}
+
+# Split $Binaries into an array if it's a single string with spaces or commas
+if ($Binaries.Count -eq 1) {
+    $Binaries = $Binaries[0] -split '[\s,]+'
+}
+
+function Get-NpmLatestVersion($packageName) {
+    try {
+        Write-Host "Fetching the latest version for $packageName from npm registry API..."
+        $encodedName = [System.Web.HttpUtility]::UrlEncode($packageName)
+        $url = "https://registry.npmjs.org/$encodedName"
+        $response = Invoke-WebRequest -Uri $url -UseBasicParsing
+        $json = $response.Content | ConvertFrom-Json
+        $version = $json."dist-tags".latest
+        Write-Host "Latest version for $packageName is $version"
+        return $version
+    } catch {
+        Write-Error "Failed to get latest version for $packageName from npm registry API. Error: $_"
+        return $null
+    }
+}
+
+function Download-File($url, $path) {
+    if (Test-Path $path) {
+        Write-Host "File $path already exists. Skipping download."
+        return $true
+    }
+    try {
+        Write-Host "Downloading from $url to $path..."
+        Invoke-WebRequest -Uri $url -OutFile $path
+        Write-Host "Download complete."
+        return $true
+    } catch {
+        Write-Error "Failed to download file from $url. Error: $_"
+        return $false
+    }
+}
+
+if ($PlatformIdentifier) {
+    Write-Host "Platform identifier provided: $PlatformIdentifier. Preparing to download tools."
+    foreach ($tool in $ToolsToDownload) {
+        $tool = $tool.Trim()
+        $latestVersion = Get-NpmLatestVersion -packageName "@appland/$tool"
+        if ($latestVersion) {
+            $os, $arch = $PlatformIdentifier.Split('-')
+            $binaryExtension = if ($os -eq 'win') { ".exe" } else { "" }
+            $fileName = "${tool}-${os}-${arch}-${latestVersion}${binaryExtension}"
+            $downloadPath = Join-Path (Get-Location) $fileName
+
+            $artifactName = "@appland/${tool}-v${latestVersion}/${tool}-${PlatformIdentifier}${binaryExtension}"
+            $url = "https://github.com/$ToolsOwner/$ToolsRepo/releases/download/$artifactName"
+            
+            if (Download-File -url $url -path $downloadPath) {
+                $Binaries += $downloadPath
+            }
+        }
+    }
+}
+
+try {
+    # 1. Create a temporary directory for extraction
+    if ($env:TEMP) {
+        $baseTemp = $env:TEMP
+    } elseif ($env:TMP) {
+        $baseTemp = $env:TMP
+    } else {
+        $baseTemp = "/tmp"
+    }
+    $tempDir = Join-Path $baseTemp ([System.Guid]::NewGuid().ToString())
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    Write-Host "Extracting VSIX package $VsixPath to a temporary directory..."
+    # 2. Extract the VSIX
+    Expand-Archive -Path $VsixPath -DestinationPath $tempDir
+
+    $packageJsonPath = Join-Path $tempDir "extension/package.json"
+    if (-not (Test-Path $packageJsonPath)) {
+        throw "Error: package.json not found in VSIX"
+    }
+
+    $packageJsonContent = Get-Content -Path $packageJsonPath -Raw
+    $packageJson = $packageJsonContent | ConvertFrom-Json
+
+    Write-Host "Reading site configuration from $SiteConfigPath..."
+    $siteConfigContent = Get-Content -Path $SiteConfigPath -Raw
+    if (-not $siteConfigContent) {
+        throw "Error: site-config.json not found or empty"
+    }
+    $siteConfig = $siteConfigContent | ConvertFrom-Json -AsHashtable
+
+    # 3. Backup original package.json and update it
+    Write-Host "Updating package.json with site configuration..."
+    Copy-Item -Path $packageJsonPath -Destination (Join-Path $tempDir "extension/package.json.orig")
+
+    if (-not $packageJson.contributes) {
+        $packageJson | Add-Member -MemberType NoteProperty -Name "contributes" -Value ([pscustomobject]@{configuration = [pscustomobject]@{properties = [pscustomobject]@{}}})
+    } elseif (-not $packageJson.contributes.configuration) {
+        $packageJson.contributes | Add-Member -MemberType NoteProperty -Name "configuration" -Value ([pscustomobject]@{properties = [pscustomobject]@{}})
+    }
+
+    $configProperties = $packageJson.contributes.configuration.properties
+
+    function Get-JsonSchemaType($val) {
+        if ($null -eq $val) { return 'null' }
+        $typeName = $val.GetType().Name
+        switch ($typeName) {
+            'String' { return 'string' }
+            'Int32' { return 'integer' }
+            'Int64' { return 'integer' }
+            'Double' { return 'number' }
+            'Single' { return 'number' }
+            'Boolean' { return 'boolean' }
+            'Hashtable' { return 'object' }
+            'OrderedHashtable' { return 'object' }
+            'Object[]' { return 'array' }
+            'ArrayList' { return 'array' }
+            default { return 'string' }
+        }
+    }
+
+    foreach ($key in $siteConfig.Keys) {
+        $value = $siteConfig[$key]
+        Write-Host "Setting $key to $($value | ConvertTo-Json -Compress)"
+
+        if ($configProperties.PSObject.Properties[$key]) {
+            $configProperties.$key.default = $value
+        } else {
+            $newProperty = [pscustomobject]@{
+                type = Get-JsonSchemaType $value
+                default = $value
+                markdownDescription = ""
+            }
+            $configProperties | Add-Member -MemberType NoteProperty -Name $key -Value $newProperty
+        }
+    }
+
+    # 4. Add site-config.json to the VSIX folder for reference
+    Write-Host "Adding site-config.json to the VSIX package..."
+    Copy-Item -Path $SiteConfigPath -Destination (Join-Path $tempDir "extension/site-config.json")
+
+    $resourcesDir = Join-Path $tempDir "extension/resources"
+    if (-not (Test-Path $resourcesDir)) {
+        New-Item -ItemType Directory -Path $resourcesDir | Out-Null
+    }
+
+    # 4a. Add binaries to /extension/resources if provided
+    if ($Binaries -and $Binaries.Count -gt 0) {
+        Write-Host "Adding binaries to the VSIX package..."
+        foreach ($bin in $Binaries) {
+            $bin = $bin.Trim()
+            if (Test-Path $bin) {
+                $binFilename = Split-Path -leaf $bin
+                Write-Host "- Adding $binFilename to /extension/resources"
+                Copy-Item -Path $bin -Destination $resourcesDir -Force
+                if ($IsLinux -or $IsMacOS) {
+                    Write-Host "  - Setting executable permissions for $binFilename"
+                    $destPath = Join-Path $resourcesDir $binFilename
+                    chmod +x $destPath
+                }
+            } else {
+                Write-Warning "Binary not found: $bin"
+            }
+        }
+    }
+
+    # 5. Write the updated package.json
+    $packageJson | ConvertTo-Json -Depth 10 | Set-Content -Path $packageJsonPath
+
+    # 6. Repack the VSIX
+    $outputVsixPath = $VsixPath.Replace(".vsix", "-mod.vsix")
+    if (Test-Path $outputVsixPath) {
+        Remove-Item $outputVsixPath
+    }
+    Write-Host "Repacking the VSIX package to $outputVsixPath..."
+    Compress-Archive -Path (Join-Path $tempDir "*") -DestinationPath $outputVsixPath
+
+    Write-Host "Successfully modified VSIX. New file is at: $outputVsixPath"
+
+} finally {
+    # 7. Clean up the temporary directory
+    if ($tempDir -and (Test-Path $tempDir)) {
+        Write-Host "Cleaning up temporary files..."
+        Remove-Item -Recurse -Force -Path $tempDir
+    }
+}

--- a/build/updateResources.js
+++ b/build/updateResources.js
@@ -21,7 +21,7 @@ function downloadGitHubRelease(repo, version) {
   const url = `https://github.com/${repo}/releases/download/v${version}/appmap-${version}.jar`;
   return fetch(url)
     .then((res) => res.arrayBuffer())
-    .then((data) => writeFile(join(resourceDir, 'appmap-java.jar'), Buffer.from(data)));
+    .then((data) => writeFile(join(resourceDir, `appmap-${version}.jar`), Buffer.from(data)));
 }
 
 async function fileExists(path) {
@@ -40,7 +40,7 @@ async function main() {
   const appmapVersion = await fetchLatestNpmVersion('@appland/appmap');
   const scannerVersion = await fetchLatestNpmVersion('@appland/scanner');
   const agentJarVersion = await fetchLatestGitHubReleaseVersion('getappmap/appmap-java');
-  const jarExists = await fileExists(join(resourceDir, 'appmap-java.jar'));
+  const jarExists = await fileExists(join(resourceDir, `appmap-${agentJarVersion}.jar`));
   const versionDeclarations = await readFile(join(resourceDir, 'versions.json'), 'utf-8').then(
     JSON.parse
   );

--- a/doc/assets.md
+++ b/doc/assets.md
@@ -1,0 +1,69 @@
+# Asset Management System
+
+The asset management system handles the download, caching, and usage of required binaries for the
+extension, such as AppMap CLI, Scanner CLI, and the Java agent. It is designed to work seamlessly
+with both automatically downloaded assets and pre-bundled binaries.
+
+## How It Works
+
+- **Automatic Download:** On startup or when required, the system checks for the presence of
+  required binaries. If missing, it downloads the latest versions from official sources (NPM, Maven,
+  GitHub).
+- **Caching:** Downloaded binaries are stored in a platform-appropriate cache directory (e.g.,
+  `~/.cache/appmap` on Linux).
+- **Symlinks:** The system maintains symlinks in `~/.appmap/bin` and `~/.appmap/lib/java` pointing
+  to the actual binaries.
+- **Bundled Binaries:** If binaries are present in the `resources` directory of the extension
+  package, these are used in preference to downloading.
+
+## Bundled Binaries in `/resources`
+
+The asset system supports using pre-existing binaries placed in the `resources` directory at the
+package root. This is especially useful for distributing a VSIX package with custom or pre-approved
+binaries.
+
+### Naming Conventions
+
+- AppMap CLI: `appmap-<platform>-<arch>-<version>` (e.g., `appmap-linux-x64-0.9.0`)
+- Scanner CLI: `scanner-<platform>-<arch>-<version>` (e.g. `scanner-win-x64-1.8.0.exe`)
+- Java Agent: `appmap-<version>.jar` (e.g. `appmap-1.44.jar`)
+
+### How Bundled Binaries Are Used
+
+- On startup, the extension checks for required binaries in the `resources` directory.
+- If a matching binary is found, it is symlinked from `resources` into `~/.appmap`.
+- If not found, the system falls back to downloading the binary.
+
+## Modifying a Published VSIX to Bundle Custom Binaries
+
+You can prepare a modified VSIX package with custom binaries by adding or replacing files in the
+`extension/resources` directory (note the package root is in `extension` subdirectory of the zip
+file).
+
+### Steps
+
+1. **Extract the VSIX:**  
+   A VSIX file is a zip archive. Extract it using any zip tool.
+
+2. **Add or Replace Binaries:**  
+   Place your binaries in the `extension/resources` directory at the root of the extracted archive,
+   following the naming conventions above.
+
+3. **Repack the VSIX:**  
+   Zip the contents back up, ensuring the directory structure is preserved and the
+   `extension/resources` directory is at the root.
+
+4. **Install the Modified VSIX:**  
+   Install the VSIX in Visual Studio Code as usual. The extension will detect and use the bundled
+   binaries from the `extension/resources` directory.
+
+### Notes
+
+- If a required binary is not found in the cache or `resources`, it will be downloaded automatically
+  (unless updates are disabled).
+- This approach is useful for distributing extensions with custom, pre-approved, or air-gapped
+  binaries.
+
+---
+
+For more details on the asset system implementation, see the source files in `src/assets/`.

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -14,7 +14,8 @@ To use the Splunk backend, you need to configure the following settings in your 
   "appmap.telemetry": {
     "backend": "splunk",
     "url": "<your-splunk-hec-url>",
-    "token": "<your-splunk-hec-token>"
+    "token": "<your-splunk-hec-token>",
+    "ca": "<your-ca-cert>"
   }
 }
 ```
@@ -23,6 +24,10 @@ To use the Splunk backend, you need to configure the following settings in your 
 - `appmap.telemetry.url`: The URL of your Splunk HTTP Event Collector (HEC) endpoint. Note it's
   recommended to include the port number (usually 8088 or 443).
 - `appmap.telemetry.token`: Your Splunk HEC token.
+- `appmap.telemetry.ca`: Your CA certificate. If not set, the server certificate will not be
+  verified. If set to `system`, the system's default CA certificates will be used. If the value
+  starts with `@`, it will be interpreted as a path to a CA certificate file. Otherwise, the value
+  will be used as the literal CA certificate.
 
 If the `backend` is set to `splunk` but the `url` or `token` are missing, telemetry data will not be
 sent.
@@ -33,3 +38,4 @@ CLI:
 - `APPMAP_TELEMETRY_BACKEND`: Set to `splunk`.
 - `SPLUNK_URL`: The URL of your Splunk HEC endpoint.
 - `SPLUNK_TOKEN`: Your Splunk HEC token.
+- `SPLUNK_CA_CERT`: Your CA certificate.

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -1,0 +1,35 @@
+# Telemetry Configuration
+
+AppMap collects telemetry data to help us improve the product. By default, this data is sent to
+AppMap's own telemetry service. However, you can configure AppMap to send telemetry data to your own
+Splunk instance.
+
+## Splunk Backend
+
+To use the Splunk backend, you need to configure the following settings in your VS Code
+`settings.json` file:
+
+```json
+{
+  "appmap.telemetry": {
+    "backend": "splunk",
+    "url": "<your-splunk-hec-url>",
+    "token": "<your-splunk-hec-token>"
+  }
+}
+```
+
+- `appmap.telemetry.backend`: Set this to `splunk` to enable the Splunk backend.
+- `appmap.telemetry.url`: The URL of your Splunk HTTP Event Collector (HEC) endpoint. Note it's
+  recommended to include the port number (usually 8088 or 443).
+- `appmap.telemetry.token`: Your Splunk HEC token.
+
+If the `backend` is set to `splunk` but the `url` or `token` are missing, telemetry data will not be
+sent.
+
+When the Splunk backend is enabled, the following environment variables are exposed to the AppMap
+CLI:
+
+- `APPMAP_TELEMETRY_BACKEND`: Set to `splunk`.
+- `SPLUNK_URL`: The URL of your Splunk HEC endpoint.
+- `SPLUNK_TOKEN`: Your Splunk HEC token.

--- a/package.json
+++ b/package.json
@@ -363,6 +363,11 @@
         "appMap.copilot.preferredModel": {
           "type": "string",
           "description": "Preferred Copilot model to use"
+        },
+        "appMap.autoUpdateTools": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable automatic updates and downloads of AppMap tools."
         }
       }
     },

--- a/resources/versions.json
+++ b/resources/versions.json
@@ -1,5 +1,5 @@
 {
-  "appmap": "3.156.0",
-  "scanner": "1.87.1",
-  "appmap-java.jar": "1.26.9"
+  "appmap": "3.192.0",
+  "scanner": "1.88.1",
+  "appmap-java.jar": "1.28.0"
 }

--- a/src/authentication/appmapServerAuthenticationProvider.ts
+++ b/src/authentication/appmapServerAuthenticationProvider.ts
@@ -53,7 +53,7 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
     return provider;
   }
 
-  async enterLicenseKeyCommand(licenseKey?: string) {
+  async enterLicenseKeyCommand(licenseKey?: string, assumeValid = false): Promise<void> {
     if (!licenseKey) {
       licenseKey = await vscode.window.showInputBox({
         title: `Enter your AppMap license key`,
@@ -63,7 +63,10 @@ export default class AppMapServerAuthenticationProvider implements vscode.Authen
 
     if (!licenseKey) return;
 
-    if (!(await LicenseKey.check(licenseKey))) {
+    // Only check validity if the license key is coming from user input.
+    // This is to avoid proxy issues — sometimes the embedded chrome
+    // will be able to connect to AppMap server, but the extension cannot.
+    if (!(assumeValid || (await LicenseKey.check(licenseKey)))) {
       vscode.window.showErrorMessage('Invalid license key');
       return;
     }

--- a/src/commands/downloadLatestJavaJar.ts
+++ b/src/commands/downloadLatestJavaJar.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export default async function downloadLatestJavaJar(
   context: vscode.ExtensionContext

--- a/src/commands/generateOpenApi.ts
+++ b/src/commands/generateOpenApi.ts
@@ -13,7 +13,8 @@ import { DEBUG_EXCEPTION, Telemetry } from '../telemetry';
 import ErrorCode from '../telemetry/definitions/errorCodes';
 import { AppmapConfigManager } from '../services/appmapConfigManager';
 import { workspaceServices } from '../services/workspaceServices';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export const GenerateOpenApi = 'appmap.generateOpenApi';
 

--- a/src/commands/installAgent.ts
+++ b/src/commands/installAgent.ts
@@ -6,7 +6,8 @@ import { Installer } from './installer';
 import DefaultInstaller from './installer/default';
 import PythonInstaller from './installer/python';
 import CommandRegistry from './commandRegistry';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export const InstallAgent = 'appmap.installAgent';
 

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -115,6 +115,10 @@ export default class ExtensionSettings {
       vscode.workspace.getConfiguration('appMap').get('useAnimation') || false
     );
   }
+
+  public static get autoUpdateTools(): boolean {
+    return vscode.workspace.getConfiguration('appMap').get<boolean>('autoUpdateTools') ?? true;
+  }
 }
 
 export interface TelemetryConfiguration {

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -45,6 +45,7 @@ export default class ExtensionSettings {
       result.APPMAP_TELEMETRY_DISABLED ??= 'false';
       if (telemetryConfig.url) result.SPLUNK_URL ??= telemetryConfig.url;
       if (telemetryConfig.token) result.SPLUNK_TOKEN ??= telemetryConfig.token;
+      if (telemetryConfig.ca) result.SPLUNK_CA_CERT ??= telemetryConfig.ca;
     }
 
     return result;
@@ -125,4 +126,5 @@ export interface TelemetryConfiguration {
   backend?: 'appinsights' | 'splunk';
   url?: string;
   token?: string;
+  ca?: string;
 }

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -22,7 +22,8 @@ import { readFile } from 'fs/promises';
 import appmapMessageHandler from '../webviews/appmapMessageHandler';
 import FilterStore from '../webviews/filterStore';
 import WebviewList from '../webviews/WebviewList';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export type FindingInfo = ResolvedFinding & {
   stackLocations?: StackLocation[];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,9 +245,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     const dependenciesInstalled = ExtensionSettings.appMapCommandLineToolsPath
       ? // do not try to download if we're using local tools anyway
         Promise.resolve()
-      : AssetService.updateAll();
+      : AssetService.ensureAssets();
     const chatSearchWebview: Promise<ChatSearchWebview> = (async () => {
-      await dependenciesInstalled;
+      try {
+        await dependenciesInstalled;
+      } catch (e) {
+        if (e instanceof Error)
+          vscode.window.showErrorMessage(`Error installing AppMap tools: ${e.message}`);
+        else vscode.window.showErrorMessage(`Error installing AppMap tools: ${e}`);
+        throw e; // no sense continuing if we can't install the tools
+      }
 
       activateUptodateService();
       await workspaceServices.enroll(processService);

--- a/src/services/appmapUptodateService.ts
+++ b/src/services/appmapUptodateService.ts
@@ -15,7 +15,8 @@ import * as vscode from 'vscode';
 import ChangeEventDebouncer from './changeEventDebouncer';
 import { WorkspaceService, WorkspaceServiceInstance } from './workspaceService';
 import { workspaceServices } from './workspaceServices';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export default class AppmapUptodateServiceInstance
   extends EventEmitter

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -10,7 +10,8 @@ import { WorkspaceService } from './workspaceService';
 import { AppmapConfigManager } from './appmapConfigManager';
 import { workspaceServices } from './workspaceServices';
 import assert from 'assert';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export class NodeProcessService implements WorkspaceService<NodeProcessServiceInstance> {
   public static readonly serviceId = 'NodeProcessService';

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -11,7 +11,8 @@ import { AUTHN_PROVIDER_NAME } from '../authentication';
 import assert from 'assert';
 import { DEBUG_EXCEPTION, Telemetry } from '../telemetry';
 import ErrorCode from '../telemetry/definitions/errorCodes';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 import { setSecretEnvVars } from './navieConfigurationService';
 import ChatCompletion from './chatCompletion';
 

--- a/src/services/rpcProcessWatcher.ts
+++ b/src/services/rpcProcessWatcher.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { NodeProcessService } from './nodeProcessService';
 import { ProcessId, ProcessWatcher, ProcessWatcherOptions } from './processWatcher';
-import AssetService, { AssetIdentifier } from '../assets/assetService';
+import AssetService from '../assets/assetService';
+import { AssetIdentifier } from '../assets';
 
 export default class RpcProcessWatcher extends ProcessWatcher {
   private readonly _onRpcPortChange: vscode.EventEmitter<number> =

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -47,7 +47,13 @@ export class Telemetry {
     if (telemetryConfig.backend === 'splunk') {
       const { url, token } = telemetryConfig;
       if (url && token) {
-        this.reporter = new SplunkTelemetryReporter(EXTENSION_ID, EXTENSION_VERSION, url, token);
+        this.reporter = new SplunkTelemetryReporter(
+          EXTENSION_ID,
+          EXTENSION_VERSION,
+          url,
+          token,
+          telemetryConfig.ca
+        );
         void this.testConnection();
         if (this.debugChannel) {
           this.debugChannel.appendLine('Using Splunk telemetry reporter at ' + url);

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { version, publisher, name } from '../../package.json';
+import ExtensionSettings from '../configuration/extensionSettings';
 import { UnionToIntersection } from '../util';
 import TelemetryResolver from './telemetryResolver';
 import TelemetryDataProvider from './telemetryDataProvider';
 import Event from './event';
+import SplunkTelemetryReporter from './splunkTelemetryReporter';
 
 const EXTENSION_ID = `${publisher}.${name}`;
 const EXTENSION_VERSION = `${version}`;
@@ -21,22 +23,69 @@ const INSTRUMENTATION_KEY = ['NTBjMWE1YzI', 'NDliNA', 'NDkxMw', 'YjdjYw', 'ODZhN
 type DataType<T> = T extends Array<TelemetryDataProvider<infer P, unknown>> ? P : unknown;
 type DataResolverArray<T> = TelemetryDataProvider<Record<string, unknown>, T>[];
 
+type Reporter = Pick<
+  TelemetryReporter,
+  'sendTelemetryEvent' | 'sendTelemetryErrorEvent' | 'dispose'
+> & {
+  testConnection?: () => Promise<unknown>;
+};
+
 /**
  * The primary interface for sending telemetry data.
  */
 export class Telemetry {
-  private static reporter = new TelemetryReporter(
-    EXTENSION_ID,
-    EXTENSION_VERSION,
-    INSTRUMENTATION_KEY
-  );
+  private static reporter: Reporter;
   private static debugChannel?: vscode.OutputChannel;
 
   static register(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(this.reporter);
-
     if (process.env.APPMAP_TELEMETRY_DEBUG) {
       this.debugChannel = vscode.window.createOutputChannel('AppMap: Telemetry');
+    }
+
+    const telemetryConfig = ExtensionSettings.telemetryConfiguration;
+
+    if (telemetryConfig.backend === 'splunk') {
+      const { url, token } = telemetryConfig;
+      if (url && token) {
+        this.reporter = new SplunkTelemetryReporter(EXTENSION_ID, EXTENSION_VERSION, url, token);
+        void this.testConnection();
+        if (this.debugChannel) {
+          this.debugChannel.appendLine('Using Splunk telemetry reporter at ' + url);
+        }
+      } else {
+        if (this.debugChannel) {
+          this.debugChannel.appendLine('Splunk telemetry reporter is not configured properly.');
+        }
+        // Don't send telemetry if Splunk is configured but the URL or token are missing.
+        this.reporter = {
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          sendTelemetryEvent: () => {},
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          sendTelemetryErrorEvent: () => {},
+          dispose: () => Promise.resolve(),
+        };
+      }
+    } else {
+      this.reporter = new TelemetryReporter(EXTENSION_ID, EXTENSION_VERSION, INSTRUMENTATION_KEY);
+    }
+
+    context.subscriptions.push(this.reporter);
+  }
+
+  private static async testConnection(): Promise<void> {
+    if (this.reporter.testConnection) {
+      try {
+        await this.reporter.testConnection();
+        this.debugChannel?.appendLine('Successfully connected to Splunk telemetry endpoint.');
+      } catch (e) {
+        this.debugChannel?.appendLine('Error connecting to Splunk telemetry endpoint: ' + e);
+        let errorMessage =
+          'Could not connect to telemetry endpoint. Telemetry will not work. \n\n' + e;
+        if (e instanceof Error && e.message.includes('cert')) {
+          errorMessage += "\n\nTry setting http.proxySupport to 'fallback' in VSCode settings.";
+        }
+        vscode.window.showErrorMessage(errorMessage);
+      }
     }
   }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -63,13 +63,7 @@ export class Telemetry {
           this.debugChannel.appendLine('Splunk telemetry reporter is not configured properly.');
         }
         // Don't send telemetry if Splunk is configured but the URL or token are missing.
-        this.reporter = {
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          sendTelemetryEvent: () => {},
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          sendTelemetryErrorEvent: () => {},
-          dispose: () => Promise.resolve(),
-        };
+        this.reporter = NOOP_TELEMETRY;
       }
     } else {
       this.reporter = new TelemetryReporter(EXTENSION_ID, EXTENSION_VERSION, INSTRUMENTATION_KEY);
@@ -143,5 +137,17 @@ export class Telemetry {
     this.reporter.sendTelemetryEvent('open_uri', { uri: uri.toString() });
   }
 }
+
+const NOOP_TELEMETRY: Reporter = {
+  sendTelemetryEvent(): void {
+    /* no-op */
+  },
+  sendTelemetryErrorEvent(): void {
+    /* no-op */
+  },
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  },
+};
 
 export * from './definitions/events';

--- a/src/telemetry/splunkTelemetryReporter.ts
+++ b/src/telemetry/splunkTelemetryReporter.ts
@@ -1,0 +1,84 @@
+import https from 'node:https';
+
+import fetch, { type Response } from 'node-fetch';
+
+export default class SplunkTelemetryReporter {
+  private static readonly DEFAULT_PORT = '443';
+  private agent: https.Agent | undefined;
+
+  constructor(
+    private extensionId: string,
+    private extensionVersion: string,
+    private url: string,
+    private token: string
+  ) {
+    const urlObj = new URL(this.url);
+    if (!urlObj.port) urlObj.port = SplunkTelemetryReporter.DEFAULT_PORT;
+    if (urlObj.pathname === '/') urlObj.pathname = '/services/collector/event/1.0';
+    this.url = urlObj.toString();
+    if (urlObj.protocol === 'https:') {
+      this.agent = new https.Agent({
+        keepAlive: true,
+        // Splunk instances may use self-signed certificates
+        rejectUnauthorized: false,
+      });
+    }
+  }
+
+  private async send(data: unknown): Promise<void> {
+    try {
+      const result = await fetch(this.url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Splunk ${this.token}`,
+        },
+        body: JSON.stringify({ event: data }),
+        agent: this.agent,
+      });
+      if (!result.ok) {
+        console.warn(`Error sending telemetry to Splunk: ${result.status} ${result.statusText}`);
+      }
+    } catch (e) {
+      // Don't let telemetry errors crash the extension
+      console.warn('Error sending telemetry to Splunk', e);
+    }
+  }
+
+  public testConnection(): Promise<Response> {
+    return fetch(this.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Splunk ${this.token}`,
+      },
+      body: '',
+      agent: this.agent,
+    });
+  }
+
+  sendTelemetryEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number }
+  ): void {
+    const data = {
+      extensionId: this.extensionId,
+      extensionVersion: this.extensionVersion,
+      eventName,
+      properties,
+      measurements,
+    };
+    this.send(data);
+  }
+
+  sendTelemetryErrorEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number }
+  ): void {
+    this.sendTelemetryEvent(`error/${eventName}`, properties, measurements);
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/webviews/signInWebview.ts
+++ b/src/webviews/signInWebview.ts
@@ -55,7 +55,8 @@ export default class SignInViewProvider implements vscode.WebviewViewProvider {
         case 'activate': {
           const apiKey = message.data;
           this.authProvider.customCancellationToken.cancel();
-          await this.authProvider.enterLicenseKeyCommand(apiKey);
+          // If the license key is coming from the webview we have already validated it
+          await this.authProvider.enterLicenseKeyCommand(apiKey, true);
           break;
         }
 

--- a/test/unit/assets/appmapCliDownloader.test.ts
+++ b/test/unit/assets/appmapCliDownloader.test.ts
@@ -2,24 +2,27 @@ import '../mock/vscode';
 import mockAssetApis from './mockAssetApis';
 import Sinon from 'sinon';
 import os, { tmpdir } from 'os';
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { default as chai, expect } from 'chai';
 import { default as chaiFs } from 'chai-fs';
 import { join } from 'path';
-import { AppMapCliDownloader, initialDownloadCompleted } from '../../../src/assets';
+import { AppMapCliDownloader, BundledFileDownloadUrlResolver, cacheDir } from '../../../src/assets';
 
 chai.use(chaiFs);
 
 describe('AppMapCliDownloader', () => {
   let homeDir: string;
+  let cache: string;
   const platform = 'win32';
   const arch = 'x64';
 
   beforeEach(async () => {
     homeDir = await mkdtemp(join(tmpdir(), 'vscode-appland-appmap-download-test-'));
     Sinon.stub(os, 'homedir').returns(homeDir);
+    BundledFileDownloadUrlResolver.extensionDirectory = homeDir;
     Sinon.stub(process, 'platform').value(platform);
     Sinon.stub(process, 'arch').value(arch);
+    cache = cacheDir();
     mockAssetApis();
   });
 
@@ -31,9 +34,8 @@ describe('AppMapCliDownloader', () => {
 
   it('fixes missing symlinks', async () => {
     await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
-    await mkdir(join(homeDir, '.appmap', 'lib', 'appmap'), { recursive: true });
-    await writeFile(join(homeDir, '.appmap', 'lib', 'appmap', 'appmap-v0.0.0-TEST'), 'test');
-    await initialDownloadCompleted();
+    await mkdir(cache, { recursive: true });
+    await writeFile(join(cache, 'appmap-win-x64-0.0.0-TEST.exe'), 'test');
 
     await AppMapCliDownloader();
 
@@ -41,25 +43,11 @@ describe('AppMapCliDownloader', () => {
     expect(join(homeDir, '.appmap', 'bin', 'appmap.exe')).to.be.a.file().with.content('test');
   });
 
-  it('redownloads the asset if initial download is not completed', async () => {
-    await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
-    await mkdir(join(homeDir, '.appmap', 'lib', 'appmap'), { recursive: true });
-    await writeFile(join(homeDir, '.appmap', 'lib', 'appmap', 'appmap-v0.0.0-TEST'), 'test');
-
-    await AppMapCliDownloader();
-
-    // The target should be replaced
-    expect(join(homeDir, '.appmap', 'bin', 'appmap.exe'))
-      .to.be.a.file()
-      .with.content('<insert appmap cli here>');
-  });
-
   it("does not replace the target if no download happens and it's valid", async () => {
     await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
-    await mkdir(join(homeDir, '.appmap', 'lib', 'appmap'), { recursive: true });
-    await writeFile(join(homeDir, '.appmap', 'lib', 'appmap', 'appmap-v0.0.0-TEST'), 'test');
+    await mkdir(cache, { recursive: true });
+    await writeFile(join(cache, 'appmap-win-x64-0.0.0-TEST.exe'), 'test');
     await writeFile(join(homeDir, '.appmap', 'bin', 'appmap.exe'), 'overriden test');
-    await initialDownloadCompleted();
 
     await AppMapCliDownloader();
 
@@ -67,5 +55,75 @@ describe('AppMapCliDownloader', () => {
     expect(join(homeDir, '.appmap', 'bin', 'appmap.exe'))
       .to.be.a.file()
       .with.content('overriden test');
+  });
+
+  it('does not download if the same version is bundled', async () => {
+    const bundledDir = join(homeDir, 'resources');
+    await mkdir(bundledDir, { recursive: true });
+    await writeFile(join(bundledDir, 'appmap-win-x64-0.0.0-TEST.exe'), 'BUNDLED');
+
+    await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
+    await symlink(
+      join(bundledDir, 'appmap-win-x64-0.0.0-TEST.exe'),
+      join(homeDir, '.appmap', 'bin', 'appmap.exe')
+    );
+
+    await AppMapCliDownloader();
+
+    // The target should not be replaced
+    expect(join(homeDir, '.appmap', 'bin', 'appmap.exe')).to.be.a.file().with.content('BUNDLED');
+  });
+
+  it('does not download if a newer version is bundled', async () => {
+    const bundledDir = join(homeDir, 'resources');
+    await mkdir(bundledDir, { recursive: true });
+    await writeFile(join(bundledDir, 'appmap-win-x64-0.0.1-TEST.exe'), 'BUNDLED');
+
+    await mkdir(cache, { recursive: true });
+    await mkdir(join(homeDir, '.appmap', 'bin'), { recursive: true });
+    await symlink(
+      join(bundledDir, 'appmap-win-x64-0.0.1-TEST.exe'),
+      join(homeDir, '.appmap', 'bin', 'appmap.exe')
+    );
+
+    await AppMapCliDownloader();
+
+    // The target should not be replaced
+    expect(join(homeDir, '.appmap', 'bin', 'appmap.exe')).to.be.a.file().with.content('BUNDLED');
+
+    // the cache should remain empty
+    expect(cache).to.be.a.directory().with.files([]);
+  });
+
+  describe('file naming and permissions', () => {
+    const cases = [
+      { platform: 'linux', arch: 'x64', expectedName: 'appmap-linux-x64-0.0.0-TEST' },
+      { platform: 'linux', arch: 'arm64', expectedName: 'appmap-linux-arm64-0.0.0-TEST' },
+      { platform: 'darwin', arch: 'x64', expectedName: 'appmap-macos-x64-0.0.0-TEST' },
+      { platform: 'darwin', arch: 'arm64', expectedName: 'appmap-macos-arm64-0.0.0-TEST' },
+      { platform: 'win32', arch: 'x64', expectedName: 'appmap-win-x64-0.0.0-TEST.exe' },
+      { platform: 'win32', arch: 'arm64', expectedName: 'appmap-win-arm64-0.0.0-TEST.exe' },
+    ];
+
+    for (const c of cases) {
+      it(`correctly names the file for ${c.platform}-${c.arch}`, async () => {
+        Sinon.stub(process, 'platform').value(c.platform);
+        Sinon.stub(process, 'arch').value(c.arch);
+        cache = cacheDir();
+
+        await AppMapCliDownloader();
+
+        expect(cache).to.be.a.directory().with.files([c.expectedName]);
+        const expectedPath = join(cache, c.expectedName);
+
+        expect(expectedPath).to.be.a.file().with.content('<insert appmap cli here>');
+
+        // check if it's executable on non-windows
+        if (c.platform !== 'win32') {
+          const stats = await stat(expectedPath);
+          expect(stats.mode & 0o111).to.not.equal(0);
+        }
+      });
+    }
   });
 });

--- a/test/unit/assets/javaAgentDownloader.test.ts
+++ b/test/unit/assets/javaAgentDownloader.test.ts
@@ -1,0 +1,56 @@
+import '../mock/vscode';
+
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import os, { tmpdir } from 'os';
+
+import { default as chai, expect } from 'chai';
+import { default as chaiFs } from 'chai-fs';
+
+import Sinon from 'sinon';
+
+import { BundledFileDownloadUrlResolver, cacheDir, JavaAgentDownloader } from '../../../src/assets';
+import mockAssetApis from './mockAssetApis';
+
+chai.use(chaiFs);
+
+describe('JavaAgentDownloader', () => {
+  it('downloads the Java agent to the expected location', async () => {
+    await JavaAgentDownloader();
+
+    expect(cache).to.be.a.directory().with.files(['appmap-0.0.0-TEST.jar']);
+
+    expect(join(cache, 'appmap-0.0.0-TEST.jar')).to.be.a.file().with.content('<insert jar here>');
+  });
+
+  it('does not download if the same version is bundled', async () => {
+    const bundledDir = join(homeDir, 'resources');
+    await mkdir(bundledDir, { recursive: true });
+    await writeFile(join(bundledDir, 'appmap-0.0.1-TEST.jar'), 'BUNDLED');
+
+    await JavaAgentDownloader();
+
+    // The target should not be replaced
+    expect(join(homeDir, '.appmap', 'lib', 'java', 'appmap.jar'))
+      .to.be.a.file()
+      .with.content('BUNDLED');
+
+    // the cache should remain empty
+    expect(cache).not.to.be.a.path();
+  });
+
+  let homeDir: string;
+  let cache: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'vscode-appland-appmap-download-test-'));
+    Sinon.stub(os, 'homedir').returns(homeDir);
+    BundledFileDownloadUrlResolver.extensionDirectory = homeDir;
+    cache = cacheDir();
+    mockAssetApis();
+  });
+  afterEach(() => {
+    Sinon.restore();
+    mockAssetApis.restore();
+  });
+});

--- a/test/unit/assets/mockAssetApis.ts
+++ b/test/unit/assets/mockAssetApis.ts
@@ -59,22 +59,26 @@ export default function mockAssetApis(opts: AssetVersionMocks = {}) {
     () => '<insert jar here>',
     options.denylist
   );
-  mockApi(
-    `https://github.com/getappmap/appmap-js/releases/download/%40appland/scanner-v${options.scanner}/scanner-linux-x64`,
-    () => '<insert scanner here>',
-    options.denylist
-  );
-  mockApi(
-    `https://github.com/getappmap/appmap-js/releases/download/%40appland/appmap-v${options.appmap}/appmap-linux-x64`,
-    () => '<insert appmap cli here>',
-    options.denylist
-  );
 
-  mockApi(
-    `https://github.com/getappmap/appmap-js/releases/download/%40appland/appmap-v${options.appmap}/appmap-win-x64.exe`,
-    () => '<insert appmap cli here>',
-    options.denylist
-  );
+  // mock all the platform/arch combinations so tests don't have to care about
+  // what the current platform/arch is
+  const platforms = ['linux', 'macos', 'win'];
+  const archs = ['x64', 'arm64'];
+  for (const platform of platforms) {
+    for (const arch of archs) {
+      const binarySuffix = `${platform}-${arch}${platform === 'win' ? '.exe' : ''}`;
+      mockApi(
+        `https://github.com/getappmap/appmap-js/releases/download/%40appland/scanner-v${options.scanner}/scanner-${binarySuffix}`,
+        () => '<insert scanner here>',
+        options.denylist
+      );
+      mockApi(
+        `https://github.com/getappmap/appmap-js/releases/download/%40appland/appmap-v${options.appmap}/appmap-${binarySuffix}`,
+        () => '<insert appmap cli here>',
+        options.denylist
+      );
+    }
+  }
 
   return options;
 }


### PR DESCRIPTION
This pull request introduces a major refactoring of the tool asset management system, significantly improving how the AppMap CLI, Scanner, and Java agent are downloaded, cached, and referenced. It also includes new configuration options and the integration of a new telemetry backend.

### New Feature: Splunk Telemetry Support

This PR integrates support for **Splunk telemetry**, including the necessary configuration options. This feature was developed in a different project and is now being merged to expand the available telemetry backends for clients.

### Asset Management Overhaul

The entire system for handling external tool binaries has been re-architected. Key changes include:
* **Platform-Appropriate Caching:** Tools are now downloaded to a dedicated, platform-appropriate cache directory.
* **Symbolic Links:** Creation of robust symlinks in `~/.appmap/bin` (for CLI/Scanner) and `~/.appmap/lib/java` (for the Java agent) that point to the cached or bundled assets.
* **Robust Assurance Logic:** A new `AssetService.ensureAssets()` method handles tool presence, updates, and installation, respecting user preferences for automatic updates.
* **Bundled Assets Support:** The system now supports bundling pre-compiled binaries within the VSIX's `resources` directory, crucial for custom VSIX builds.
* **Cleanup:** The old `.download-complete` marker logic has been replaced with more robust version and presence checks.

### New Configuration and Build Features

* **Tool Auto-Update Setting:** Introduces the boolean configuration setting `appMap.autoUpdateTools` (default: `true`), allowing users to disable automatic downloads and updates of the external tools for greater control.
* **VSIX Customization:** Added `build/bundleConfig.ps1` and new documentation (`build/bundleConfig.md`) to support **pre-configuring the VSIX package** with custom settings and bundled tools, enabling specialized deployments.
* **Versioned Java Agent JAR:** The Java agent JAR filename now includes the version (e.g., `appmap-1.28.0.jar`), improving clarity in asset management.
* **CI/CD:** The CI workflow now includes a dedicated `build-vsix` job for packaging VSIX files.
* **License Check Fix:** Prevents rechecking the license key when it is provided directly from the sign-in view.

The documentation has been updated with a comprehensive guide on the new asset system in `doc/assets.md`.