### PR TITLE
fix(telemetry): propagate IDE telemetry opt-out to child processes

### DIFF
--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -51,11 +51,18 @@ export default class ExtensionSettings {
 
     const telemetryConfig = this.telemetryConfiguration;
     if (telemetryConfig.backend === 'splunk') {
+      // Splunk telemetry targets enterprise environments where the organization's
+      // telemetry policy is enforced, so it is kept enabled regardless of the
+      // local IDE telemetry setting.
       result.APPMAP_TELEMETRY_BACKEND ??= 'splunk';
       result.APPMAP_TELEMETRY_DISABLED ??= 'false';
       if (telemetryConfig.url) result.SPLUNK_URL ??= telemetryConfig.url;
       if (telemetryConfig.token) result.SPLUNK_TOKEN ??= telemetryConfig.token;
       if (telemetryConfig.ca) result.SPLUNK_CA_CERT ??= telemetryConfig.ca;
+    } else if (!vscode.env.isTelemetryEnabled) {
+      // Propagate the user's IDE telemetry opt-out to child processes (RPC server,
+      // indexer, scanner).
+      result.APPMAP_TELEMETRY_DISABLED ??= 'true';
     }
 
     result.APPMAP_TELEMETRY_PROPERTIES ??= JSON.stringify({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -286,15 +286,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       );
       ReviewWebview.register(context, rpcService);
 
+      // Restart the RPC server, indexer and scanner so they pick up the environment
+      // built by ExtensionSettings.appMapCommandLineEnvironment (command-line
+      // environment and telemetry configuration). Both restart paths handle their
+      // own errors, so voiding the returned promise cannot yield an unhandled
+      // rejection.
+      const restartServicesForEnvironmentChange = (reason: string) => {
+        rpcService.debouncedRestart();
+        void processService.restartAll(reason);
+      };
+
       context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((e) => {
-          if (
-            e.affectsConfiguration('appMap.commandLineEnvironment') ||
-            e.affectsConfiguration('appMap.telemetry')
-          ) {
-            rpcService.debouncedRestart();
-          }
+          if (e.affectsConfiguration('appMap.commandLineEnvironment'))
+            restartServicesForEnvironmentChange('AppMap command-line environment changed');
+          else if (e.affectsConfiguration('appMap.telemetry'))
+            restartServicesForEnvironmentChange('AppMap telemetry configuration changed');
         }),
+        // Honor the IDE's global telemetry opt-out at runtime by propagating it to
+        // child processes when the user toggles it.
+        vscode.env.onDidChangeTelemetryEnabled(() =>
+          restartServicesForEnvironmentChange('IDE telemetry setting changed')
+        ),
         vscode.commands.registerCommand('appmap.rpc.restart', async () => {
           await rpcService.restartServer();
           vscode.window.showInformationMessage('Navie restarted successfully.');

--- a/src/services/nodeProcessService.ts
+++ b/src/services/nodeProcessService.ts
@@ -37,6 +37,22 @@ export class NodeProcessService implements WorkspaceService<NodeProcessServiceIn
     return instance;
   }
 
+  // Restart every instance of this service so it picks up a fresh environment
+  // (see ExtensionSettings.appMapCommandLineEnvironment). Failures are logged
+  // rather than propagated, so callers can safely fire-and-forget.
+  async restartAll(reason: string): Promise<void> {
+    NodeProcessService.outputChannel.appendLine(`${reason}. Restarting AppMap services.`);
+    const instances = workspaceServices().getServiceInstancesFromClass(NodeProcessService);
+    const results = await Promise.allSettled(instances.map((instance) => instance.restart(reason)));
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        NodeProcessService.outputChannel.appendLine(
+          `Failed to restart AppMap service after ${reason}: ${result.reason}`
+        );
+      }
+    }
+  }
+
   private async handleConfigChange(folder: vscode.WorkspaceFolder): Promise<void> {
     const currentInstance = workspaceServices().getServiceInstanceFromClass(
       NodeProcessService,

--- a/src/services/workspaceServices.ts
+++ b/src/services/workspaceServices.ts
@@ -122,7 +122,19 @@ export class WorkspaceServices implements vscode.Disposable {
   }
 
   /**
-   * Gets all instances of a given service, with an optional folder name.
+   * Gets all instances of a service identified by its class, with an optional workspace folder filter.
+   */
+  getServiceInstancesFromClass<
+    T extends WorkspaceService<I>,
+    I extends WorkspaceServiceInstance = WorkspaceServiceInstanceType<T>
+  >(serviceClass: WorkspaceServiceConstructor<T>, folder?: vscode.WorkspaceFolder): I[] {
+    const service = this.getService(serviceClass);
+    if (!service) return [];
+    return this.getServiceInstances<T, I>(service, folder);
+  }
+
+  /**
+   * Gets all instances of a given service, with an optional workspace folder filter.
    */
   getServiceInstances<
     T extends WorkspaceService<I>,

--- a/test/unit/configuration/extensionSettings.test.ts
+++ b/test/unit/configuration/extensionSettings.test.ts
@@ -1,0 +1,90 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import ExtensionSettings from '../../../src/configuration/extensionSettings';
+
+const SPLUNK_CONFIG = {
+  backend: 'splunk' as const,
+  url: 'https://splunk.example.com',
+  token: 'some-token',
+};
+
+describe('ExtensionSettings.appMapCommandLineEnvironment', () => {
+  const originalTelemetryEnabled = vscode.env.isTelemetryEnabled;
+  let commandLineEnvironment: Record<string, string>;
+
+  beforeEach(() => {
+    commandLineEnvironment = {};
+    Sinon.stub(vscode.workspace, 'getConfiguration').returns({
+      get: (key: string) => (key === 'commandLineEnvironment' ? commandLineEnvironment : undefined),
+    } as unknown as vscode.WorkspaceConfiguration);
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    setTelemetryEnabled(originalTelemetryEnabled);
+  });
+
+  function setTelemetryEnabled(value: boolean): void {
+    // vscode.env.isTelemetryEnabled is a readonly property at runtime; the mock
+    // exposes it as a writable data property so tests can vary it.
+    (vscode.env as { isTelemetryEnabled: boolean }).isTelemetryEnabled = value;
+  }
+
+  function stubTelemetryConfig(config: Record<string, unknown>): void {
+    Sinon.stub(ExtensionSettings, 'telemetryConfiguration').get(() => config);
+  }
+
+  describe('with the default (Application Insights) backend', () => {
+    beforeEach(() => stubTelemetryConfig({}));
+
+    it('does not disable child-process telemetry when the IDE has telemetry enabled', () => {
+      setTelemetryEnabled(true);
+      expect(ExtensionSettings.appMapCommandLineEnvironment).to.not.have.property(
+        'APPMAP_TELEMETRY_DISABLED'
+      );
+    });
+
+    it('propagates the IDE telemetry opt-out to child processes', () => {
+      setTelemetryEnabled(false);
+      expect(ExtensionSettings.appMapCommandLineEnvironment).to.have.property(
+        'APPMAP_TELEMETRY_DISABLED',
+        'true'
+      );
+    });
+
+    it('does not override an explicit APPMAP_TELEMETRY_DISABLED from the user environment', () => {
+      setTelemetryEnabled(false);
+      commandLineEnvironment = { APPMAP_TELEMETRY_DISABLED: 'false' };
+      expect(ExtensionSettings.appMapCommandLineEnvironment).to.have.property(
+        'APPMAP_TELEMETRY_DISABLED',
+        'false'
+      );
+    });
+  });
+
+  describe('with the Splunk backend', () => {
+    beforeEach(() => stubTelemetryConfig(SPLUNK_CONFIG));
+
+    it('forces telemetry on regardless of the IDE opt-out (enterprise enforcement)', () => {
+      setTelemetryEnabled(false);
+      const env = ExtensionSettings.appMapCommandLineEnvironment;
+      // 'false' is parsed by the CLI as "not disabled", i.e. telemetry stays on.
+      expect(env).to.have.property('APPMAP_TELEMETRY_DISABLED', 'false');
+      expect(env).to.have.property('APPMAP_TELEMETRY_BACKEND', 'splunk');
+      expect(env).to.have.property('SPLUNK_URL', SPLUNK_CONFIG.url);
+      expect(env).to.have.property('SPLUNK_TOKEN', SPLUNK_CONFIG.token);
+    });
+
+    it('never disables telemetry even when the IDE has telemetry enabled', () => {
+      setTelemetryEnabled(true);
+      expect(ExtensionSettings.appMapCommandLineEnvironment).to.have.property(
+        'APPMAP_TELEMETRY_DISABLED',
+        'false'
+      );
+    });
+  });
+});

--- a/test/unit/mock/vscode/env.ts
+++ b/test/unit/mock/vscode/env.ts
@@ -1,8 +1,13 @@
 import { Uri } from 'vscode';
+import EventEmitter from './EventEmitter';
 
-export function isTelemetryEnabled() {
-  return false;
-}
+// Mirrors vscode.env.isTelemetryEnabled (a boolean property, not a function).
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const isTelemetryEnabled = true;
+
+const telemetryEnabledEmitter = new EventEmitter<boolean>();
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const onDidChangeTelemetryEnabled = telemetryEnabledEmitter.event;
 
 export async function asExternalUri(uri: Uri) {
   return uri;

--- a/test/unit/services/nodeProcessService.test.ts
+++ b/test/unit/services/nodeProcessService.test.ts
@@ -1,0 +1,68 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import { NodeProcessService } from '../../../src/services/nodeProcessService';
+import * as WorkspaceServicesModule from '../../../src/services/workspaceServices';
+import MockExtensionContext from '../../mocks/mockExtensionContext';
+
+describe('NodeProcessService', () => {
+  let sinon: Sinon.SinonSandbox;
+  let service: NodeProcessService;
+  let appendLine: Sinon.SinonStub;
+
+  beforeEach(() => {
+    sinon = Sinon.createSandbox();
+    service = new NodeProcessService(new MockExtensionContext());
+    appendLine = sinon.stub(NodeProcessService.outputChannel, 'appendLine');
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('restartAll', () => {
+    function stubInstances(instances: { restart: Sinon.SinonStub }[]): void {
+      sinon.stub(WorkspaceServicesModule, 'workspaceServices').returns({
+        getServiceInstancesFromClass: sinon.stub().returns(instances),
+      } as unknown as WorkspaceServicesModule.WorkspaceServices);
+    }
+
+    it('restarts every enrolled instance with the given reason', async () => {
+      const a = { restart: sinon.stub().resolves() };
+      const b = { restart: sinon.stub().resolves() };
+      stubInstances([a, b]);
+
+      await service.restartAll('test reason');
+
+      expect(a.restart.calledOnceWith('test reason')).to.be.true;
+      expect(b.restart.calledOnceWith('test reason')).to.be.true;
+    });
+
+    it('logs a failed restart instead of rejecting, and still restarts the others', async () => {
+      const ok = { restart: sinon.stub().resolves() };
+      const bad = { restart: sinon.stub().rejects(new Error('boom')) };
+      stubInstances([bad, ok]);
+
+      // Must not reject even though one instance fails.
+      await service.restartAll('test reason');
+
+      expect(ok.restart.calledOnce, 'sibling instance still restarted').to.be.true;
+      expect(bad.restart.calledOnce).to.be.true;
+
+      const loggedFailure = appendLine
+        .getCalls()
+        .some((call) => /Failed to restart AppMap service.*boom/.test(call.args[0] as string));
+      expect(loggedFailure, 'failure was written to the output channel').to.be.true;
+    });
+
+    it('is a no-op when no instances are enrolled', async () => {
+      stubInstances([]);
+      await service.restartAll('test reason');
+      // Only the "Restarting AppMap services" line, no failures.
+      const failures = appendLine
+        .getCalls()
+        .filter((call) => /Failed to restart/.test(call.args[0] as string));
+      expect(failures).to.be.empty;
+    });
+  });
+});

--- a/test/unit/services/workspaceServices.test.ts
+++ b/test/unit/services/workspaceServices.test.ts
@@ -1,0 +1,52 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+
+import { WorkspaceServices } from '../../../src/services/workspaceServices';
+import type { WorkspaceServiceInstance } from '../../../src/services/workspaceService';
+
+class FakeService {
+  static serviceId = 'FakeService';
+  create() {
+    return { folder: {} as vscode.WorkspaceFolder, dispose: () => undefined };
+  }
+}
+
+class OtherService {
+  static serviceId = 'OtherService';
+  create() {
+    return { folder: {} as vscode.WorkspaceFolder, dispose: () => undefined };
+  }
+}
+
+describe('WorkspaceServices.getServiceInstancesFromClass', () => {
+  let services: WorkspaceServices;
+  let service: FakeService;
+  const folder = { uri: vscode.Uri.file('/project'), name: 'project', index: 0 };
+
+  function instance(): WorkspaceServiceInstance {
+    return { folder, dispose: () => undefined };
+  }
+
+  beforeEach(async () => {
+    services = new WorkspaceServices();
+    service = new FakeService();
+    // Registers the service; no folders are open in the mock, so no instances
+    // are created by enroll() itself.
+    await services.enroll(service as never);
+  });
+
+  it('returns all instances registered for the class', () => {
+    const [a, b] = [instance(), instance()];
+    services.enrollServiceInstance(folder, a, service as never);
+    services.enrollServiceInstance(folder, b, service as never);
+
+    const result = services.getServiceInstancesFromClass(FakeService as never);
+    expect(result).to.have.members([a, b]);
+  });
+
+  it('returns an empty array when the class was never enrolled', () => {
+    expect(services.getServiceInstancesFromClass(OtherService as never)).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
The RPC server, indexer and scanner inherit their telemetry configuration from the environment built by appMapCommandLineEnvironment. That environment never reflected the user's VS Code telemetry setting, so disabling telemetry in the IDE left the child CLIs sending telemetry.

Set APPMAP_TELEMETRY_DISABLED=true when vscode.env.isTelemetryEnabled is false, and restart the child processes on onDidChangeTelemetryEnabled so the change takes effect at runtime.

The Splunk backend is exempt: it targets enterprise environments where the organization's telemetry policy is enforced regardless of the local IDE setting, so it is always left enabled (APPMAP_TELEMETRY_DISABLED=false).

Also, makes sure that indexer/scanner services restart on telemetry config change.