### PR TITLE
fix: avoid exposing proxy credentials in telemetry

### DIFF
--- a/src/telemetry/definitions/events.ts
+++ b/src/telemetry/definitions/events.ts
@@ -26,7 +26,6 @@ export const PROJECT_OPEN = new Event({
     Properties.PROJECT_PATH,
     Properties.VERSION_CONTROL_REPOSITORY,
     Properties.PROXY_ENABLED,
-    Properties.PROXY_SETTINGS,
   ],
   metrics: [Metrics.NUM_WORKSPACE_FOLDERS],
 });

--- a/src/telemetry/definitions/properties.ts
+++ b/src/telemetry/definitions/properties.ts
@@ -67,14 +67,7 @@ export const PROXY_ENABLED = new TelemetryDataProvider({
   id: 'appmap.proxy.enabled',
   async value() {
     const settings = proxySettings();
-    return String(settings.http_proxy || settings.https_proxy);
-  },
-});
-
-export const PROXY_SETTINGS = new TelemetryDataProvider({
-  id: 'appmap.proxy_settings',
-  async value() {
-    return JSON.stringify(proxySettings());
+    return String(!!(settings.http_proxy || settings.https_proxy));
   },
 });
 


### PR DESCRIPTION
Proxy URLs configured via VSCode settings or environment variables can
contain embedded passwords (e.g. http://user:pass@proxy:3128).
appmap.proxy.enabled now reports a boolean instead of the raw URL, and
appmap.proxy_settings has been dropped entirely since the boolean is
sufficient for troubleshooting.

https://claude.ai/code/session_01Nsx9G88oNSFcyzqwtnHwFe