### PR TITLE
Fixes for model configuration

### DIFF
--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -295,7 +295,11 @@ export default class RpcProcessService implements Disposable {
     }
 
     if (change.env) {
-      const env = vscode.workspace.getConfiguration('appMap').get('commandLineEnvironment', {});
+      // we need to clone the returned object because it's
+      // a proxy and we can't delete properties from it directly
+      const env = {
+        ...vscode.workspace.getConfiguration('appMap').get('commandLineEnvironment', {}),
+      };
       let envChanged = false;
       Object.entries(change.env).forEach(([k, v]) => {
         if (env[k] !== v) {
@@ -311,6 +315,8 @@ export default class RpcProcessService implements Disposable {
         await vscode.workspace
           .getConfiguration('appMap')
           .update('commandLineEnvironment', env, true);
+        // note that the RPC server will be restarted in response to the configuration
+        // change event, so we don't need to trigger it manually here
       }
     }
 

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -287,10 +287,8 @@ export default class ChatSearchWebview {
 
         case 'change-model-config': {
           const { key, value, secret } = message;
-          if (secret) {
-            const options = secret ? { secretEnv: { [key]: value } } : { env: { [key]: value } };
-            this.rpcService.updateEnv(options);
-          }
+          const options = secret ? { secretEnv: { [key]: value } } : { env: { [key]: value } };
+          await this.rpcService.updateEnv(options);
           break;
         }
 

--- a/test/mocks/mockAppMapCollection.ts
+++ b/test/mocks/mockAppMapCollection.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+
+import type AppMapCollection from '../../src/services/appmapCollection';
+import type AppMapLoader from '../../src/services/appmapLoader';
+
+import EventEmitter from '../unit/mock/vscode/EventEmitter';
+
+export default class MockAppMapCollection implements AppMapCollection {
+  public readonly _onUpdated = new EventEmitter<vscode.WorkspaceFolder | undefined>();
+  public readonly onUpdated = this._onUpdated.event;
+
+  public allAppMaps(): AppMapLoader[] {
+    return [];
+  }
+
+  public appMaps(): AppMapLoader[] {
+    return [];
+  }
+
+  public allAppMapsForWorkspaceFolder(): AppMapLoader[] {
+    return [];
+  }
+
+  public has(): boolean {
+    return false;
+  }
+
+  public remove(): void {
+    // no-op
+  }
+
+  public clear(): void {
+    // no-op
+  }
+}

--- a/test/mocks/mockAppMapLoader.ts
+++ b/test/mocks/mockAppMapLoader.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+import type { AppMap } from '@appland/models';
+
+import type AppMapLoader from '../../src/services/appmapLoader';
+import type { AppMapDescriptor } from '../../src/services/appmapLoader';
+
+export default class MockAppMapLoader implements AppMapLoader {
+  public descriptor: AppMapDescriptor;
+
+  constructor(descriptor: Partial<AppMapDescriptor> = {}) {
+    this.descriptor = {
+      resourceUri: vscode.Uri.file('/mock/path/mock.appmap.json'),
+      timestamp: Date.now(),
+      ...descriptor,
+    };
+  }
+
+  async loadAppMap(): Promise<AppMap> {
+    return {} as AppMap;
+  }
+}

--- a/test/unit/lib/deleteAppMap.test.ts
+++ b/test/unit/lib/deleteAppMap.test.ts
@@ -1,12 +1,16 @@
+import '../mock/vscode';
+
 import { default as chai, expect } from 'chai';
 import { default as chaiFs } from 'chai-fs';
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { randomUUID } from 'crypto';
-import '../mock/vscode';
-import { promises as fs } from 'fs';
-import type AppMapCollection from '../../../src/services/appmapCollection';
+import sinon from 'sinon';
 import { URI } from 'vscode-uri';
+
+import MockAppMapCollection from '../../mocks/mockAppMapCollection';
+
 import deleteAppMap from '../../../src/lib/deleteAppMap';
 
 chai.use(chaiFs);
@@ -15,8 +19,10 @@ describe('deleteAppMap', () => {
   let tmpDir: string;
   let indexDir: string;
   let appMapUri: URI;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(async () => {
+    sandbox = sinon.createSandbox();
     tmpDir = path.join(tmpdir(), randomUUID());
     indexDir = path.join(tmpDir, 'test');
     appMapUri = URI.file(path.join(tmpDir, 'test.appmap.json'));
@@ -25,13 +31,15 @@ describe('deleteAppMap', () => {
     await fs.writeFile(appMapUri.fsPath, '{}');
   });
 
-  afterEach(() => fs.rm(tmpDir, { recursive: true, force: true }));
+  afterEach(async () => {
+    sandbox.restore();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
 
   it('retains the index directory if the AppMap is already known to the collection', async () => {
-    const mockCollection = {
-      has: () => true,
-      remove: () => true,
-    } as unknown as AppMapCollection;
+    const mockCollection = new MockAppMapCollection();
+    sandbox.stub(mockCollection, 'has').returns(true);
+    sandbox.stub(mockCollection, 'remove').returns();
 
     await deleteAppMap(appMapUri, mockCollection);
 
@@ -40,10 +48,9 @@ describe('deleteAppMap', () => {
   });
 
   it('deletes the index directory if the AppMap has not yet been acknowledged by the collection', async () => {
-    const mockCollection = {
-      has: () => false,
-      remove: () => true,
-    } as unknown as AppMapCollection;
+    const mockCollection = new MockAppMapCollection();
+    sandbox.stub(mockCollection, 'has').returns(false);
+    sandbox.stub(mockCollection, 'remove').returns();
 
     await deleteAppMap(appMapUri, mockCollection);
 

--- a/test/unit/lib/deleteFolderAppMaps.test.ts
+++ b/test/unit/lib/deleteFolderAppMaps.test.ts
@@ -1,16 +1,19 @@
+import MockVSCode from '../mock/vscode';
+
 import { default as chai, expect } from 'chai';
 import { default as chaiFs } from 'chai-fs';
-import sinonChai from 'sinon-chai';
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { randomUUID } from 'crypto';
-import '../mock/vscode';
-import { promises as fs } from 'fs';
-import type AppMapCollection from '../../../src/services/appmapCollection';
-import { URI } from 'vscode-uri';
-import deleteFolderAppMaps from '../../../src/lib/deleteFolderAppMaps';
 import Sinon from 'sinon';
-import MockVSCode from '../mock/vscode';
+import sinonChai from 'sinon-chai';
+import { URI } from 'vscode-uri';
+
+import deleteFolderAppMaps from '../../../src/lib/deleteFolderAppMaps';
+
+import MockAppMapCollection from '../../mocks/mockAppMapCollection';
+import MockAppMapLoader from '../../mocks/mockAppMapLoader';
 
 chai.use(chaiFs);
 chai.use(sinonChai);
@@ -21,7 +24,7 @@ describe('deleteFolderAppMaps', () => {
   let indexDir: string;
   let appMapUri: URI;
   let sandbox: Sinon.SinonSandbox;
-  let mockCollection: AppMapCollection;
+  let mockCollection: MockAppMapCollection;
 
   beforeEach(async () => {
     sandbox = Sinon.createSandbox();
@@ -29,11 +32,12 @@ describe('deleteFolderAppMaps', () => {
     projectDir = path.join(tmpdir(), projectName);
     indexDir = path.join(projectDir, 'test');
     appMapUri = URI.file(path.join(projectDir, 'test.appmap.json'));
-    mockCollection = {
-      appMaps: () => [{ descriptor: { resourceUri: appMapUri } }],
-      has: () => true,
-      remove: () => true,
-    } as unknown as AppMapCollection;
+    mockCollection = new MockAppMapCollection();
+    sandbox
+      .stub(mockCollection, 'appMaps')
+      .returns([new MockAppMapLoader({ resourceUri: appMapUri })]);
+    sandbox.stub(mockCollection, 'has').returns(true);
+    sandbox.stub(mockCollection, 'remove').returns();
 
     await fs.mkdir(indexDir, { recursive: true });
     await fs.writeFile(appMapUri.fsPath, '{}');

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -15,7 +15,7 @@ import * as extensions from './extensions';
 import * as lm from './lm';
 import { URI, Utils } from 'vscode-uri';
 import workspace from './workspace';
-import window from './window';
+import { default as window, ViewColumn } from './window';
 import commands from './commands';
 import * as env from './env';
 import * as authentication from './authentication';
@@ -56,6 +56,7 @@ const MockVSCode = {
     constructor(public id: string) {}
   },
   QuickPickItemKind,
+  ViewColumn,
   Selection,
   CodeAction,
   CodeActionKind,

--- a/test/unit/mock/vscode/window.ts
+++ b/test/unit/mock/vscode/window.ts
@@ -35,6 +35,26 @@ function withProgress<R>(
   );
 }
 
+export enum ViewColumn {
+  Active = -1,
+  Beside = -2,
+  One = 1,
+  Two = 2,
+  Three = 3,
+  Four = 4,
+  Five = 5,
+  Six = 6,
+  Seven = 7,
+  Eight = 8,
+  Nine = 9,
+}
+
+export interface MockWebviewPanel extends vscode.WebviewPanel {
+  receiveMessage(message: unknown): void;
+}
+
+export const WebviewPanels: MockWebviewPanel[] = [];
+
 export default {
   createStatusBarItem() {
     return {
@@ -61,6 +81,38 @@ export default {
     show: doNothing,
     dispose: doNothing,
   }),
+  createWebviewPanel: (
+    viewType: string,
+    title: string,
+    showOptions: ViewColumn | { preserveFocus?: boolean; viewColumn: ViewColumn },
+    options?: vscode.WebviewPanelOptions & vscode.WebviewOptions
+  ): vscode.WebviewPanel => {
+    const onDidReceiveMessage = new EventEmitter<unknown>();
+    const viewColumn = typeof showOptions === 'number' ? showOptions : showOptions.viewColumn;
+    const panel: MockWebviewPanel = {
+      viewType,
+      title,
+      visible: true,
+      active: true,
+      viewColumn,
+      options: options || {},
+      webview: {
+        html: '',
+        options: options || {},
+        onDidReceiveMessage: onDidReceiveMessage.event,
+        postMessage: async () => false,
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        cspSource: 'mock-csp-source',
+      },
+      onDidChangeViewState: new EventEmitter<vscode.WebviewPanelOnDidChangeViewStateEvent>().event,
+      onDidDispose: new EventEmitter<void>().event,
+      dispose: doNothing,
+      reveal: doNothing,
+      receiveMessage: (msg: unknown) => onDidReceiveMessage.fire(msg),
+    };
+    WebviewPanels.push(panel);
+    return panel;
+  },
   createTerminal(options: vscode.TerminalOptions = { cwd: cwd() }) {
     return new Terminal(options);
   },

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -37,7 +37,13 @@ export const EVENTS = {
 
 export class Configuration extends Map<string, unknown> {
   get(key: string, defaultValue?: unknown): unknown {
-    return super.get(key) ?? defaultValue;
+    const value = super.get(key) ?? defaultValue;
+    // Simulate VS Code's proxy-backed configuration objects, which do not support
+    // property deletion (attempting to do so throws a TypeError at runtime).
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return Object.freeze({ ...value });
+    }
+    return value;
   }
 
   inspect(key: string): { workspaceValue?: unknown } | undefined {

--- a/test/unit/services/chatSearchData.test.ts
+++ b/test/unit/services/chatSearchData.test.ts
@@ -4,37 +4,29 @@ import Sinon from 'sinon';
 import '../mock/vscode';
 import * as vscode from 'vscode';
 
-import AppMapCollection from '../../../src/services/appmapCollection';
-import RpcProcessService from '../../../src/services/rpcProcessService';
-import ChatSearchDataService, { LatestAppMap } from '../../../src/services/chatSearchDataService';
+import MockAppMapCollection from '../../mocks/mockAppMapCollection';
+import MockAppMapLoader from '../../mocks/mockAppMapLoader';
 
-type AppMapListener = (appmaps: LatestAppMap[]) => void;
+import RpcProcessService from '../../../src/services/rpcProcessService';
+import ChatSearchDataService from '../../../src/services/chatSearchDataService';
 
 describe('ChatSearchData', () => {
   let sinon: Sinon.SinonSandbox;
   let chatSearchData: ChatSearchDataService;
   let port: Sinon.SinonStub;
-  let onUpdatedStub: Sinon.SinonStub;
-  let allAppMapsStub: Sinon.SinonStub;
-  let appmapListeners: Array<AppMapListener>;
-  let appmaps: AppMapCollection;
+  let appmaps: MockAppMapCollection;
 
   beforeEach(async () => {
     sinon = Sinon.createSandbox();
-    port = sinon.stub();
-    appmapListeners = [];
-    onUpdatedStub = sinon.stub().callsFake((listener: AppMapListener) => {
-      appmapListeners.push(listener);
-    });
-    allAppMapsStub = sinon.stub();
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    appmaps = {
-      allAppMaps: allAppMapsStub,
-      onUpdated: onUpdatedStub,
-    } as any;
-    const rpcService: RpcProcessService = { port } as any;
-    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    appmaps = new MockAppMapCollection();
+    const rpcService = sinon.createStubInstance(RpcProcessService);
+    port = rpcService.port;
     chatSearchData = new ChatSearchDataService(rpcService, appmaps);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   describe('when no port is available', () => {
@@ -107,15 +99,16 @@ describe('ChatSearchData', () => {
 
   describe('latestAppMaps', () => {
     // Mock appmaps with timestamps
-    const mockAppMaps = [...Array(20).keys()].map((i) => ({
-      descriptor: {
-        timestamp: Date.now() - i * 1000, // Assure descending order by timestamp
-        metadata: { name: `AppMap ${i}` },
-        resourceUri: { fsPath: `path/to/appmap${i}.json` },
-      },
-    }));
+    const mockAppMaps = [...Array(20).keys()].map(
+      (i) =>
+        new MockAppMapLoader({
+          timestamp: Date.now() - i * 1000, // Assure descending order by timestamp
+          metadata: { name: `AppMap ${i}` },
+          resourceUri: vscode.Uri.file(`path/to/appmap${i}.json`),
+        })
+    );
 
-    beforeEach(() => allAppMapsStub.returns(mockAppMaps));
+    beforeEach(() => sinon.stub(appmaps, 'allAppMaps').returns(mockAppMaps));
 
     it('provides the latest 10 appmaps based on timestamp', async () => {
       const latestAppMaps = chatSearchData.latestAppMaps();
@@ -137,10 +130,7 @@ describe('ChatSearchData', () => {
         });
 
         // Trigger the update
-        expect(appmapListeners).to.have.lengthOf(1);
-        for (const listener of appmapListeners) {
-          listener([sinon.stub() as unknown as LatestAppMap]);
-        }
+        appmaps._onUpdated.fire(undefined);
       });
     });
   });

--- a/test/unit/webviews/chatSearchWebview.test.ts
+++ b/test/unit/webviews/chatSearchWebview.test.ts
@@ -1,0 +1,100 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import CommandRegistry from '../../../src/commands/commandRegistry';
+import ExtensionState from '../../../src/configuration/extensionState';
+import RpcProcessService from '../../../src/services/rpcProcessService';
+import ChatSearchWebview from '../../../src/webviews/chatSearchWebview';
+
+import MockAppMapCollection from '../../mocks/mockAppMapCollection';
+import MockExtensionContext from '../../mocks/mockExtensionContext';
+import EventEmitter from '../mock/vscode/EventEmitter';
+import { WebviewPanels } from '../mock/vscode/window';
+
+function createMockRpcService(
+  sandbox: sinon.SinonSandbox
+): sinon.SinonStubbedInstance<RpcProcessService> {
+  const rpcService = sandbox.createStubInstance(RpcProcessService);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- readonly property
+  (rpcService as any).onRpcPortChange = new EventEmitter().event;
+  sandbox.stub(rpcService, 'onBeforeRestart').get(() => new EventEmitter().event);
+  rpcService.port.returns(8080);
+
+  return rpcService;
+}
+
+describe('ChatSearchWebview', () => {
+  let sandbox: sinon.SinonSandbox;
+  let context: MockExtensionContext;
+  let extensionState: sinon.SinonStubbedInstance<ExtensionState>;
+  let appmaps: MockAppMapCollection;
+  let rpcService: sinon.SinonStubbedInstance<RpcProcessService>;
+  let chatSearchWebview: ChatSearchWebview;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    context = new MockExtensionContext();
+    CommandRegistry.setContext(context);
+    extensionState = sandbox.createStubInstance(ExtensionState);
+
+    appmaps = new MockAppMapCollection();
+    rpcService = createMockRpcService(sandbox);
+
+    chatSearchWebview = ChatSearchWebview.register(
+      context,
+      extensionState as unknown as ExtensionState,
+      appmaps,
+      rpcService as unknown as RpcProcessService
+    );
+
+    // Clear out any previous mock panels
+    WebviewPanels.length = 0;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should process change-model-config for non-secret env variables', async () => {
+    await chatSearchWebview.explain();
+
+    // The panel should have been created and added to the mocked WebviewPanels array
+    expect(WebviewPanels).to.have.lengthOf(1);
+    const panel = WebviewPanels[0];
+
+    // Simulate sending a message from the webview
+    panel.receiveMessage({
+      command: 'change-model-config',
+      key: 'MODEL_NAME',
+      value: 'gpt-4',
+      secret: false,
+    });
+
+    expect(rpcService.updateEnv.calledOnce).to.be.true;
+    expect(rpcService.updateEnv.firstCall.args[0]).to.deep.equal({
+      env: { MODEL_NAME: 'gpt-4' },
+    });
+  });
+
+  it('should process change-model-config for secret env variables', async () => {
+    await chatSearchWebview.explain();
+
+    expect(WebviewPanels).to.have.lengthOf(1);
+    const panel = WebviewPanels[0];
+
+    panel.receiveMessage({
+      command: 'change-model-config',
+      key: 'API_KEY',
+      value: 'secret_token',
+      secret: true,
+    });
+
+    expect(rpcService.updateEnv.calledOnce).to.be.true;
+    expect(rpcService.updateEnv.firstCall.args[0]).to.deep.equal({
+      secretEnv: { API_KEY: 'secret_token' },
+    });
+  });
+});


### PR DESCRIPTION
This fixes the issue where updating OpenAI API base URL through the 'gear' icon in UI was impossible — the changes were simply ignored. Looking into this exposed two bugs:
- the model config change webview event handler for some reason only dispatched configuration update when a _secret_ setting (such as an API key) was updated;
- fixing the above revealed that deleting environment variables (such as when the user would like to go back to the default OpenAI endpoint) didn't work due to how configuration objects returned by VSCode behave.

To manually test this change, simply open the gear icon and try setting OpenAI base URL; observe that it's updated in the environment variables setting in configuration and that AppMap RPC is restarted. Then, open the gear icon again, clear the override; observe that the variable is gone from the setting and the RPC server is restarted again.