### PR TITLE
feat: Fix a code issue from finding or known function

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
         "title": "AppMap: Copy Out-of-Date Tests to Clipboard"
       },
       {
+        "command": "appmap.openFindingAsMarkdown",
+        "title": "AppMap: Open Finding as Markdown",
+        "icon": "$(markdown)"
+      },
+      {
         "command": "appmap.context.openInFileExplorer",
         "title": "AppMap View: Open in File Explorer"
       },
@@ -569,6 +574,10 @@
           "when": "false"
         },
         {
+          "command": "appmap.openFindingAsMarkdown",
+          "when": "false"
+        },
+        {
           "command": "appmap.context.deleteAppMaps",
           "when": "false"
         },
@@ -673,6 +682,11 @@
         {
           "command": "appmap.context.inspectCodeObject",
           "when": "config.appMap.inspectEnabled == true && ( viewItem == appmap.views.codeObjects.package || viewItem == appmap.views.codeObjects.class || viewItem == appmap.views.codeObjects.function || viewItem == appmap.views.codeObjects.query || viewItem == appmap.views.codeObjects.route )"
+        },
+        {
+          "command": "appmap.openFindingAsMarkdown",
+          "when": "view == appmap.views.findings && viewItem == appmap.views.analysis.finding",
+          "group": "inline"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -216,6 +216,11 @@
         "title": "AppMap: Compare Sequence Diagrams"
       },
       {
+        "command": "appmap.generateSequenceDiagramFiles",
+        "title": "AppMap: Generate Sequence Diagram (PlantUML)",
+        "icon": "$(symbol-structure)"
+      },
+      {
         "command": "appmap.explain",
         "title": "AppMap: Ask Navie AI"
       },
@@ -560,6 +565,10 @@
           "when": "false"
         },
         {
+          "command": "appmap.generateSequenceDiagramFiles",
+          "when": "false"
+        },
+        {
           "command": "appmap.context.deleteAppMaps",
           "when": "false"
         },
@@ -651,6 +660,11 @@
         {
           "command": "appmap.context.compareSequenceDiagrams",
           "when": "view == appmap.views.appmaps && viewItem == appmap.views.appmaps.appMap"
+        },
+        {
+          "command": "appmap.generateSequenceDiagramFiles",
+          "when": "view == appmap.views.appmaps && viewItem == appmap.views.appmaps.appMap",
+          "group": "navigation@4"
         },
         {
           "command": "appmap.context.deleteAppMaps",

--- a/resources/versions.json
+++ b/resources/versions.json
@@ -1,5 +1,5 @@
 {
-  "appmap": "3.192.0",
-  "scanner": "1.88.1",
-  "appmap-java.jar": "1.28.0"
+  "appmap": "3.196.2",
+  "scanner": "1.89.0",
+  "appmap-java.jar": "1.28.1"
 }

--- a/src/commands/generateSequenceDiagramFiles.ts
+++ b/src/commands/generateSequenceDiagramFiles.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import { AppMap, buildAppMap } from '@appland/models';
+import { buildDiagram, format, FormatType, Specification } from '@appland/sequence-diagram';
+import { writeFile, readFile } from 'fs/promises';
+import AppMapLoader from '../services/appmapLoader';
+
+export default function registerCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'appmap.generateSequenceDiagramFiles',
+      async (item: AppMapLoader) => {
+        if (!item) {
+          vscode.window.showErrorMessage('No AppMap selected');
+          return;
+        }
+
+        if (!item.descriptor || !item.descriptor.resourceUri) {
+          vscode.window.showErrorMessage(
+            'Invalid AppMap item: missing descriptor or resourceUri'
+          );
+          console.error('AppMap item:', item);
+          return;
+        }
+
+        const appmapUri = item.descriptor.resourceUri;
+
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Generating sequence diagram',
+          },
+          async (progress) => {
+            try {
+              // Read and build AppMap
+              progress.report({ message: 'Loading AppMap...' });
+              const data = await readFile(appmapUri.fsPath, 'utf-8');
+              const appmap: AppMap = buildAppMap().source(data).build();
+
+              // Build specification with defaults (no prompts)
+              progress.report({ message: 'Building diagram specification...' });
+              const specification = Specification.build(appmap, {
+                exclude: getDefaultExcludePackages(appmap),
+                expand: [],
+              });
+
+              // Build diagram
+              progress.report({ message: 'Generating diagram...' });
+              const diagram = buildDiagram(appmapUri.fsPath, appmap, specification);
+
+              // Generate PlantUML
+              progress.report({ message: 'Formatting PlantUML...' });
+              const uml = format(FormatType.PlantUML, diagram, appmapUri.fsPath);
+              const umlFile = `${appmapUri.fsPath}.uml`;
+              await writeFile(umlFile, uml.diagram);
+
+              // Open file
+              progress.report({ message: 'Opening file...' });
+              const umlDoc = await vscode.workspace.openTextDocument(umlFile);
+              await vscode.window.showTextDocument(umlDoc, { preview: false });
+
+              vscode.window.showInformationMessage(
+                `Generated sequence diagram: ${vscode.workspace.asRelativePath(umlFile)}`
+              );
+            } catch (error) {
+              vscode.window.showErrorMessage(
+                `Failed to generate sequence diagram: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          }
+        );
+      }
+    )
+  );
+}
+
+// Helper function to get default exclude packages based on language
+function getDefaultExcludePackages(appmap: AppMap): string[] {
+  const language = appmap.metadata.language?.name || 'unknownLanguage';
+
+  const IGNORE_PACKAGES: Record<string, string[]> = {
+    ruby: [
+      'actionpack',
+      'activesupport',
+      'activerecord',
+      'actionview',
+      'json',
+      'logger',
+      'openssl',
+      'ruby',
+      'sprockets',
+    ],
+  };
+
+  const packages = IGNORE_PACKAGES[language] || [];
+  return packages.map((pkg) => `package:${pkg}`);
+}

--- a/src/commands/openFindingAsMarkdown.ts
+++ b/src/commands/openFindingAsMarkdown.ts
@@ -1,0 +1,232 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { FindingTreeItem } from '../tree/findingsTreeDataProvider';
+import { RawEventData } from '../types/rawEvent';
+
+const MAX_STACK_FRAMES = 5;
+const MESSAGE_WIDTH = 100;
+
+function wordWrap(text: string, maxWidth: number): string {
+  const lines: string[] = [];
+  const paragraphs = text.split('\n');
+
+  for (const paragraph of paragraphs) {
+    if (paragraph.trim().length === 0) {
+      lines.push('');
+      continue;
+    }
+
+    const words = paragraph.split(/\s+/);
+    let currentLine = '';
+
+    for (const word of words) {
+      const testLine = currentLine.length === 0 ? word : `${currentLine} ${word}`;
+
+      if (testLine.length <= maxWidth) {
+        currentLine = testLine;
+      } else {
+        if (currentLine.length > 0) {
+          lines.push(currentLine);
+        }
+        currentLine = word;
+      }
+    }
+
+    if (currentLine.length > 0) {
+      lines.push(currentLine);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function createFileLink(stackFrame: string, workspaceFolder: vscode.WorkspaceFolder): string {
+  // Parse format: "path/to/file.ts:42" or "path/to/file.ts" or "path/to/file.ts:-1"
+  const match = stackFrame.match(/^(.+?)(?::(-?\d+))?$/);
+  if (!match) return stackFrame;
+
+  const [, filePath, lineStr] = match;
+  let lineNumber: number | null = null;
+
+  // Parse and validate line number
+  if (lineStr) {
+    const parsedLine = parseInt(lineStr, 10);
+    // Only use line number if it's a positive integer (>= 1)
+    if (parsedLine >= 1) {
+      lineNumber = parsedLine;
+    }
+  }
+
+  // Resolve to absolute path first
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(workspaceFolder.uri.fsPath, filePath);
+
+  // Convert to workspace-relative path for both display and link
+  const relativePath = vscode.workspace.asRelativePath(absolutePath);
+
+  // Create link URL (workspace-relative with line number fragment if present)
+  const linkUrl = lineNumber ? `${relativePath}#L${lineNumber}` : relativePath;
+
+  // Create display text (with line number after colon if present)
+  const displayText = lineNumber ? `${relativePath}:${lineNumber}` : relativePath;
+
+  return `[${displayText}](${linkUrl})`;
+}
+
+function formatFindingSynopsis(
+  findingTreeItem: FindingTreeItem,
+  workspaceFolder: vscode.WorkspaceFolder
+): string {
+  const resolvedFinding = findingTreeItem.finding;
+  const finding = resolvedFinding.finding;
+
+  // Build synopsis in markdown format
+  const parts: string[] = [];
+
+  // Header with rule title
+  parts.push(`# ${finding.ruleTitle}`);
+  parts.push('');
+
+  // Rule ID
+  parts.push(`This AppMap matches the following analysis rule: \`${finding.ruleId}\``);
+  parts.push('');
+
+  // Rule description
+  if (resolvedFinding.rule.description) {
+    parts.push(resolvedFinding.rule.description);
+    parts.push('');
+  }
+
+  // Impact domain and occurrence count
+  const metadata: string[] = [];
+  if (resolvedFinding.impactDomain) {
+    metadata.push(`**Impact Domain**: ${resolvedFinding.impactDomain}`);
+  }
+  if (finding.occurranceCount && finding.occurranceCount > 1) {
+    metadata.push(`**Occurrences**: ${finding.occurranceCount}`);
+  }
+  if (metadata.length > 0) {
+    parts.push(metadata.join(' | '));
+    parts.push('');
+  }
+
+  // Message (word-wrapped in code block)
+  parts.push(`## Finding Details`);
+  parts.push('```');
+  parts.push(wordWrap(finding.message, MESSAGE_WIDTH));
+  parts.push('```');
+  parts.push('');
+
+  // Group message if different from main message
+  if (finding.groupMessage && finding.groupMessage !== finding.message) {
+    parts.push(`## Group Summary`);
+    parts.push('```');
+    parts.push(wordWrap(finding.groupMessage, MESSAGE_WIDTH));
+    parts.push('```');
+    parts.push('');
+  }
+
+  // Source location
+  if (resolvedFinding.locationLabel) {
+    parts.push(`## Source Location`);
+    parts.push(createFileLink(resolvedFinding.locationLabel, workspaceFolder));
+    parts.push('');
+  }
+
+  // Stack trace (top N frames)
+  if (finding.stack && finding.stack.length > 0) {
+    parts.push(`## Stack Trace`);
+    const stackFrames = finding.stack.slice(0, MAX_STACK_FRAMES);
+    stackFrames.forEach((frame) => {
+      parts.push(`- ${createFileLink(frame, workspaceFolder)}`);
+    });
+    if (finding.stack.length > MAX_STACK_FRAMES) {
+      parts.push(`- ... (${finding.stack.length - MAX_STACK_FRAMES} more frames)`);
+    }
+    parts.push('');
+  }
+
+  // Participating events if available
+  // Note: participatingEvents is incorrectly typed as Event in @appland/scanner,
+  // but actually contains raw JSON data with snake_case properties
+  if (finding.participatingEvents && Object.keys(finding.participatingEvents).length > 0) {
+    const rawEvents = finding.participatingEvents as unknown as Record<string, RawEventData>;
+    parts.push(`## Code Event Context`);
+    for (const [name, rawEvent] of Object.entries(rawEvents)) {
+      const event: RawEventData = rawEvent;
+      // Add event type/method if available
+      if (event.http_server_request) {
+        const req = event.http_server_request;
+        const normalizedPath =
+          req.normalized_path_info && req.normalized_path_info !== req.path_info
+            ? ` (${req.normalized_path_info})`
+            : '';
+        parts.push(`- **${name}**: ${req.request_method} ${req.path_info}${normalizedPath}`);
+      } else if (event.sql_query) {
+        parts.push(`- **${name}** (SQL):`);
+        parts.push('  ```sql');
+        parts.push(`  ${event.sql_query.sql || 'N/A'}`);
+        parts.push('  ```');
+        if (event.sql_query.database_type) {
+          parts.push(`  Database: ${event.sql_query.database_type}`);
+        }
+      } else {
+        const location = [event.defined_class, event.static ? '.' : '#', event.method_id]
+          .filter(Boolean)
+          .join('');
+        parts.push(`- **${name}**: ${location}`);
+      }
+    }
+    parts.push('');
+  }
+
+  // AppMap file (workspace-relative path as clickable link)
+  const workspaceRelativePath = vscode.workspace.asRelativePath(resolvedFinding.appMapUri.fsPath);
+  parts.push(`## AppMap`);
+  parts.push(`[${workspaceRelativePath}](${workspaceRelativePath})`);
+  parts.push('');
+
+  // References
+  parts.push(`## References`);
+  if (resolvedFinding.rule.references && Object.keys(resolvedFinding.rule.references).length > 0) {
+    parts.push(`- ${resolvedFinding.rule.url}`);
+    for (const [name, url] of Object.entries(resolvedFinding.rule.references)) {
+      parts.push(`- [${name}](${url.toString()})`);
+    }
+    parts.push('');
+  }
+
+  return parts.join('\n');
+}
+
+export default function registerCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'appmap.openFindingAsMarkdown',
+      async (findingTreeItem: FindingTreeItem) => {
+        try {
+          // Get workspace folder for resolving relative paths
+          const workspaceFolder = findingTreeItem.finding.folder;
+          const synopsis = formatFindingSynopsis(findingTreeItem, workspaceFolder);
+
+          // Create untitled markdown document
+          const document = await vscode.workspace.openTextDocument({
+            content: synopsis,
+            language: 'markdown',
+          });
+
+          // Show the document first (required for preview command to work)
+          await vscode.window.showTextDocument(document);
+
+          // Then open the markdown preview
+          await vscode.commands.executeCommand('markdown.showPreview', document.uri);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`Failed to open finding as markdown: ${errorMessage}`);
+          console.error('Open finding as markdown error:', error);
+        }
+      }
+    )
+  );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ import FindingInfoWebview from './webviews/findingInfoWebview';
 import { AppMapRecommenderService } from './services/appmapRecommenderService';
 import openCodeObjectInSource from './commands/openCodeObjectInSource';
 import learnMoreRuntimeAnalysis from './commands/learnMoreRuntimeAnalysis';
+import openFindingAsMarkdown from './commands/openFindingAsMarkdown';
 import ReviewWebview from './webviews/reviewWebview';
 import SignInViewProvider from './webviews/signInWebview';
 import SignInManager from './services/signInManager';
@@ -237,6 +238,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     FindingsOverviewWebview.register(context);
     FindingInfoWebview.register(context);
+    openFindingAsMarkdown(context);
 
     const processService = new NodeProcessService(context);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import deleteAllAppMaps from './commands/deleteAllAppMaps';
 import registerInspectCodeObject from './commands/inspectCodeObject';
 import registerSequenceDiagram from './commands/sequenceDiagram';
 import registerCompareSequenceDiagrams from './commands/compareSequenceDiagram';
+import registerGenerateSequenceDiagramFiles from './commands/generateSequenceDiagramFiles';
 import openCodeObjectInAppMap from './commands/openCodeObjectInAppMap';
 import outOfDateTests from './commands/outOfDateTests';
 import PickCopilotModelCommand from './commands/pickCopilotModel';
@@ -230,6 +231,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     registerSequenceDiagram(context, appmapCollectionFile);
     registerCompareSequenceDiagrams(context, appmapCollectionFile);
+    registerGenerateSequenceDiagramFiles(context);
 
     InstallGuideWebView.register(context, projectStates);
 

--- a/src/lib/AppMapQuickPickItem.ts
+++ b/src/lib/AppMapQuickPickItem.ts
@@ -1,5 +1,0 @@
-import * as vscode from 'vscode';
-
-export type AppMapQuickPickItem = vscode.QuickPickItem & {
-  resourceUri: vscode.Uri;
-};

--- a/src/lib/promptForAppMap.ts
+++ b/src/lib/promptForAppMap.ts
@@ -5,13 +5,13 @@ import AppMapLoader from '../services/appmapLoader';
 import { getWorkspaceFolderFromPath, timeAgo } from '../util';
 import { AppmapConfigManager } from '../services/appmapConfigManager';
 import { workspaceServices } from '../services/workspaceServices';
-import { AppMapQuickPickItem } from './AppMapQuickPickItem';
 
 export async function promptForAppMap(
   appmaps: AppMapLoader[],
   exclude: vscode.Uri[] = []
 ): Promise<vscode.Uri | undefined> {
   const now = Date.now();
+  const uriMap = new Map<string, vscode.Uri>();
   const items = (
     await Promise.all(
       appmaps
@@ -43,17 +43,20 @@ export async function promptForAppMap(
             }
           }
 
-          return {
-            resourceUri: appmap.descriptor.resourceUri,
-            label: label.join(' '),
+          const itemLabel = label.join(' ');
+          const item: vscode.QuickPickItem = {
+            label: itemLabel,
             description: timeAgo(appmap.descriptor.timestamp, now),
             detail: path,
-          } as AppMapQuickPickItem;
+          };
+          // Store the URI in a map keyed by the detail (file path) which is unique
+          uriMap.set(path, appmap.descriptor.resourceUri);
+          return item;
         })
     )
   ).sort((a, b) => a.label.localeCompare(b.label));
-  const result = await vscode.window.showQuickPick<AppMapQuickPickItem>(items);
+  const result = await vscode.window.showQuickPick(items);
   if (!result) return;
 
-  return result.resourceUri;
+  return uriMap.get(result.detail!);
 }

--- a/src/services/resolvedFinding.ts
+++ b/src/services/resolvedFinding.ts
@@ -5,6 +5,7 @@ import present from '../lib/present';
 import ValueCache from '../lib/ValueCache';
 import assert from 'assert';
 import { warn } from 'console';
+import { RawEventData } from '../types/rawEvent';
 
 class StackFrameIndex {
   locationByFrame = new Map<string, vscode.Location>();
@@ -187,13 +188,17 @@ export class ResolvedFinding {
     const filePath = filePaths.find(Boolean);
     if (!filePath) return;
 
+    // Note: finding.event and finding.relatedEvents are incorrectly typed as Event
+    // in @appland/scanner, but actually contain raw JSON data with snake_case properties
+    const rawEvent = finding.event as unknown as RawEventData;
     const state = {
       currentView: 'viewFlow',
-      selectedObject: `event:${finding.event.id}`,
+      selectedObject: `event:${rawEvent.id}`,
     } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     if (finding.relatedEvents) {
-      state.traceFilter = finding.relatedEvents.map((evt) => ['id', evt.id].join(':')).join(' ');
+      const rawRelatedEvents = finding.relatedEvents as unknown as RawEventData[];
+      state.traceFilter = rawRelatedEvents.map((evt) => ['id', evt.id].join(':')).join(' ');
     }
 
     const uri = vscode.Uri.file(filePath);

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -109,7 +109,7 @@ class RuleTreeItem extends vscode.TreeItem {
   }
 }
 
-class FindingTreeItem extends vscode.TreeItem {
+export class FindingTreeItem extends vscode.TreeItem {
   constructor(public ruleTreeItem: RuleTreeItem, public finding: ResolvedFinding) {
     super(FindingTreeItem.label(finding));
 

--- a/src/types/rawEvent.ts
+++ b/src/types/rawEvent.ts
@@ -1,0 +1,98 @@
+/**
+ * RawEventData represents the actual JSON structure of events as stored in AppMap files
+ * and returned from the scanner. These use snake_case naming (from Ruby/Python origins),
+ * unlike the Event class from @appland/models which uses camelCase.
+ *
+ * Note: The Finding interface from @appland/scanner incorrectly types some fields as Event
+ * when they are actually raw JSON objects. This type provides the correct structure.
+ */
+
+export interface RawHttpServerRequest {
+  readonly request_method: string;
+  readonly path_info: string;
+  readonly normalized_path_info?: string;
+  readonly protocol?: string;
+  readonly headers?: Record<string, string>;
+}
+
+export interface RawHttpServerResponse {
+  readonly status: number;
+  readonly headers?: Record<string, string>;
+}
+
+export interface RawHttpClientRequest {
+  readonly request_method: string;
+  readonly url: string;
+  readonly headers?: Record<string, string>;
+}
+
+export interface RawHttpClientResponse {
+  readonly status: number;
+  readonly headers?: Record<string, string>;
+}
+
+export interface RawSqlQuery {
+  readonly database_type: string;
+  readonly sql: string;
+  readonly explain_sql?: string;
+  readonly server_version?: string;
+}
+
+export interface RawParameterObject {
+  readonly name?: string;
+  readonly class: string;
+  readonly value?: string;
+  readonly size?: number;
+}
+
+export interface RawExceptionObject {
+  readonly class: string;
+  readonly message: string;
+  readonly path?: string;
+  readonly lineno?: number;
+}
+
+export interface RawReturnValue {
+  readonly class: string;
+  readonly value?: string;
+  readonly size?: number;
+}
+
+/**
+ * Raw event data structure as it appears in AppMap JSON files.
+ * This is what Finding.participatingEvents, Finding.event, Finding.scope,
+ * and Finding.relatedEvents actually contain (despite being typed as Event).
+ */
+export interface RawEventData {
+  readonly id: number;
+  readonly event?: 'call' | 'return';
+  readonly thread_id?: number;
+  readonly parent_id?: number;
+  readonly elapsed?: number;
+
+  // HTTP request/response
+  readonly http_server_request?: RawHttpServerRequest;
+  readonly http_server_response?: RawHttpServerResponse;
+  readonly http_client_request?: RawHttpClientRequest;
+  readonly http_client_response?: RawHttpClientResponse;
+
+  // SQL query
+  readonly sql_query?: RawSqlQuery;
+
+  // Method/function info
+  readonly defined_class?: string;
+  readonly method_id?: string;
+  readonly path?: string;
+  readonly lineno?: number;
+  readonly static?: boolean;
+
+  // Parameters and return values
+  readonly parameters?: RawParameterObject[];
+  readonly receiver?: RawParameterObject;
+  readonly return_value?: RawReturnValue;
+  readonly exceptions?: RawExceptionObject[];
+  readonly message?: RawParameterObject[];
+
+  // Metadata
+  readonly labels?: string[];
+}

--- a/test/integration/sequenceDiagram/compareSequenceDiagrams.test.ts
+++ b/test/integration/sequenceDiagram/compareSequenceDiagrams.test.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { SinonSandbox, createSandbox } from 'sinon';
 import { initializeWorkspace, waitForExtension, waitFor } from '../util';
 import { EXPAND_PACKAGES_TITLE, PACKAGES_TITLE } from '../../../src/lib/sequenceDiagram';
-import { AppMapQuickPickItem } from '../../../src/lib/AppMapQuickPickItem';
 import { join } from 'path';
 import assert from 'assert';
 import { fileExists } from '../../../src/util';
@@ -34,9 +33,9 @@ describe('Compare sequence diagram', () => {
 
     const quickPick = sinon.stub(vscode.window, 'showQuickPick');
     quickPick.onFirstCall().resolves({
-      resourceUri: baseUri,
       label: 'Microposts_controller_can_get_microposts_as_JSON',
-    } as AppMapQuickPickItem);
+      detail: baseUri.fsPath,
+    } as vscode.QuickPickItem);
 
     const inputBox = sinon.stub(vscode.window, 'showInputBox');
 
@@ -50,9 +49,9 @@ describe('Compare sequence diagram', () => {
       .calledWith(sinon.match({ title: EXPAND_PACKAGES_TITLE }));
 
     quickPick.onSecondCall().resolves({
-      resourceUri: headUri,
       label: 'Microposts_interface_micropost_interface',
-    } as AppMapQuickPickItem);
+      detail: headUri.fsPath,
+    } as vscode.QuickPickItem);
 
     const openExternal = sinon.stub(vscode.env, 'openExternal');
 

--- a/test/integration/sequenceDiagram/sequenceDiagram.test.ts
+++ b/test/integration/sequenceDiagram/sequenceDiagram.test.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { SinonSandbox, createSandbox } from 'sinon';
 import { initializeWorkspace, waitForExtension, waitFor } from '../util';
 import { EXPAND_PACKAGES_TITLE, PACKAGES_TITLE } from '../../../src/lib/sequenceDiagram';
-import { AppMapQuickPickItem } from '../../../src/lib/AppMapQuickPickItem';
 import { join } from 'path';
 import assert from 'assert';
 import { fileExists } from '../../../src/util';
@@ -27,9 +26,9 @@ describe('Sequence diagram', () => {
     );
 
     sinon.stub(vscode.window, 'showQuickPick').resolves({
-      resourceUri: appmapUri,
       label: 'Microposts_interface micropost interface',
-    } as AppMapQuickPickItem);
+      detail: appmapUri.fsPath,
+    } as vscode.QuickPickItem);
 
     const inputBox = sinon.stub(vscode.window, 'showInputBox');
 


### PR DESCRIPTION
Adds an inline markdown icon to finding rows that opens a comprehensive finding report as a   
markdown preview with clickable file links.

Intended usage:
- Paste into an AI Assistant to fix the problem.
                                                                                              
Key features:                                                                                 
- Opens finding synopsis as markdown preview with workspace-relative clickable links          
- Shows complete rule context (ID, description, documentation)                                
- Includes stack trace, SQL queries, and participating events without truncation              
- Automatic line number validation (strips invalid values)                                    
                                                                                              
Technical:                                                                                    
- Created RawEventData type definitions for proper typing of snake_case event data            
- Fixed type mismatches in Finding interface fields 

# Example

<img width="618" height="145" alt="Screenshot 2026-01-15 at 2 41 55 PM" src="https://github.com/user-attachments/assets/7b81b15e-919d-40bc-ad7f-beb2b36d11e9" />

# N plus 1 SQL query

This AppMap matches the following analysis rule: `n-plus-one-query`

Finds occurrences of a query being repeated within a loop.

**Impact Domain**: Performance | **Occurrences**: 8

## Finding Details
```
<templates>/UsersKgilpinSourceLandOfAppsDjangoOscar_Issue2484SrcOscarTemplatesOscarCatalogueBrowseHtml#render[218]
contains 8 occurrences of SQL: SELECT "partner_stockrecord"."id",
"partner_stockrecord"."product_id", "partner_stockrecord"."partner_id",
"partner_stockrecord"."partner_sku", "partner_stockrecord"."price_currency",
"partner_stockrecord"."price", "partner_stockrecord"."num_in_stock",
"partner_stockrecord"."num_allocated", "partner_stockrecord"."low_stock_threshold",
"partner_stockrecord"."date_created", "partner_stockrecord"."date_updated" FROM
"partner_stockrecord" WHERE "partner_stockrecord"."product_id" = ? LIMIT ?
```

## Group Summary
```
SELECT "partner_stockrecord"."id", "partner_stockrecord"."product_id",
"partner_stockrecord"."partner_id", "partner_stockrecord"."partner_sku",
"partner_stockrecord"."price_currency", "partner_stockrecord"."price",
"partner_stockrecord"."num_in_stock", "partner_stockrecord"."num_allocated",
"partner_stockrecord"."low_stock_threshold", "partner_stockrecord"."date_created",
"partner_stockrecord"."date_updated" FROM "partner_stockrecord" WHERE
"partner_stockrecord"."product_id" = ? LIMIT ?
```

## Source Location
[src/oscar/apps/partner/strategy.py:199](src/oscar/apps/partner/strategy.py#L199)

## Stack Trace
- [src/oscar/apps/partner/strategy.py:200](src/oscar/apps/partner/strategy.py#L200)
- [src/oscar/apps/partner/strategy.py:152](src/oscar/apps/partner/strategy.py#L152)
- [src/oscar/apps/partner/strategy.py:135](src/oscar/apps/partner/strategy.py#L135)

## Code Event Context
- **commonAncestor**: <templates>.UsersKgilpinSourceLandOfAppsDjangoOscar_Issue2484SrcOscarTemplatesOscarCatalogueBrowseHtml#render

## AppMap
[tmp/appmap/requests/1767987869_01673_http_127_0_0_1_8000_en-gb_catalogue_.appmap.json](tmp/appmap/requests/1767987869_01673_http_127_0_0_1_8000_en-gb_catalogue_.appmap.json)

## References
- https://appland.com/docs/analysis/rules-reference.html#n-plus-one-query
- [CWE-1073](https://cwe.mitre.org/data/definitions/1073.html)
