### PR TITLE
test(analysis): DRY findings-tree tests and support snapshot regeneration

### DIFF
--- a/test/integration/analysisTree/analysisTreeTest.ts
+++ b/test/integration/analysisTree/analysisTreeTest.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import assert from 'assert';
+import { join, sep } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import { performance } from 'perf_hooks';
+import { promisify } from 'util';
+import { glob } from 'glob';
+
+import {
+  withAuthenticatedUser,
+  ProjectSeveralFindings,
+  waitFor,
+  initializeWorkspace,
+  CompactTreeItem,
+  enumerateTree,
+} from '../util';
+import { FindingsTreeDataProvider } from '../../../src/tree/findingsTreeDataProvider';
+import { removeFindingModifiedDate } from './removeFindingModifiedDate';
+import { waitForAnalysisTree } from './waitForAnalysisTree';
+
+// Run the suite with UPDATE_SNAPSHOTS=1 to rewrite the golden files from the
+// live tree instead of asserting against them, e.g.
+//
+//   UPDATE_SNAPSHOTS=1 TEST_FILE=./analysisTree/treeItems.test.ts yarn test:integration
+//
+// Review the resulting diff before committing.
+const UPDATE_SNAPSHOTS = !!process.env.UPDATE_SNAPSHOTS;
+
+export interface AnalysisTreeTestOptions {
+  /** describe(...) block title */
+  describe: string;
+  /** it(...) title */
+  it: string;
+  /** Golden file for the whole tree, relative to this directory. */
+  snapshot: string;
+  /**
+   * Optional golden file for the "Findings" subtree, spliced under
+   * project → Findings. Lets tests that share the same findings tree reuse a
+   * single golden instead of duplicating it. On update it is written
+   * separately and blanked out in the main snapshot.
+   */
+  findingsSnapshot?: string;
+  /**
+   * Optional per-tick mutation, applied after the modified dates are stripped
+   * from every findings file. Use it to shape the fixture for this test (e.g.
+   * mark a test as failed, or make a finding recent).
+   */
+  prepare?: () => Promise<void>;
+}
+
+// At runtime __dirname is the compiled location (…/out/test/integration/analysisTree),
+// but the golden files live in the TypeScript source tree — and since we read them via
+// fs (not `import`), tsc never copies fresh ones into out/. Resolve back to source so
+// snapshots are read from and written to the files under version control. Under ts-node
+// there is no `out/` segment and this is a no-op. The matched segment is specific enough
+// (`/out/test/integration/`) that it can't collide with an ancestor directory name.
+const SOURCE_DIR = __dirname.replace(
+  `${sep}out${sep}test${sep}integration${sep}`,
+  `${sep}test${sep}integration${sep}`
+);
+
+function snapshotPath(file: string): string {
+  return join(SOURCE_DIR, file);
+}
+
+function findingsNode(tree: CompactTreeItem[]): CompactTreeItem {
+  const project = tree.find((item) => item.label === 'project-several-findings');
+  assert(project, 'expected a "project-several-findings" node in the tree');
+  const findings = project.children.find((item) => item.label === 'Findings');
+  assert(findings, 'expected a "Findings" node under the project');
+  return findings;
+}
+
+async function readSnapshot(options: AnalysisTreeTestOptions): Promise<CompactTreeItem[]> {
+  const tree = JSON.parse(await readFile(snapshotPath(options.snapshot), 'utf8'));
+  if (options.findingsSnapshot) {
+    findingsNode(tree).children = JSON.parse(
+      await readFile(snapshotPath(options.findingsSnapshot), 'utf8')
+    );
+  }
+  return tree;
+}
+
+async function writeSnapshot(
+  options: AnalysisTreeTestOptions,
+  actual: CompactTreeItem[]
+): Promise<void> {
+  if (options.findingsSnapshot) {
+    const findings = findingsNode(actual);
+    // enumerateTree always sets children to an array, but guard anyway so a future
+    // change can't silently write the string "undefined" to the golden.
+    await writeFile(
+      snapshotPath(options.findingsSnapshot),
+      JSON.stringify(findings.children ?? [], null, 2) + '\n'
+    );
+    // Keep the main snapshot free of the (separately stored) findings subtree.
+    findings.children = [];
+  }
+  await writeFile(snapshotPath(options.snapshot), JSON.stringify(actual, null, 2) + '\n');
+}
+
+// How long the tree must stop changing before we trust it. It has to exceed the
+// prepareFindings interval (1s) plus re-index latency, otherwise we snapshot the
+// freshly-loaded tree before this test's `prepare` mutation (a failed test, a
+// recent finding, …) has had a chance to land.
+const SETTLE_MS = 5000;
+
+// The tree is populated asynchronously by a background scan, and prepareFindings
+// keeps rewriting the findings files, so there is no single "done" signal. When
+// asserting we poll until the tree matches the golden; when regenerating we
+// can't use the golden as the settle condition, so instead we wait until the
+// enumerated tree has held steady (and non-empty) for SETTLE_MS. Elapsed time,
+// not a read count, is what matters: the base tree can go quiet for several fast
+// reads before the 1s-interval mutation ever fires.
+async function waitForStableTree(
+  analysisTree: FindingsTreeDataProvider
+): Promise<CompactTreeItem[]> {
+  let latest: CompactTreeItem[] = [];
+  let latestSerialized = '';
+  // performance.now() is monotonic; a wall-clock jump must not reset or short-circuit
+  // the settle window.
+  let stableSince = performance.now();
+  await waitFor(
+    'analysis tree to settle before snapshotting',
+    async () => {
+      const tree = await enumerateTree(analysisTree);
+      const serialized = JSON.stringify(tree);
+      if (serialized !== latestSerialized) {
+        latest = tree;
+        latestSerialized = serialized;
+        stableSince = performance.now();
+      }
+      const loaded = tree.some((item) => item.label === 'project-several-findings');
+      return loaded && performance.now() - stableSince >= SETTLE_MS;
+    },
+    60000
+  );
+  return latest;
+}
+
+export function describeAnalysisTree(options: AnalysisTreeTestOptions): void {
+  describe(options.describe, () => {
+    withAuthenticatedUser();
+
+    let analysisTree: FindingsTreeDataProvider;
+    let prepareFindingsTask: NodeJS.Timeout;
+
+    const prepareFindings = async () => {
+      await Promise.all(
+        (
+          await promisify(glob)('**/appmap-findings.json', { cwd: ProjectSeveralFindings })
+        ).map(removeFindingModifiedDate)
+      );
+      if (options.prepare) await options.prepare();
+    };
+
+    beforeEach(initializeWorkspace);
+    beforeEach(async () => (analysisTree = await waitForAnalysisTree()));
+    beforeEach(() => (prepareFindingsTask = setInterval(prepareFindings, 1000)));
+    afterEach(() => (prepareFindingsTask ? clearTimeout(prepareFindingsTask) : undefined));
+    afterEach(initializeWorkspace);
+
+    it(options.it, async () => {
+      if (UPDATE_SNAPSHOTS) {
+        await writeSnapshot(options, await waitForStableTree(analysisTree));
+        return;
+      }
+
+      const expected = await readSnapshot(options);
+      await waitFor(`Expecting tree items to match ${options.snapshot}`, async () => {
+        const actualTreeItems = await enumerateTree(analysisTree);
+        assert.deepStrictEqual(
+          JSON.stringify(actualTreeItems, null, 2),
+          JSON.stringify(expected, null, 2)
+        );
+        // Previous line will throw, which is considered 'false' by waitFor
+        return true;
+      });
+    });
+  });
+}

--- a/test/integration/analysisTree/analysisTreeTest.ts
+++ b/test/integration/analysisTree/analysisTreeTest.ts
@@ -24,7 +24,7 @@ import { waitForAnalysisTree } from './waitForAnalysisTree';
 //   UPDATE_SNAPSHOTS=1 TEST_FILE=./analysisTree/treeItems.test.ts yarn test:integration
 //
 // Review the resulting diff before committing.
-const UPDATE_SNAPSHOTS = !!process.env.UPDATE_SNAPSHOTS;
+const UPDATE_SNAPSHOTS = process.env.UPDATE_SNAPSHOTS === '1';
 
 export interface AnalysisTreeTestOptions {
   /** describe(...) block title */
@@ -130,7 +130,8 @@ async function waitForStableTree(
         latestSerialized = serialized;
         stableSince = performance.now();
       }
-      const loaded = tree.some((item) => item.label === 'project-several-findings');
+      const project = tree.find((item) => item.label === 'project-several-findings');
+      const loaded = !!project?.children?.some((item) => item.label === 'Findings');
       return loaded && performance.now() - stableSince >= SETTLE_MS;
     },
     60000
@@ -157,7 +158,7 @@ export function describeAnalysisTree(options: AnalysisTreeTestOptions): void {
     beforeEach(initializeWorkspace);
     beforeEach(async () => (analysisTree = await waitForAnalysisTree()));
     beforeEach(() => (prepareFindingsTask = setInterval(prepareFindings, 1000)));
-    afterEach(() => (prepareFindingsTask ? clearTimeout(prepareFindingsTask) : undefined));
+    afterEach(() => (prepareFindingsTask ? clearInterval(prepareFindingsTask) : undefined));
     afterEach(initializeWorkspace);
 
     it(options.it, async () => {

--- a/test/integration/analysisTree/failedTest.test.ts
+++ b/test/integration/analysisTree/failedTest.test.ts
@@ -1,83 +1,38 @@
 // @project project-several-findings
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import assert from 'assert';
-
-import {
-  withAuthenticatedUser,
-  ProjectSeveralFindings,
-  waitFor,
-  initializeWorkspace,
-  CompactTreeItem,
-  enumerateTree,
-} from '../util';
-import { FindingsTreeDataProvider } from '../../../src/tree/findingsTreeDataProvider';
-
-import { glob } from 'glob';
-import { promisify } from 'util';
-import { removeFindingModifiedDate } from './removeFindingModifiedDate';
-import { waitForAnalysisTree } from './waitForAnalysisTree';
-import { Metadata } from '@appland/models';
 import { join } from 'path';
 import { readFile, writeFile } from 'fs/promises';
+import { Metadata } from '@appland/models';
 
-import treeItems from './failedTestTreeItems.json';
-import findingsTreeItems_noDateIndicated from './findingsTreeItems_noDateIndicated.json';
-(
-  treeItems
-    .find((item) => item.label === 'project-several-findings')!
-    .children.find((item) => item.label === 'Findings') as CompactTreeItem
-).children = findingsTreeItems_noDateIndicated;
+import { ProjectSeveralFindings } from '../util';
+import { describeAnalysisTree } from './analysisTreeTest';
 
 const appmapFileName = join(
   ProjectSeveralFindings,
   'tmp/appmap/minitest/Microposts_interface_micropost_interface.appmap.json'
 );
 
-describe('Runtime analysis failed test tree item', () => {
-  withAuthenticatedUser();
+let appmapStr: string;
 
-  let analysisTree: FindingsTreeDataProvider;
-  let prepareFindingsTask: NodeJS.Timeout;
-  let appmapStr: string;
+// Mark the Microposts appmap as a failed test so it shows up under "Failed tests".
+const markTestFailed = async () => {
+  if (!appmapStr) appmapStr = await readFile(appmapFileName, 'utf-8');
+  const appmapData = JSON.parse(appmapStr);
+  const metadata = appmapData.metadata as Metadata;
+  if (metadata.test_status === 'succeeded') {
+    metadata.test_status = 'failed';
+    metadata.test_failure = {
+      message: 'Null pointer exception',
+      location: 'app/models/user.rb:47',
+    };
+    appmapStr = JSON.stringify(appmapData, null, 2);
+    await writeFile(appmapFileName, appmapStr);
+  }
+};
 
-  const prepareFindings = async () => {
-    await Promise.all(
-      (
-        await promisify(glob)('**/appmap-findings.json', {
-          cwd: ProjectSeveralFindings,
-        })
-      ).map(removeFindingModifiedDate)
-    );
-
-    if (!appmapStr) appmapStr = await readFile(appmapFileName, 'utf-8');
-    const appmapData = JSON.parse(appmapStr);
-    const metadata = appmapData.metadata as Metadata;
-    if (metadata.test_status === 'succeeded') {
-      metadata.test_status = 'failed';
-      metadata.test_failure = {
-        message: 'Null pointer exception',
-        location: 'app/models/user.rb:47',
-      };
-      appmapStr = JSON.stringify(appmapData, null, 2);
-      await writeFile(appmapFileName, appmapStr);
-    }
-  };
-
-  beforeEach(initializeWorkspace);
-  beforeEach(async () => (analysisTree = await waitForAnalysisTree()));
-  beforeEach(() => (prepareFindingsTask = setInterval(prepareFindings, 1000)));
-  afterEach(() => (prepareFindingsTask ? clearTimeout(prepareFindingsTask) : undefined));
-  afterEach(initializeWorkspace);
-
-  it('has the expected tree items', async () => {
-    await waitFor(`Expecting tree items to match expectation`, async () => {
-      const actualTreeItems = await enumerateTree(analysisTree);
-      assert.deepStrictEqual(
-        JSON.stringify(actualTreeItems, null, 2),
-        JSON.stringify(treeItems, null, 2)
-      );
-      // Previous line will throw, which is considered 'false' by waitFor
-      return true;
-    });
-  });
+describeAnalysisTree({
+  describe: 'Runtime analysis failed test tree item',
+  it: 'has the expected tree items',
+  snapshot: 'failedTestTreeItems.json',
+  findingsSnapshot: 'findingsTreeItems_noDateIndicated.json',
+  prepare: markTestFailed,
 });

--- a/test/integration/analysisTree/failedTestTreeItems.json
+++ b/test/integration/analysisTree/failedTestTreeItems.json
@@ -16,7 +16,8 @@
         ]
       },
       {
-        "label": "Findings"
+        "label": "Findings",
+        "children": []
       }
     ]
   }

--- a/test/integration/analysisTree/findingsTreeItems_noDateIndicated.json
+++ b/test/integration/analysisTree/findingsTreeItems_noDateIndicated.json
@@ -11,6 +11,10 @@
               {
                 "label": "log_device.rb",
                 "children": []
+              },
+              {
+                "label": "log_device.rb",
+                "children": []
               }
             ]
           }
@@ -22,6 +26,14 @@
           {
             "label": "N plus 1 SQL query",
             "children": [
+              {
+                "label": "_micropost.html.erb",
+                "children": []
+              },
+              {
+                "label": "_micropost.html.erb",
+                "children": []
+              },
               {
                 "label": "_micropost.html.erb",
                 "children": []

--- a/test/integration/analysisTree/recentFinding.test.ts
+++ b/test/integration/analysisTree/recentFinding.test.ts
@@ -1,81 +1,44 @@
 // @project project-several-findings
-import assert from 'assert';
-import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
-
-import {
-  withAuthenticatedUser,
-  ProjectSeveralFindings,
-  waitFor,
-  initializeWorkspace,
-  enumerateTree,
-} from '../util';
-import { FindingsTreeDataProvider } from '../../../src/tree/findingsTreeDataProvider';
-
-import treeItems from './recentFindingTreeItems.json';
-import { Finding } from '@appland/scanner';
+import { readFile, writeFile } from 'fs/promises';
 import { debug } from 'console';
-import { promisify } from 'util';
-import { glob } from 'glob';
-import { removeFindingModifiedDate } from './removeFindingModifiedDate';
-import { waitForAnalysisTree } from './waitForAnalysisTree';
+import { Finding } from '@appland/scanner';
+
+import { ProjectSeveralFindings } from '../util';
+import { describeAnalysisTree } from './analysisTreeTest';
 
 const findingsFileName = join(
   ProjectSeveralFindings,
   'tmp/appmap/minitest/Microposts_interface_micropost_interface/appmap-findings.json'
 );
 
-describe("Runtime analysis findings tree items, when a finding's modified date is recent", () => {
-  withAuthenticatedUser();
+let findingsFileContents: string | undefined;
 
-  let prepareFindingsTask: NodeJS.Timeout;
-  let analysisTree: FindingsTreeDataProvider;
-  let findingsFileContents: string | undefined;
-
-  const prepareFindings = async () => {
-    await Promise.all(
-      (
-        await promisify(glob)('**/appmap-findings.json', {
-          cwd: ProjectSeveralFindings,
-        })
-      ).map(removeFindingModifiedDate)
-    );
-
-    if (!findingsFileContents) {
-      try {
-        findingsFileContents = await readFile(findingsFileName, 'utf8');
-      } catch (e) {
-        const err = e as Error;
-        debug(`${findingsFileName} cannot be read. This is anticipated and will be retried.`);
-        debug(err.toString());
-        return;
-      }
+// Give the n+1 query finding a recent modified date so it lands in the
+// "Last 24 hours" date bucket.
+const markFindingRecent = async () => {
+  if (!findingsFileContents) {
+    try {
+      findingsFileContents = await readFile(findingsFileName, 'utf8');
+    } catch (e) {
+      debug(`${findingsFileName} cannot be read. This is anticipated and will be retried.`);
+      debug((e as Error).toString());
+      return;
     }
-    const findingsFile = JSON.parse(findingsFileContents) as { findings: Finding[] };
-    const nPlusOneQuery = findingsFile.findings.find(
-      (finding: { ruleId: string }) => finding.ruleId === 'n-plus-one-query'
-    ) as Finding;
-    if (nPlusOneQuery.scopeModifiedDate === undefined) {
-      nPlusOneQuery.scopeModifiedDate = new Date();
-      await writeFile(findingsFileName, JSON.stringify(findingsFile, null, 2));
-    }
-  };
+  }
+  const findingsFile = JSON.parse(findingsFileContents) as { findings: Finding[] };
+  const nPlusOneQuery = findingsFile.findings.find(
+    (finding) => finding.ruleId === 'n-plus-one-query'
+  ) as Finding;
+  if (nPlusOneQuery.scopeModifiedDate === undefined) {
+    nPlusOneQuery.scopeModifiedDate = new Date();
+    await writeFile(findingsFileName, JSON.stringify(findingsFile, null, 2));
+  }
+};
 
-  beforeEach(initializeWorkspace);
-  beforeEach(async () => (analysisTree = await waitForAnalysisTree()));
-  beforeEach(() => (prepareFindingsTask = setInterval(prepareFindings, 1000)));
-  afterEach(() => (prepareFindingsTask ? clearTimeout(prepareFindingsTask) : undefined));
-  afterEach(initializeWorkspace);
-
-  it('has a bucket for "Last 24 hours"', async () => {
-    await waitFor(`Expecting to find a date bucket for "Last 24 hours"`, async () => {
-      const actualTreeItems = await enumerateTree(analysisTree);
-      assert.deepStrictEqual(
-        JSON.stringify(actualTreeItems, null, 2),
-        JSON.stringify(treeItems, null, 2)
-      );
-      // Previous line will throw, which is considered 'false' by waitFor
-      return true;
-    });
-  });
+describeAnalysisTree({
+  describe: "Runtime analysis findings tree items, when a finding's modified date is recent",
+  it: 'has a bucket for "Last 24 hours"',
+  snapshot: 'recentFindingTreeItems.json',
+  prepare: markFindingRecent,
 });

--- a/test/integration/analysisTree/recentFindingTreeItems.json
+++ b/test/integration/analysisTree/recentFindingTreeItems.json
@@ -1,5 +1,8 @@
 [
-  { "label": "Findings table", "children": [] },
+  {
+    "label": "Findings table",
+    "children": []
+  },
   {
     "label": "project-several-findings",
     "children": [
@@ -37,6 +40,10 @@
                       {
                         "label": "log_device.rb",
                         "children": []
+                      },
+                      {
+                        "label": "log_device.rb",
+                        "children": []
                       }
                     ]
                   }
@@ -48,6 +55,14 @@
                   {
                     "label": "N plus 1 SQL query",
                     "children": [
+                      {
+                        "label": "_micropost.html.erb",
+                        "children": []
+                      },
+                      {
+                        "label": "_micropost.html.erb",
+                        "children": []
+                      },
                       {
                         "label": "_micropost.html.erb",
                         "children": []

--- a/test/integration/analysisTree/treeItems.json
+++ b/test/integration/analysisTree/treeItems.json
@@ -1,5 +1,8 @@
 [
-  { "label": "Findings table", "children": [] },
+  {
+    "label": "Findings table",
+    "children": []
+  },
   {
     "label": "project-several-findings",
     "children": [

--- a/test/integration/analysisTree/treeItems.test.ts
+++ b/test/integration/analysisTree/treeItems.test.ts
@@ -1,61 +1,9 @@
 // @project project-several-findings
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import assert from 'assert';
+import { describeAnalysisTree } from './analysisTreeTest';
 
-import {
-  withAuthenticatedUser,
-  ProjectSeveralFindings,
-  waitFor,
-  initializeWorkspace,
-  CompactTreeItem,
-  enumerateTree,
-} from '../util';
-import { FindingsTreeDataProvider } from '../../../src/tree/findingsTreeDataProvider';
-
-import treeItems from './treeItems.json';
-import findingsTreeItems_noDateIndicated from './findingsTreeItems_noDateIndicated.json';
-(
-  treeItems
-    .find((item) => item.label === 'project-several-findings')!
-    .children.find((item) => item.label === 'Findings') as CompactTreeItem
-).children = findingsTreeItems_noDateIndicated;
-
-import { glob } from 'glob';
-import { promisify } from 'util';
-import { removeFindingModifiedDate } from './removeFindingModifiedDate';
-import { waitForAnalysisTree } from './waitForAnalysisTree';
-
-describe('Runtime analysis findings tree items', () => {
-  withAuthenticatedUser();
-
-  let analysisTree: FindingsTreeDataProvider;
-  let prepareFindingsTask: NodeJS.Timeout;
-
-  const prepareFindings = async () => {
-    await Promise.all(
-      (
-        await promisify(glob)('**/appmap-findings.json', {
-          cwd: ProjectSeveralFindings,
-        })
-      ).map(removeFindingModifiedDate)
-    );
-  };
-
-  beforeEach(initializeWorkspace);
-  beforeEach(async () => (analysisTree = await waitForAnalysisTree()));
-  beforeEach(() => (prepareFindingsTask = setInterval(prepareFindings, 1000)));
-  afterEach(() => (prepareFindingsTask ? clearTimeout(prepareFindingsTask) : undefined));
-  afterEach(initializeWorkspace);
-
-  it('has the expected tree items', async () => {
-    await waitFor(`Expecting tree items to match expectation`, async () => {
-      const actualTreeItems = await enumerateTree(analysisTree);
-      assert.deepStrictEqual(
-        JSON.stringify(actualTreeItems, null, 2),
-        JSON.stringify(treeItems, null, 2)
-      );
-      // Previous line will throw, which is considered 'false' by waitFor
-      return true;
-    });
-  });
+describeAnalysisTree({
+  describe: 'Runtime analysis findings tree items',
+  it: 'has the expected tree items',
+  snapshot: 'treeItems.json',
+  findingsSnapshot: 'findingsTreeItems_noDateIndicated.json',
 });


### PR DESCRIPTION
The three analysisTree tree-view tests were near-identical copies of the same auth + prepareFindings + waitFor(deepStrictEqual) scaffolding. Extract it into a single parametrized describeAnalysisTree() helper; each test now declares only its title, per-tick fixture mutation, and golden file.

Add UPDATE_SNAPSHOTS=1 regeneration: instead of asserting, wait until the enumerated tree settles (unchanged and non-empty for 5s, timed with a monotonic clock) and write it back to the source golden files, re-splitting the shared "Findings" subtree as before. The settle window must exceed the 1s prepareFindings interval so mutation-dependent branches (failed test, recent finding) are captured instead of a pre-mutation tree. Goldens are read from and written to the source tree, not the compiled out/ copies.

Update the golden files for the scanner's switch to deduping the findings report by hash_v2 (appmap-js): findings that collided on the legacy v1 hash (e.g. the same secret logged from two statements) [are now reported distinctly](https://github.com/getappmap/appmap-js/commit/5c129abcaa3d707a348d6ec824a49789fcebd839), so a few leaves appear that the v1 hash previously collapsed.

Assisted-by: Claude:claude-opus-4-8