### PR TITLE
Reposition Marketplace listing around runtime data and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ People see the map. Agents query the trace. One run, same ground truth.
 
 ## Why developers use it
 
-- **Review behavior, not just diffs.** See what an AI-generated change actually did at runtime
-  before you open the PR.
+- **A visual check on your AI's work.** On complex changes the diff outgrows what anyone can hold
+  in their head. AppMap shows what the change actually did at runtime, so your approval rests on
+  evidence, not on the AI's own explanation.
 - **Debug in one query, not fifteen greps.** The request path, the SQL, and the exception are one
   trace away, for you and your agent.
 - **Give your agent ground truth.** Answers from real execution over MCP, not guesses from static

--- a/README.md
+++ b/README.md
@@ -3,130 +3,81 @@
 
 # AppMap for Visual Studio Code
 
-### Runtime‑aware AI starts here
+## Runtime-aware AI starts here
 
-#### **Live code behavior, surfaced to your AI tools in Visual Studio Code**
+**Live code behavior, for your eyes and your AI tools, in Visual Studio Code.**
 
-AppMap Navie for Visual Studio Code brings the power of real-time execution data and AI-driven
-insights right to your code editor. No more guessing what your code does under the hood. Navie
-watches your application run and uses that live context to provide **smarter suggestions**, **faster
-debugging**, and **runtime-aware code reviews**.
+AppMap records how your application actually runs, with zero code changes. It turns every run into
+interactive sequence diagrams, dependency maps, flame graphs, and trace views you can read, and
+makes the same runtime data available to any AI coding agent through the Model Context Protocol
+(MCP). GitHub Copilot, Claude, Cursor, and any other MCP-capable agent can query real execution
+traces instead of guessing from static code.
 
-## Key Benefits
+People see the map. Agents query the trace. One run, same ground truth.
 
-### Smarter AI assistance
+![AppMap diagrams of a recorded test run in Visual Studio Code](https://github.com/getappmap/vscode-appland/blob/master/images/walkthrough/record-appmaps.png?raw=true)
 
-Navie combines static analysis with live AppMap traces, so you can ask things like _"What just
-happened?"_ and get answers based on the actual runtime flow, HTTP calls, SQL queries, exceptions,
-I/O, and more.
+## Works with any AI coding agent via MCP
 
-### Faster debugging & fewer defects
+AppMap includes an MCP server that exposes your recorded runtime data as read-only query tools. Any
+MCP-capable coding agent can connect and ask how your application actually ran. Which endpoints are
+slow. Where time is spent. What SQL was issued. What exceptions occurred. How a single request
+executed end to end.
 
-Pinpoint performance bottlenecks and logic errors through automatically generated sequence diagrams,
-flame graphs, dependency maps, and trace views.
+The extension keeps the query index up to date automatically as you record. Point your agent at the
+server and start asking questions.
 
-### Context‑aware code reviews
+Agents can rank function and SQL hotspots, inspect call trees with captured parameters and return
+values, find related recordings, and compare per-route latency between git branches.
 
-From security checks to maintainability recommendations, Navie’s `@review` mode analyzes your
-current branch changes against your base branch with runtime insights.
+Get started:
 
-### Zero fine‑tuning required
+- [Configure the AppMap MCP server for any AI coding agent](https://appmap.io/docs/reference/appmap-mcp.html)
+- [AppMap for Visual Studio Code reference](https://appmap.io/docs/reference/vscode.html)
+- [Record AppMap Data](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html)
 
-Works out-of-the-box with enterprise‑ready LLMs—simply plug in your API key or let Navie default to
-GitHub Copilot or AppMap’s built‑in endpoint.
+## See what your code actually does
 
-![implement-redis](https://github.com/getappmap/vscode-appland/assets/511733/46243179-893e-474c-925a-91b385c3468d)
+- **Sequence diagrams** show the full request path, from HTTP to database, from one recording.
+- **Dependency maps** reveal the running architecture: services, code, SQL, and how they connect.
+- **Flame graphs and trace views** pinpoint performance bottlenecks and logic errors.
+- **Zero effort capture.** AppMap records code execution, data flow, HTTP, SQL, and exceptions
+  automatically as your tests or your app run. No code changes.
 
-## What AppMap Does
+## What AppMap does
 
-- Captures real‑time snapshots of code execution, data flow, and behavior with zero effort and no
+- Captures real-time snapshots of code execution, data flow, and behavior with zero effort and no
   code changes.
-
-- Feeds runtime context to AI assistants like Navie, GitHub Copilot, Anthropic Claude, Google
-  Gemini, OpenAI, and your own local LLMs.
-
-- Delivers deep code explanations, diagrams, implementation plans, tests, and patch-ready code
-  snippets, all grounded in what your application just did.
+- Renders that behavior as interactive diagrams people can inspect in the editor.
+- Feeds the same runtime context to AI assistants over MCP: GitHub Copilot, Anthropic Claude,
+  Cursor, Google Gemini, and your own local LLMs.
+- Grounds explanations, reviews, and fixes in what your application just did, not in guesses from
+  static code.
 
 ## Get started
 
 1. **Install
    [the AppMap extension](https://marketplace.visualstudio.com/items?itemName=appland.appmap)** from
    within the code editor or from the marketplace.
+2. **Sign in with an email address, or with GitHub or GitLab.** Guided setup configures the
+   recording agent for your project (Java, Python, Ruby, Node.js).
+3. **Run your tests or exercise your app.** AppMap Data is recorded automatically, diagrams appear
+   in the editor, and the query index stays fresh for your AI agent.
+4. **Connect your agent** using the
+   [MCP configuration guide](https://appmap.io/docs/reference/appmap-mcp.html).
 
-2. **Sign in with an email address, or with GitHub or GitLab** and Navie will be available in
-   `@explain` mode. This enables Navie to respond to general coding and development questions and
-   answer questions about using AppMap data.
+## Documentation
 
-3. **Ask Navie** for guidance recording AppMap data specific to interactions or code scenarios
-   you're interested in analyzing.
-
-## Chat Modes
-
-Navie provides different modes of interaction for an efficient workflow and optimized results from
-AI-assisted coding.
-
-![Chat Modes](https://github.com/getappmap/vscode-appland/blob/master/images/command-palette-menu.jpg?raw=true)
-
-- **`@explain` (default)**: Navie makes context-aware suggestions, provides specific solutions, and
-  reasons about the larger context of the specific code being worked on.
-
-- **`@plan`**: Navie focuses the AI response on building a detailed implementation plan for the
-  relevant query. This will focus Navie on only understanding the problem and the application to
-  generate a step-by-step plan.
-
-- **`@generate`**: Activate code generation mode by beginning any question with the prefix
-  "@generate". In this mode Navie's response are optimized to include code snippets you can use
-  directly in the files are working on.
-
-- **`@test`**: Navie's responses are optimized for test case creation, such as unit testing or
-  integration testing. This prefix will understand how your tests are currently written and provide
-  updated tests based on features or code that is provided.
-
-- **`@diagram`**: Navie will create and render a Mermaid compatible diagram within the Navie chat
-  window. You can open this diagram in the [Mermaid Live Editor](https://mermaid.live), copy the
-  Mermaid Definitions to your clipboard, save to disk, or expand a full window view.
-
-- **`@search`**: By leveraging smart search capabilities, this command will locate specific code
-  elements, relevant modules, or examples.
-
-- **`@review`**: This command will review the code changes on your current branch and provide
-  actionable insights on various aspects of code, ensuring alignment with best practices in areas
-  such as code quality, security, and maintainability.
-
-- **`@help`**: Activate help mode by beginning any question with the prefix "@help". This mode
-  offers assistance with using AppMap, including guidance for generating and leveraging AppMap data
-  effectively.
-
-## Pinned Context
-
-Pin specific data files to your conversation with Navie to include data sources you know are
-relevant to the issue. This includes pinning the text of the issue itself, and Navie responses.
-
-![Pinned Context](https://github.com/getappmap/vscode-appland/blob/master/images/pinned-context.jpg?raw=true)
-
-## Making AppMap Data
-
-You can improve the quality and accuracy of Navie AI by
-[making AppMap Data for your project](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html).
-
-#### Documentation
-
-Navie is an open-source extension built with enterprise needs in mind, delivering a flexible LLM
-backend that allows organizations to fine-tune their AI solutions at scale. With advanced features
-like customizable token limits, robust automation tools, and seamless integration with existing
-workflows.
-
-For detailed information [visit our documentation](https://appmap.io/docs/appmap-docs.html).
+AppMap is open source and built for enterprise environments: recordings and analysis stay local,
+and the data spec is public. For detailed information
+[visit our documentation](https://appmap.io/docs/appmap-docs.html).
 
 ## Licensing and Security
 
 [Open source MIT license](https://github.com/getappmap/vscode-appland/blob/master/LICENSE) |
 [Terms and conditions](https://appmap.io/community/terms-and-conditions.html)
 
-To learn more about security of AppMap, or the use of data with AI when using Navie, see the AppMap
-[security disclosure](https://appmap.io/security) for more detailed information and discussion.
+To learn more about AppMap security, see the [security disclosure](https://appmap.io/security).
 
-There is [no fee](https://appmap.io/pricing) for personal use of AppMap for graphing and limited
-Navie use. Pricing for premium features and integrations are listed on
-[AppMap’s Pricing Page](https://appmap.io/pricing).
+AppMap is free for every developer and for organizations under 250 employees. Larger organizations
+standardizing on AppMap are supported with a [support contract](https://appmap.io/pricing).

--- a/README.md
+++ b/README.md
@@ -46,27 +46,27 @@ Get started:
 
 ## Ways to use AppMap with your AI
 
-- **Explain unfamiliar code.** Ask your agent how a feature actually works. It answers from recorded
-  requests, SQL, and call trees instead of guessing from file names.
-- **Diagnose bugs in one query.** A single call tree query returns the diagnosis-bearing frames,
-  with captured parameters and return values, that a static agent reconstructs with about fifteen
-  grep-and-read calls.
-- **Review changes against reality.** Record the same flows on your base branch and your PR branch,
-  then compare: sequence diagram diffs and compare reports show what the change actually did,
-  including side effects the code diff never showed.
-- **Scan for behavioral defects.** AppMap's built-in code scanners are a behavioral check for
-  structural code quality defects, the kind static analysis misses and AIs reading source cannot
-  see: N+1 queries, missing authentication, secrets in logs, slow queries. Findings appear right in
-  the editor.
-- **Document APIs from behavior.** Generate OpenAPI definitions from observed HTTP traffic instead
-  of hand-written annotations.
+- **Explain unfamiliar code.** Ask your agent how a feature works. It answers from recorded
+  requests, SQL queries, and call trees.
+- **Diagnose bugs.** A call tree query returns the executed frames for the flow under
+  investigation, with captured parameters and return values.
+- **Compare before and after.** Record the same flows on your base branch and your PR branch;
+  sequence diagram diffs and compare reports show extra calls, changed SQL, and new downstream
+  dependencies.
+- **Scan for behavioral defects.** The built-in code scanners check recorded behavior for
+  structural code quality defects, as distinct from static defects: N+1 queries, missing
+  authentication, secrets in logs, slow queries. Findings appear in the editor.
+- **Generate OpenAPI definitions** from observed HTTP traffic.
 
-### What runtime context is worth
+### The cost, measured
 
-In a controlled AppMap study (June 2026), an agent with trace access held 100% diagnostic accuracy
-under a tight tool-call budget, while the static-context agent fell from 91% to 28% as the budget
-tightened. Pairing a compact model with trace data delivered near-frontier accuracy at about half
-the cost. And recording costs zero model tokens: the running application produces the data.
+A controlled AppMap study (June 2026) compared trace-augmented and static agents on the same bugs
+and the same models. The trace-augmented agent held 100% diagnostic accuracy as the tool-call
+budget tightened to three calls; the static agent fell from 91% to 28%. One call tree query
+returned the frames that the static agent reconstructed with about fifteen file-reading calls. A
+compact model paired with trace data reached 88% verified fixes at $0.57 per fix; a frontier model
+without traces reached 95% at $1.16. Recording a trace consumes no model tokens; the running
+application produces it.
 
 ## See what your code actually does
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 **Live code behavior, for your eyes and your AI tools, in Visual Studio Code.**
 
 AppMap records how your application actually runs, with zero code changes. Every run becomes
-interactive sequence diagrams, dependency maps, flame graphs, and trace views. The same runtime
-data is available to any AI coding agent through the Model Context Protocol (MCP). GitHub Copilot,
+interactive sequence diagrams, dependency maps, flame graphs, and trace views. The same runtime data
+is available to any AI coding agent through the Model Context Protocol (MCP). GitHub Copilot,
 Claude, Cursor, and any other MCP-capable agent can query real execution traces instead of guessing
 from static code.
 
@@ -17,8 +17,8 @@ People see the map. Agents query the trace. One run, same ground truth.
 
 ## Why developers use it
 
-- **A visual check on your AI's work.** On complex changes the diff outgrows what anyone can hold
-  in their head. AppMap shows what the change actually did at runtime, so your approval rests on
+- **A visual check on your AI's work.** On complex changes the diff outgrows what anyone can hold in
+  their head. AppMap shows what the change actually did at runtime, so your approval rests on
   evidence, not on the AI's own explanation.
 - **Debug in one query, not fifteen greps.** The request path, the SQL, and the exception are one
   trace away, for you and your agent.
@@ -43,6 +43,30 @@ Get started:
 - [Configure the AppMap MCP server for any AI coding agent](https://appmap.io/docs/reference/appmap-mcp.html)
 - [AppMap for Visual Studio Code reference](https://appmap.io/docs/reference/vscode.html)
 - [Record AppMap Data](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html)
+
+## Ways to use AppMap with your AI
+
+- **Explain unfamiliar code.** Ask your agent how a feature actually works. It answers from recorded
+  requests, SQL, and call trees instead of guessing from file names.
+- **Diagnose bugs in one query.** A single call tree query returns the diagnosis-bearing frames,
+  with captured parameters and return values, that a static agent reconstructs with about fifteen
+  grep-and-read calls.
+- **Review changes against reality.** Record the same flows on your base branch and your PR branch,
+  then compare: sequence diagram diffs and compare reports show what the change actually did,
+  including side effects the code diff never showed.
+- **Scan for behavioral defects.** AppMap's built-in code scanners are a behavioral check for
+  structural code quality defects, the kind static analysis misses and AIs reading source cannot
+  see: N+1 queries, missing authentication, secrets in logs, slow queries. Findings appear right in
+  the editor.
+- **Document APIs from behavior.** Generate OpenAPI definitions from observed HTTP traffic instead
+  of hand-written annotations.
+
+### What runtime context is worth
+
+In a controlled AppMap study (June 2026), an agent with trace access held 100% diagnostic accuracy
+under a tight tool-call budget, while the static-context agent fell from 91% to 28% as the budget
+tightened. Pairing a compact model with trace data delivered near-frontier accuracy at about half
+the cost. And recording costs zero model tokens: the running application produces the data.
 
 ## See what your code actually does
 
@@ -78,8 +102,8 @@ Get started:
 
 ## Documentation
 
-AppMap is open source and built for enterprise environments: recordings and analysis stay local,
-and the data spec is public. For detailed information
+AppMap is open source and built for enterprise environments: recordings and analysis stay local, and
+the data spec is public. For detailed information
 [visit our documentation](https://appmap.io/docs/appmap-docs.html).
 
 ## Licensing and Security

--- a/README.md
+++ b/README.md
@@ -48,25 +48,25 @@ Get started:
 
 - **Explain unfamiliar code.** Ask your agent how a feature works. It answers from recorded
   requests, SQL queries, and call trees.
-- **Diagnose bugs.** A call tree query returns the executed frames for the flow under
-  investigation, with captured parameters and return values.
+- **Diagnose bugs.** A call tree query returns the executed frames for the flow under investigation,
+  with captured parameters and return values.
 - **Compare before and after.** Record the same flows on your base branch and your PR branch;
   sequence diagram diffs and compare reports show extra calls, changed SQL, and new downstream
   dependencies.
-- **Scan for behavioral defects.** The built-in code scanners check recorded behavior for
-  structural code quality defects, as distinct from static defects: N+1 queries, missing
-  authentication, secrets in logs, slow queries. Findings appear in the editor.
+- **Scan for behavioral defects.** The built-in code scanners check recorded behavior for structural
+  code quality defects, as distinct from static defects: N+1 queries, missing authentication,
+  secrets in logs, slow queries. Findings appear in the editor.
 - **Generate OpenAPI definitions** from observed HTTP traffic.
 
 ### The cost, measured
 
 A controlled AppMap study (June 2026) compared trace-augmented and static agents on the same bugs
-and the same models. The trace-augmented agent held 100% diagnostic accuracy as the tool-call
-budget tightened to three calls; the static agent fell from 91% to 28%. One call tree query
-returned the frames that the static agent reconstructed with about fifteen file-reading calls. A
-compact model paired with trace data reached 88% verified fixes at $0.57 per fix; a frontier model
-without traces reached 95% at $1.16. Recording a trace consumes no model tokens; the running
-application produces it.
+and the same models. The trace-augmented agent held 100% diagnostic accuracy as the tool-call budget
+tightened to three calls; the static agent fell from 91% to 28%. One call tree query returned the
+frames that the static agent reconstructed with about fifteen file-reading calls. A compact model
+paired with trace data reached 88% verified fixes at $0.57 per fix; a frontier model without traces
+reached 95% at $1.16. Recording a trace consumes no model tokens; the running application produces
+it.
 
 ## See what your code actually does
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,22 @@
 
 **Live code behavior, for your eyes and your AI tools, in Visual Studio Code.**
 
-AppMap records how your application actually runs, with zero code changes. It turns every run into
-interactive sequence diagrams, dependency maps, flame graphs, and trace views you can read, and
-makes the same runtime data available to any AI coding agent through the Model Context Protocol
-(MCP). GitHub Copilot, Claude, Cursor, and any other MCP-capable agent can query real execution
-traces instead of guessing from static code.
+AppMap records how your application actually runs, with zero code changes. Every run becomes
+interactive sequence diagrams, dependency maps, flame graphs, and trace views. The same runtime
+data is available to any AI coding agent through the Model Context Protocol (MCP). GitHub Copilot,
+Claude, Cursor, and any other MCP-capable agent can query real execution traces instead of guessing
+from static code.
 
 People see the map. Agents query the trace. One run, same ground truth.
 
-![AppMap diagrams of a recorded test run in Visual Studio Code](https://github.com/getappmap/vscode-appland/blob/master/images/walkthrough/record-appmaps.png?raw=true)
+## Why developers use it
+
+- **Review behavior, not just diffs.** See what an AI-generated change actually did at runtime
+  before you open the PR.
+- **Debug in one query, not fifteen greps.** The request path, the SQL, and the exception are one
+  trace away, for you and your agent.
+- **Give your agent ground truth.** Answers from real execution over MCP, not guesses from static
+  code.
 
 ## Works with any AI coding agent via MCP
 
@@ -37,6 +44,8 @@ Get started:
 - [Record AppMap Data](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html)
 
 ## See what your code actually does
+
+![AppMap diagrams of a recorded test run in Visual Studio Code](https://github.com/getappmap/vscode-appland/blob/master/images/walkthrough/record-appmaps.png?raw=true)
 
 - **Sequence diagrams** show the full request path, from HTTP to database, from one recording.
 - **Dependency maps** reveal the running architecture: services, code, SQL, and how they connect.
@@ -79,5 +88,5 @@ and the data spec is public. For detailed information
 
 To learn more about AppMap security, see the [security disclosure](https://appmap.io/security).
 
-AppMap is free for every developer and for organizations under 250 employees. Larger organizations
-standardizing on AppMap are supported with a [support contract](https://appmap.io/pricing).
+This extension is for individual developers working in the code editor. Check out the
+[pricing page](https://appmap.io/pricing).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "appland",
   "name": "appmap",
   "displayName": "AppMap",
-  "description": "AI-driven chat with a deep understanding of your code. Build effective solutions using an intuitive chat interface and powerful code visualizations.",
+  "description": "Runtime-aware AI starts here. AppMap records how your app actually runs — interactive diagrams for you, and real execution data for any AI coding agent via MCP.",
   "version": "0.142.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "appland",
   "name": "appmap",
   "displayName": "AppMap",
-  "description": "Runtime-aware AI starts here. AppMap records how your app actually runs — interactive diagrams for you, and real execution data for any AI coding agent via MCP.",
+  "description": "Runtime-aware AI starts here. AppMap records how your app actually runs: interactive diagrams for you, and real execution data for any AI coding agent via MCP.",
   "version": "0.142.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rewrites the VS Code Marketplace listing (README.md) and the `package.json` search tagline to the new positioning: recorded runtime behavior serving both interactive diagrams (for people) and MCP query tools (for AI coding agents).

**Rendered preview:** [README.md on this branch](https://github.com/getappmap/vscode-appland/blob/claude/appmap-extension-descriptions-qj4u4t/README.md)

## What changed

- **README.md**: keeps the "Runtime-aware AI starts here" opening and the GitHub/Slack badges; adds the "Why developers use it", "Works with any AI coding agent via MCP", and "Ways to use AppMap with your AI" sections (usage patterns, behavioral code scanners, OpenAPI generation) plus "The cost, measured" (June 2026 controlled-study results); promotes the visual identity into its own "See what your code actually does" section; removes retired assistant branding and the chat-modes catalog (docs remain the home for those commands); replaces the pricing block with the individual-developer scope statement and a pricing page link. No em-dashes in user-facing copy.
- **Images**: the two chat screenshots were dropped with their sections; the hero GIF is replaced by the existing in-repo diagram screenshot `images/walkthrough/record-appmaps.png`, placed under "See what your code actually does". A new capture of an MCP agent calling `get_call_tree` is assigned separately and lands in a follow-up PR; this PR ships text-first.
- **package.json**: search tagline updated from the chat-centric description to match the new positioning.

## Verification gate (resolved)

The bundled-CLI check passed: `appmap query mcp` shipped in `@appland/appmap` v3.200.0, and the `release-manifests` branch of appmap-js currently serves exactly that version — both extensions auto-download the CLI from that manifest, so MCP is already available to existing installs. Per the rewrite doc, this PR is body copy only and the changelog entry is skipped (the CHANGELOG here is semantic-release-generated anyway).

## CI status

Per team guidance, CI is not required for extension doc-only changes. The `unit`, `build-vsix`, and `prepare` jobs pass on this branch. The `integration` failure is pre-existing and unrelated: scanner 1.91.0's `hash_v2` dedup change invalidated the `analysisTree` test expectations repo-wide (see the diagnosis comment below); it needs its own small fix PR and does not block this one.

## Before merging

- Confirm the three docs URLs are live: `/docs/reference/appmap-mcp.html`, `/docs/reference/vscode.html`, and `/docs/get-started-with-appmap/making-appmap-data.html`.
- **This listing and the JetBrains listing (getappmap/appmap-intellij-plugin#953) must be updated in tandem going forward.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ABtRpfafUxEJemZN5wUbN