### PR TITLE
feat(customer-id): implement managed entitlement for locked-down deployments

### DIFF
--- a/build/bundleConfig.md
+++ b/build/bundleConfig.md
@@ -20,9 +20,16 @@ values from a `site-config.json` file. It injects configuration defaults and rep
         "url": "https://localhost:8088",
         "token": "abcd1234"
     },
-    "appMap.autoUpdateTools": false
+    "appMap.autoUpdateTools": false,
+    "appMap.customerId": "acme-corp"
 }
 ```
+
+Keys that the extension's `package.json` does not declare — `appMap.customerId` among them — are
+synthesized as new configuration properties, so they exist as registered settings only inside the
+repackaged package. `appMap.customerId` identifies the organization the installation belongs to and
+puts the extension into its signed-in state without requiring users to authenticate; see
+[Organization Configuration](../doc/organization-config.md#customer-id).
 
 ## Usage
 

--- a/doc/organization-config.md
+++ b/doc/organization-config.md
@@ -52,6 +52,7 @@ Only keys in the `appMap.*` namespace are applied. Any other keys in the file ar
 | `appMap.manifest.appmapUrl` | URL of the AppMap CLI release manifest. Override this to point at an internal mirror. |
 | `appMap.manifest.scannerUrl` | URL of the Scanner release manifest. Override this to point at an internal mirror. |
 | `appMap.autoUpdateTools` | Whether to check for and download tool updates on startup. Set to `false` when distributing a VSIX with pre-bundled binaries (via `bundleConfig`) to prevent the extension from replacing them. For version pinning without bundled binaries, use a versioned manifest URL (e.g. `appmap-v3.197.1.json`) instead of the `-latest` pointer. |
+| `appMap.customerId` | Identifies the organization this installation belongs to, and puts the extension into its signed-in state without requiring users to authenticate against getappmap.com. See [Customer ID](#customer-id). |
 
 For binary mirroring — hosting the AppMap and Scanner binaries on internal infrastructure and
 pointing the manifest URLs at them — see [Asset Management](assets.md) and the
@@ -79,7 +80,7 @@ Set `appMap.configurationUrl` in your VS Code settings deployment (e.g. via a ma
 ### 3. User command (manual)
 
 Ask users to run the **AppMap: Set organization configuration URL** command
-(`Ctrl+Shift+P` / `Cmd+Shift+P`, then type `AppMap organization`). A quick-pick menu offers two
+(`Ctrl+Shift+P` / `Cmd+Shift+P`, then type `AppMap organization`). A quick-pick menu offers four
 options:
 
 - **Set URL** — prompts for a URL. If `APPMAP_CONFIG_URL` is set in the environment, the prompt is
@@ -87,6 +88,14 @@ options:
   setting.
 - **Local File** — opens a file browser to select a local JSON configuration file and applies it
   immediately as a one-shot operation. See [One-shot local file application](#one-shot-local-file-application).
+- **Clear** — reverts every setting the organization configuration applied, discards the cached
+  configuration, and removes the URL setting. If the URL came from `APPMAP_CONFIG_URL`, a warning
+  explains that AppMap cannot unset the variable and the configuration will be applied again on the
+  next activation.
+- **Status** — reports whether this installation is entitled by a
+  [customer ID](#customer-id) and where that came from, along with the active configuration URL and
+  its source. This is usually the fastest way to answer "which configuration is this editor
+  actually using?".
 
 ## Behavior details
 
@@ -141,6 +150,86 @@ configuration on the next extension activation as long as the environment variab
 If the configuration URL remains set but a key is removed from the remote JSON file, that key is
 reverted to its default value on the next successful fetch. This allows the organization to
 un-apply a setting centrally.
+
+## Customer ID
+
+Normally every user must sign in to getappmap.com through GitHub, GitLab, or email before the
+extension leaves its "sign in" state. Where licensing is already settled by an agreement with
+AppMap, that step adds nothing: it fails outright under network restrictions, and it puts an
+authentication flow through security review that grants no more than the contract already does.
+
+Setting `appMap.customerId` removes it. The extension behaves as though the user were signed in:
+the sign-in view and the "Activate AppMap" walkthrough step disappear, and runtime analysis is
+enabled. The value is also passed to the AppMap CLI subprocesses as `APPMAP_CUSTOMER_ID`, and sent
+with telemetry events as `common.customerid` so that usage can be attributed to your organization
+(see [Telemetry Configuration](telemetry.md)).
+
+```json
+{
+  "appMap.customerId": "acme-corp"
+}
+```
+
+Use whatever identifier your AppMap agreement specifies. Any non-empty string is accepted; blank
+and whitespace-only values are treated as absent.
+
+### What it is not
+
+- **Not a secret.** It is not a license key or a token, it grants no access to anything, and it
+  does not need to be protected. It is stored in the extension's local storage in plain text, and
+  on a bundled build it is visible in the VS Code settings UI.
+- **Not an enforcement mechanism.** The extension is open source, so the check is a business
+  process, not a security boundary. It records which organization an installation belongs to; it
+  does not prevent anything.
+- **Not a substitute for authentication where authentication is wanted.** Signing in still works
+  and still takes precedence: if a user has a real session, its API key is what authenticates
+  requests, and the customer ID is used only for attribution. The AppMap sign-in entry stays
+  available in the Accounts menu.
+
+Because attribution rides on telemetry, it only reaches you if telemetry is enabled and a backend
+is reachable. Treat it as best-effort reporting rather than seat counting.
+
+### Setting it
+
+The customer ID can be delivered through any of the organization-configuration channels:
+
+1. **Configuration URL** — include `appMap.customerId` in the JSON your configuration URL serves.
+   This is the usual choice, and the only one that can be changed centrally afterwards. As with
+   any other key, the last successful fetch is cached, so entitlement survives a temporarily
+   unreachable configuration server — which matters most in exactly the restricted networks this
+   feature exists for.
+2. **Local file** — include it in a JSON file applied through the **Local File** quick-pick option.
+   Applied once, and retained afterwards.
+3. **Bundled VSIX** — include it in the `site-config.json` you repackage the extension with. See
+   [bundleConfig](../build/bundleConfig.md). The extension then carries its own customer ID with no
+   configuration server involved, which suits fully air-gapped deployments.
+
+A configuration URL or local file takes precedence over a bundled value, so a repackaged VSIX can
+be re-pointed centrally without rebuilding it. If the bundled value changes in a later VSIX, the
+new one takes effect unless a configuration URL has set one.
+
+Setting `appMap.customerId` by hand in `settings.json` has **no effect** — only a value delivered
+through one of the channels above is honored. On a bundled build, where the setting is visible in
+the settings UI, AppMap warns once per session if it finds a hand-written override and offers to
+remove it.
+
+### Retention and removal
+
+Like every other organization-configuration key, the customer ID follows
+[single-shot mode](#single-shot-mode): removing the configuration URL does **not** revert it. This
+is deliberate, so that a URL can be used as a one-time bootstrap, but it does mean that an
+installation stays entitled after the URL is gone.
+
+To remove it, either:
+
+- remove `appMap.customerId` from the JSON your configuration URL serves, while the URL is still
+  set — it is reverted on the next successful fetch, like any other key; or
+- run **AppMap: Set organization configuration URL** and choose **Clear**, which reverts every
+  setting the organization configuration applied, the customer ID included.
+
+On a bundled build, clearing reverts to the customer ID built into the VSIX rather than to nothing —
+that value is part of the installation. To run a bundled build unentitled, install a standard build
+from the Marketplace.
 
 ## Troubleshooting
 

--- a/doc/organization-config.md
+++ b/doc/organization-config.md
@@ -88,10 +88,12 @@ options:
   setting.
 - **Local File** — opens a file browser to select a local JSON configuration file and applies it
   immediately as a one-shot operation. See [One-shot local file application](#one-shot-local-file-application).
-- **Clear** — reverts every setting the organization configuration applied, discards the cached
-  configuration, and removes the URL setting. If the URL came from `APPMAP_CONFIG_URL`, a warning
-  explains that AppMap cannot unset the variable and the configuration will be applied again on the
-  next activation.
+- **Clear** — reverts the settings the organization configuration applied, discards the cached
+  configuration, and removes the URL setting. Settings you have edited since they were applied are
+  left as you set them; the customer ID is always cleared. This works whether or not a URL is still
+  set, so it is also the way to undo a configuration applied by a URL you have already removed. If
+  the URL came from `APPMAP_CONFIG_URL`, a warning explains that AppMap cannot unset the variable
+  and the configuration will be applied again on the next activation.
 - **Status** — reports whether this installation is entitled by a
   [customer ID](#customer-id) and where that came from, along with the active configuration URL and
   its source. This is usually the fastest way to answer "which configuration is this editor
@@ -127,8 +129,12 @@ previously applied settings are **not** automatically reverted. This allows the 
 as a one-time configuration bootstrap: set the URL, let settings apply, then remove the URL to
 stop automatic updates while keeping the configuration in place.
 
-To revert specific settings after removing the URL, clear them manually in the VS Code settings UI
-or `settings.json`.
+AppMap keeps its record of which keys were applied after the URL is removed, so the **Clear**
+option remains able to revert them later. Nothing is re-fetched or re-applied without a URL — the
+record exists only so that the configuration can still be undone. To revert an individual setting
+instead, change it in the VS Code settings UI or `settings.json`; **Clear** will then leave your
+value alone, since it only reverts keys that still hold the value the organization configuration
+gave them.
 
 ### One-shot local file application
 
@@ -224,8 +230,12 @@ To remove it, either:
 
 - remove `appMap.customerId` from the JSON your configuration URL serves, while the URL is still
   set — it is reverted on the next successful fetch, like any other key; or
-- run **AppMap: Set organization configuration URL** and choose **Clear**, which reverts every
-  setting the organization configuration applied, the customer ID included.
+- run **AppMap: Set organization configuration URL** and choose **Clear**, which reverts the
+  settings the organization configuration applied and always clears the customer ID, whether or not
+  a configuration URL is still set.
+
+**Clear** is the only way to remove a customer ID locally: the setting is inert, and the value is
+held in the extension's own storage rather than in `settings.json`.
 
 On a bundled build, clearing reverts to the customer ID built into the VSIX rather than to nothing —
 that value is part of the installation. To run a bundled build unentitled, install a standard build

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -39,3 +39,13 @@ CLI:
 - `SPLUNK_URL`: The URL of your Splunk HEC endpoint.
 - `SPLUNK_TOKEN`: Your Splunk HEC token.
 - `SPLUNK_CA_CERT`: Your CA certificate.
+
+## Customer ID
+
+If a customer ID has been configured for your installation — see
+[Organization Configuration](organization-config.md) — it is transmitted with every telemetry event
+as the property `common.customerid`, on both backends. This lets a managed deployment attribute
+usage to the organization it was licensed to.
+
+The customer ID is only sent if telemetry is enabled and a backend is reachable. It is not an
+enforcement mechanism, and attribution derived from it is best-effort.

--- a/src/authentication/index.ts
+++ b/src/authentication/index.ts
@@ -11,6 +11,13 @@ export async function getApiKey(
   createIfNone: boolean,
   ssoTarget?: string
 ): Promise<string | undefined> {
+  // APPMAP_TEST_API_KEY is a test fixture, not a deployment mechanism, and deliberately
+  // separate from the customer ID (see doc/organization-config.md). It short-circuits
+  // vscode.authentication.getSession, whose consent prompt is blocked in test environments —
+  // see withAuthenticatedUser in test/integration/util.ts. It must keep returning a value
+  // *from* getApiKey, because the integration suite exercises the authenticated code paths;
+  // a customer ID entitles the extension without ever standing in for a credential, so the
+  // two cannot be unified without breaking that suite.
   if (!createIfNone && Environment.appMapTestApiKey) return Environment.appMapTestApiKey;
 
   let session: vscode.AuthenticationSession | undefined;

--- a/src/authentication/isActivated.ts
+++ b/src/authentication/isActivated.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { getApiKey } from '.';
+import { isEntitled } from '../configuration/customerId';
+
+/**
+ * Whether AppMap is activated for this installation: the user has signed in, or a customer ID
+ * entitles them.
+ *
+ * This is the condition deciding whether the language services may run and whether Navie is
+ * usable, so it lives in one place rather than being spelled out at each site.
+ *
+ * Deliberately its own module rather than part of `./index`: calls between functions declared
+ * in the same module compile to direct references, which `Sinon.stub(authentication,
+ * 'getApiKey')` cannot intercept — several suites rely on stubbing it. Across a module
+ * boundary the call goes through the exports object and the stub is honored.
+ */
+export default async function isActivated(context: vscode.ExtensionContext): Promise<boolean> {
+  // Entitlement first, so an entitled user never reaches getApiKey on hot paths.
+  return isEntitled(context) || Boolean(await getApiKey(false));
+}

--- a/src/commands/setConfigurationUrl.ts
+++ b/src/commands/setConfigurationUrl.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import RemoteConfig, { getConfigUrl, type Config } from '../configuration/remoteConfig';
+import { getCustomerId, getCustomerIdState } from '../configuration/customerId';
 
 export default async function setConfigurationUrl(
   context: vscode.ExtensionContext,
-  channel?: vscode.OutputChannel
+  channel: vscode.OutputChannel
 ): Promise<void> {
   const options = [
     {
@@ -15,6 +16,16 @@ export default async function setConfigurationUrl(
       label: 'Local File',
       description: 'Browse for a local JSON configuration file to one-shot apply it',
       key: 'file',
+    },
+    {
+      label: 'Clear',
+      description: 'Revert applied settings and remove the organization configuration',
+      key: 'clear',
+    },
+    {
+      label: 'Status',
+      description: 'Show the active organization configuration and entitlement',
+      key: 'status',
     },
   ];
 
@@ -73,13 +84,72 @@ export default async function setConfigurationUrl(
       }
     }
 
-    await RemoteConfig.applyLocalConfig(sanitized, channel);
+    await RemoteConfig.applyLocalConfig(context, sanitized, channel);
     await RemoteConfig.markApplied(context);
-    if (channel) {
-      channel.appendLine(`Successfully applied configuration from local file: ${uri.fsPath}`);
-    }
+    channel.appendLine(`Successfully applied configuration from local file: ${uri.fsPath}`);
     vscode.window.showInformationMessage(
       'Successfully applied local organization configuration. These settings will persist until changed manually.'
     );
+  } else if (picked.key === 'clear') {
+    await clearOrganizationConfiguration(context, channel);
+  } else if (picked.key === 'status') {
+    channel.appendLine(describeStatus(context));
   }
+}
+
+async function clearOrganizationConfiguration(
+  context: vscode.ExtensionContext,
+  channel?: vscode.OutputChannel
+): Promise<void> {
+  const configUrl = getConfigUrl();
+
+  // Reverts every key the cached configuration applied, the customer ID included, and drops
+  // the cache. Clearing the customer ID reseeds synchronously, so the value reported below is
+  // the one the user is actually left with rather than one that reappears on the next reload.
+  await RemoteConfig.rollbackRemoteConfig(context, channel);
+
+  if (configUrl?.source === 'setting') {
+    await vscode.workspace
+      .getConfiguration('appMap')
+      .update('configurationUrl', undefined, vscode.ConfigurationTarget.Global);
+  }
+
+  if (channel) channel.appendLine('Cleared organization configuration.');
+
+  const customerId = getCustomerId(context);
+  const message = ['Organization configuration cleared and its settings reverted.'];
+
+  if (customerId) {
+    message.push(
+      `The customer ID has been reset to the value from your installation (${customerId}).`
+    );
+  }
+
+  // One notification per action. An environment variable the extension cannot unset is a
+  // caveat on this outcome rather than a separate event, so it escalates the message instead
+  // of stacking a second toast on top of it.
+  if (configUrl?.source === 'env var') {
+    message.push(
+      `The URL comes from the environment variable APPMAP_CONFIG_URL (${configUrl.url}), which the extension cannot unset, so the configuration will be applied again on the next activation unless the variable is removed.`
+    );
+    vscode.window.showWarningMessage(message.join(' '));
+  } else {
+    vscode.window.showInformationMessage(message.join(' '));
+  }
+}
+
+function describeStatus(context: vscode.ExtensionContext): string {
+  const state = getCustomerIdState(context);
+  const entitlement = !state
+    ? 'This installation is not entitled by a customer ID.'
+    : state.source === 'bundled'
+    ? `Entitled via bundled installation (customer ID ${state.value}).`
+    : `Entitled via organization config (customer ID ${state.value}).`;
+
+  const configUrl = getConfigUrl();
+  const url = configUrl
+    ? `Organization configuration URL: ${configUrl.url} (source: ${configUrl.source}).`
+    : 'No organization configuration URL is set.';
+
+  return [entitlement, url].join('\n');
 }

--- a/src/configuration/customerId.ts
+++ b/src/configuration/customerId.ts
@@ -1,0 +1,241 @@
+import * as vscode from 'vscode';
+import fireAndForget from '../lib/fireAndForget';
+
+// Managed entitlement for locked-down deployments. A customer ID switches the extension
+// into its authenticated state without contacting getappmap.com; it is set by administrators
+// through the organization-configuration channels (bundled VSIX, config URL, local file).
+//
+// It is deliberately unverified. The extension is open source, so a client-side check is a
+// business-process boundary, not a security boundary. This must never be described as an
+// enforcement mechanism. It is also not a secret; see doc/organization-config.md.
+//
+// Entitlement is a separate axis from credentials: a customer ID never masquerades as an
+// API key, and getApiKey() keeps returning only real session tokens.
+
+// globalState rather than SecretStorage: the value is not a secret, and SecretStorage depends
+// on an OS keyring that is absent or broken in headless-Linux, container, and remote setups —
+// a silent get() failure there would de-entitle users unpredictably. Not registered for
+// Settings Sync, so it cannot ride onto personal machines.
+const STATE_KEY = 'appmap.customerId';
+
+const CONFIG_SECTION = 'appMap';
+const CONFIG_KEY = 'customerId';
+
+export type CustomerIdSource = 'bundled' | 'orgConfig';
+
+export interface CustomerIdState {
+  value: string;
+  source: CustomerIdSource;
+}
+
+// Blank or whitespace-only values are treated as absent throughout.
+function normalize(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+// Unrecognized shapes read as absent, so a corrupt entry self-heals by re-seeding.
+function readState(context: vscode.ExtensionContext): CustomerIdState | undefined {
+  const raw = context.globalState.get<unknown>(STATE_KEY);
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  const { value, source } = raw as Partial<CustomerIdState>;
+  if (source !== 'bundled' && source !== 'orgConfig') return undefined;
+
+  const normalized = normalize(value);
+  if (!normalized) return undefined;
+
+  return { value: normalized, source };
+}
+
+function writeState(
+  context: vscode.ExtensionContext,
+  state: CustomerIdState | undefined
+): Thenable<void> {
+  return context.globalState.update(STATE_KEY, state);
+}
+
+/**
+ * The customer ID baked into a repackaged VSIX, if any.
+ *
+ * Only the setting's *default* is consulted. `appMap.customerId` is declared in no repo
+ * package.json — build/bundleConfig.ps1 synthesizes the property from site-config.json — so
+ * the default exists only inside a bundled build. Unregistered keys are still readable through
+ * get(), so reading anything but `defaultValue` would let a hand-written settings.json entry
+ * entitle any build.
+ */
+export function bundledCustomerId(): string | undefined {
+  return normalize(
+    vscode.workspace.getConfiguration(CONFIG_SECTION).inspect<string>(CONFIG_KEY)?.defaultValue
+  );
+}
+
+/** The customer ID and where it came from, or undefined when not entitled. */
+export function getCustomerIdState(context: vscode.ExtensionContext): CustomerIdState | undefined {
+  return readState(context);
+}
+
+/** The single read path for entitlement. No other caller consults getConfiguration(). */
+export function getCustomerId(context: vscode.ExtensionContext): string | undefined {
+  return readState(context)?.value;
+}
+
+export function isEntitled(context: vscode.ExtensionContext): boolean {
+  return getCustomerId(context) !== undefined;
+}
+
+const entitlementChanged = new vscode.EventEmitter<string | undefined>();
+
+/**
+ * Fires when the effective customer ID changes, with the new value.
+ *
+ * globalState.update() announces nothing, so without this every consumer of entitlement would
+ * hold stale state until the window reloaded. It fires from the mutators rather than from their
+ * callers so that no future writer can forget to, and only on an effective change: clearing on a
+ * bundled build reseeds to the same ID, and reporting that as a transition would restart the
+ * language services for nothing.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const onDidChangeEntitlement: vscode.Event<string | undefined> = entitlementChanged.event;
+
+/**
+ * Project the bundled default onto globalState. Run once per activation, before anything
+ * consults entitlement.
+ *
+ * globalState is a projection, not an independent source of truth, but organization config
+ * wins over the bundled default: an `orgConfig` value is left alone in every case, while a
+ * `bundled` value tracks the default it came from — re-seeding when a VSIX upgrade changes it,
+ * and clearing when a vanilla build is installed over a bundled one.
+ */
+export async function seedCustomerId(context: vscode.ExtensionContext): Promise<void> {
+  const state = readState(context);
+  if (state?.source === 'orgConfig') return;
+
+  const bundled = bundledCustomerId();
+
+  if (state?.source === 'bundled') {
+    if (!bundled) await writeState(context, undefined);
+    else if (state.value !== bundled)
+      await writeState(context, { value: bundled, source: 'bundled' });
+    return;
+  }
+
+  if (bundled) await writeState(context, { value: bundled, source: 'bundled' });
+  else if (context.globalState.get(STATE_KEY) !== undefined) await writeState(context, undefined);
+}
+
+/**
+ * Record a customer ID. Internal: the value is only ever written by seeding and by
+ * organization-config apply, never by a user-facing command.
+ *
+ * Returns the resulting customer ID, which for a blank value is whatever re-seeding leaves
+ * behind rather than nothing.
+ */
+export async function setCustomerId(
+  context: vscode.ExtensionContext,
+  value: string,
+  source: CustomerIdSource
+): Promise<string | undefined> {
+  const normalized = normalize(value);
+  if (!normalized) return clearCustomerId(context);
+
+  const current = readState(context);
+  if (current?.value !== normalized || current.source !== source) {
+    await writeState(context, { value: normalized, source });
+  }
+  if (current?.value !== normalized) entitlementChanged.fire(normalized);
+
+  return normalized;
+}
+
+// The scopes a user can define the setting in, paired with the target that clears each.
+const OVERRIDE_SCOPES = [
+  ['globalValue', vscode.ConfigurationTarget.Global],
+  ['workspaceValue', vscode.ConfigurationTarget.Workspace],
+  ['workspaceFolderValue', vscode.ConfigurationTarget.WorkspaceFolder],
+] as const;
+
+type Inspection = ReturnType<vscode.WorkspaceConfiguration['inspect']>;
+
+function definedOverrides(inspection: Inspection): vscode.ConfigurationTarget[] {
+  if (!inspection) return [];
+  return OVERRIDE_SCOPES.filter(([scope]) => inspection[scope] !== undefined).map(
+    ([, target]) => target
+  );
+}
+
+/**
+ * Warn a user who sets `appMap.customerId` by hand that it does nothing.
+ *
+ * Only the setting's default is ever read, so an override is inert in every build. That is
+ * worth saying on a bundled build, where the key is a registered setting and the organization
+ * controls it anyway. In a public build the key is unregistered and this stays silent: a
+ * notification explaining that the setting has no effect would advertise the feature to
+ * precisely the one user poking at it.
+ *
+ * Warns at most once per registration, since editing settings.json fires several change
+ * events in a row.
+ */
+export function registerCustomerIdOverrideWarning(): vscode.Disposable {
+  let warned = false;
+
+  async function warnAboutOverride(): Promise<void> {
+    if (warned) return;
+
+    const inspection = vscode.workspace
+      .getConfiguration(CONFIG_SECTION)
+      .inspect<string>(CONFIG_KEY);
+    if (inspection?.defaultValue === undefined) return;
+
+    const targets = definedOverrides(inspection);
+    if (targets.length === 0) return;
+
+    // Set before awaiting, so a burst of change events cannot queue a second notification.
+    warned = true;
+
+    const removeSetting = 'Remove setting';
+    const choice = await vscode.window.showWarningMessage(
+      `The appMap.customerId setting has no effect — the customer ID for this installation is managed by your organization's configuration. Your value is being ignored.`,
+      removeSetting
+    );
+    if (choice !== removeSetting) return;
+
+    // Rewriting settings.json is offered rather than assumed, and a user can have the key
+    // defined in more than one scope.
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    for (const target of targets) await config.update(CONFIG_KEY, undefined, target);
+  }
+
+  // An override that predates this window is just as inert as one typed into it, and the
+  // change event never fires for it. Not awaited: activation must not block on a notification.
+  fireAndForget(warnAboutOverride);
+
+  return vscode.workspace.onDidChangeConfiguration((e) => {
+    // Deliberately narrow: appmapServerConfiguration.ts watches all of `appMap`, which would
+    // run this on every unrelated settings edit.
+    if (e.affectsConfiguration(`${CONFIG_SECTION}.${CONFIG_KEY}`))
+      return fireAndForget(warnAboutOverride);
+  });
+}
+
+/**
+ * Clear the customer ID, then re-seed synchronously so that a bundled build reconverges on its
+ * own ID immediately. There is no tombstone: callers can report the value the user is actually
+ * left with rather than one that reappears on the next reload.
+ *
+ * Returns the customer ID in effect afterwards, or undefined when clearing took full effect.
+ */
+export async function clearCustomerId(
+  context: vscode.ExtensionContext
+): Promise<string | undefined> {
+  const before = getCustomerId(context);
+
+  await writeState(context, undefined);
+  await seedCustomerId(context);
+
+  const after = getCustomerId(context);
+  if (before !== after) entitlementChanged.fire(after);
+
+  return after;
+}

--- a/src/configuration/remoteConfig.ts
+++ b/src/configuration/remoteConfig.ts
@@ -3,10 +3,13 @@ import * as fs from 'fs/promises';
 import tryRequest from '../lib/tryRequest';
 import { clearCustomerId, getCustomerId, setCustomerId } from './customerId';
 
+// Record of what the organization configuration applied. Retained when the URL goes away —
+// nothing is re-applied without a URL, but this is the only thing a later rollback can work
+// from. Dropped only by an explicit rollback.
 const CACHE_KEY = 'remoteConfig';
-// Permanent record that an organization configuration has been applied at least once.
-// Unlike CACHE_KEY, this is never cleared; it drives UI affordances such as hiding
-// the sign-in screen's "apply your organization's configuration" prompt.
+// Record that an organization configuration has been applied at least once. It drives UI
+// affordances such as hiding the sign-in screen's "apply your organization's configuration"
+// prompt, and survives the URL being removed; only an explicit rollback clears it.
 const APPLIED_MARKER_KEY = 'orgConfigAppliedAt';
 const TIMEOUT_MS = 3000;
 const EXCLUDED_KEY = 'appMap.configurationUrl';
@@ -104,27 +107,43 @@ async function applyConfigKeys(
   }
 }
 
-// Undo a single key previously applied from an organization configuration. Clearing the
-// customer ID reseeds, so on a bundled build the installation's own ID comes back.
+// Undo a single key previously applied from an organization configuration.
+//
+// A key the user has edited since it was applied is left alone — at that point the value is
+// theirs, not ours to revert. The customer ID is exempt: it is reverted unconditionally,
+// because entitlement has no other recovery path (the setting is inert and globalState is not
+// user-editable). Clearing it reseeds, so on a bundled build the installation's own ID returns.
 async function revertConfigKey(
   context: vscode.ExtensionContext,
   fullKey: string,
+  appliedValue: unknown,
   channel?: vscode.OutputChannel
 ): Promise<void> {
-  if (channel) {
-    channel.appendLine(`Reverting ${fullKey}`);
-  }
-
   if (fullKey === CUSTOMER_ID_KEY) {
+    if (channel) channel.appendLine(`Reverting ${fullKey}`);
     await clearCustomerId(context);
     return;
   }
 
   const subKey = fullKey.slice('appMap.'.length);
+  const appMapConfig = vscode.workspace.getConfiguration('appMap');
+  const current = appMapConfig.get(subKey);
+
+  if (JSON.stringify(current) !== JSON.stringify(appliedValue)) {
+    if (channel) {
+      channel.appendLine(
+        `Keeping ${fullKey}: changed since it was applied (${JSON.stringify(current)})`
+      );
+    }
+    return;
+  }
+
+  if (channel) {
+    channel.appendLine(`Reverting ${fullKey}`);
+  }
+
   try {
-    await vscode.workspace
-      .getConfiguration('appMap')
-      .update(subKey, undefined, vscode.ConfigurationTarget.Global);
+    await appMapConfig.update(subKey, undefined, vscode.ConfigurationTarget.Global);
   } catch (e) {
     if (channel) {
       channel.appendLine(`Failed to update configuration key ${subKey}: ${e}`);
@@ -137,12 +156,21 @@ async function rollbackRemoteConfig(
   channel?: vscode.OutputChannel
 ): Promise<void> {
   const cached = context.globalState.get<ConfigCache>(CACHE_KEY);
-  if (cached) {
-    for (const fullKey of Object.keys(cached.config)) {
-      await revertConfigKey(context, fullKey, channel);
-    }
-    await context.globalState.update(CACHE_KEY, undefined);
+
+  for (const [fullKey, appliedValue] of Object.entries(cached?.config ?? {})) {
+    // Handled below, unconditionally, so that it works even with no cache to walk.
+    if (fullKey === CUSTOMER_ID_KEY) continue;
+    await revertConfigKey(context, fullKey, appliedValue, channel);
   }
+
+  if (getCustomerId(context) !== undefined) {
+    await revertConfigKey(context, CUSTOMER_ID_KEY, undefined, channel);
+  }
+
+  await context.globalState.update(CACHE_KEY, undefined);
+  // Cleared along with everything else: this is an explicit undo, so the sign-in view's
+  // "apply your organization's configuration" prompt should be offered again.
+  await context.globalState.update(APPLIED_MARKER_KEY, undefined);
 }
 
 async function doApply(
@@ -162,7 +190,10 @@ async function doApply(
           )}`
         );
       }
-      await context.globalState.update(CACHE_KEY, undefined);
+      // The cache is deliberately kept. Nothing is re-applied without a URL — this branch
+      // applies nothing — but it stays as the record of what was applied, which is the only
+      // thing the clear command has to revert from. Dropping it here used to make clearing a
+      // no-op for anyone who removed the URL first.
     }
     return;
   }
@@ -201,8 +232,8 @@ async function doApply(
 
   // Revert keys present in old cache but absent from new fetch
   if (cached) {
-    for (const oldKey of Object.keys(cached.config)) {
-      if (!(oldKey in fetched)) await revertConfigKey(context, oldKey, channel);
+    for (const [oldKey, oldValue] of Object.entries(cached.config)) {
+      if (!(oldKey in fetched)) await revertConfigKey(context, oldKey, oldValue, channel);
     }
   }
 

--- a/src/configuration/remoteConfig.ts
+++ b/src/configuration/remoteConfig.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import tryRequest from '../lib/tryRequest';
+import { clearCustomerId, getCustomerId, setCustomerId } from './customerId';
 
 const CACHE_KEY = 'remoteConfig';
 // Permanent record that an organization configuration has been applied at least once.
@@ -9,6 +10,7 @@ const CACHE_KEY = 'remoteConfig';
 const APPLIED_MARKER_KEY = 'orgConfigAppliedAt';
 const TIMEOUT_MS = 3000;
 const EXCLUDED_KEY = 'appMap.configurationUrl';
+const CUSTOMER_ID_KEY = 'appMap.customerId';
 
 export type Config = Record<`appMap.${string}`, unknown>;
 
@@ -51,9 +53,38 @@ function sanitizeConfig(raw: unknown): Config {
   return sanitized;
 }
 
-async function applyConfigKeys(config: Config, channel?: vscode.OutputChannel): Promise<void> {
+// Diverted to globalState rather than written through getConfiguration().update(), which
+// would throw in a public build where the key is not a registered setting.
+async function applyCustomerId(
+  context: vscode.ExtensionContext,
+  value: unknown,
+  channel?: vscode.OutputChannel
+): Promise<void> {
+  const current = getCustomerId(context);
+  const applied =
+    typeof value === 'string'
+      ? await setCustomerId(context, value, 'orgConfig')
+      : await clearCustomerId(context);
+
+  if (applied !== current && channel) {
+    channel.appendLine(
+      `Setting ${CUSTOMER_ID_KEY}: ${JSON.stringify(current)} → ${JSON.stringify(applied)}`
+    );
+  }
+}
+
+async function applyConfigKeys(
+  context: vscode.ExtensionContext,
+  config: Config,
+  channel?: vscode.OutputChannel
+): Promise<void> {
   const appMapConfig = vscode.workspace.getConfiguration('appMap');
   for (const [fullKey, value] of Object.entries(config)) {
+    if (fullKey === CUSTOMER_ID_KEY) {
+      await applyCustomerId(context, value, channel);
+      continue;
+    }
+
     const subKey = fullKey.slice('appMap.'.length);
     const current = appMapConfig.get(subKey);
     if (JSON.stringify(current) !== JSON.stringify(value)) {
@@ -73,25 +104,42 @@ async function applyConfigKeys(config: Config, channel?: vscode.OutputChannel): 
   }
 }
 
+// Undo a single key previously applied from an organization configuration. Clearing the
+// customer ID reseeds, so on a bundled build the installation's own ID comes back.
+async function revertConfigKey(
+  context: vscode.ExtensionContext,
+  fullKey: string,
+  channel?: vscode.OutputChannel
+): Promise<void> {
+  if (channel) {
+    channel.appendLine(`Reverting ${fullKey}`);
+  }
+
+  if (fullKey === CUSTOMER_ID_KEY) {
+    await clearCustomerId(context);
+    return;
+  }
+
+  const subKey = fullKey.slice('appMap.'.length);
+  try {
+    await vscode.workspace
+      .getConfiguration('appMap')
+      .update(subKey, undefined, vscode.ConfigurationTarget.Global);
+  } catch (e) {
+    if (channel) {
+      channel.appendLine(`Failed to update configuration key ${subKey}: ${e}`);
+    }
+  }
+}
+
 async function rollbackRemoteConfig(
   context: vscode.ExtensionContext,
   channel?: vscode.OutputChannel
 ): Promise<void> {
   const cached = context.globalState.get<ConfigCache>(CACHE_KEY);
   if (cached) {
-    const appMapConfig = vscode.workspace.getConfiguration('appMap');
     for (const fullKey of Object.keys(cached.config)) {
-      const subKey = fullKey.slice('appMap.'.length);
-      if (channel) {
-        channel.appendLine(`Reverting ${fullKey}`);
-      }
-      try {
-        await appMapConfig.update(subKey, undefined, vscode.ConfigurationTarget.Global);
-      } catch (e) {
-        if (channel) {
-          channel.appendLine(`Failed to update configuration key ${subKey}: ${e}`);
-        }
-      }
+      await revertConfigKey(context, fullKey, channel);
     }
     await context.globalState.update(CACHE_KEY, undefined);
   }
@@ -149,21 +197,12 @@ async function doApply(
   }
 
   // Apply keys from fetched config
-  await applyConfigKeys(fetched, channel);
+  await applyConfigKeys(context, fetched, channel);
 
   // Revert keys present in old cache but absent from new fetch
   if (cached) {
-    const appMapConfig = vscode.workspace.getConfiguration('appMap');
     for (const oldKey of Object.keys(cached.config)) {
-      if (!(oldKey in fetched)) {
-        const subKey = oldKey.slice('appMap.'.length);
-        channel.appendLine(`Reverting ${oldKey}`);
-        try {
-          await appMapConfig.update(subKey, undefined, vscode.ConfigurationTarget.Global);
-        } catch (e) {
-          channel.appendLine(`Failed to update configuration key ${subKey}: ${e}`);
-        }
-      }
+      if (!(oldKey in fetched)) await revertConfigKey(context, oldKey, channel);
     }
   }
 
@@ -189,12 +228,14 @@ export default class RemoteConfig {
     return readAndParseLocalConfig(fsPath);
   }
 
-  static async applyConfigKeys(config: Config, channel?: vscode.OutputChannel): Promise<void> {
-    return applyConfigKeys(config, channel);
-  }
-
-  static applyLocalConfig(config: Config, channel?: vscode.OutputChannel): Promise<void> {
-    applyChain = applyChain.then(() => applyConfigKeys(config, channel)).catch(() => undefined);
+  static applyLocalConfig(
+    context: vscode.ExtensionContext,
+    config: Config,
+    channel?: vscode.OutputChannel
+  ): Promise<void> {
+    applyChain = applyChain
+      .then(() => applyConfigKeys(context, config, channel))
+      .catch(() => undefined);
     return applyChain;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,11 @@ import outOfDateTests from './commands/outOfDateTests';
 import PickCopilotModelCommand from './commands/pickCopilotModel';
 import QuickReviewCommand from './commands/quickReview';
 import ExtensionState from './configuration/extensionState';
+import {
+  onDidChangeEntitlement,
+  registerCustomerIdOverrideWarning,
+  seedCustomerId,
+} from './configuration/customerId';
 import AppMapEditorProvider from './editor/appmapEditorProvider';
 import appmapHoverProvider from './hover/appmapHoverProvider';
 import ProcessServiceImpl from './processServiceImpl';
@@ -98,6 +103,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
   // so any telemetry events go to the right place
   await RemoteConfig.apply(context, orgConfigChannel);
 
+  // Must follow RemoteConfig.apply, which may deliver a customer ID, and precede every
+  // consumer of entitlement: SignInManager and AnalysisManager below. Telemetry reads it
+  // lazily per event, so its position relative to Telemetry.register does not matter.
+  await seedCustomerId(context).catch((e) =>
+    orgConfigChannel.appendLine(`Failed to resolve the customer ID: ${e}`)
+  );
+
+  context.subscriptions.push(registerCustomerIdOverrideWarning());
+
   Telemetry.register(context);
 
   migrateOpenAIApiKey(context).catch((e) => {
@@ -137,7 +151,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       appmapServerAuthenticationProvider.removeSession();
     });
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register(extensionState, context);
     const signInWebview = new SignInViewProvider(context, appmapServerAuthenticationProvider);
     context.subscriptions.push(
       vscode.window.registerWebviewViewProvider(SignInViewProvider.viewType, signInWebview)
@@ -307,6 +321,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
         // child processes when the user toggles it.
         vscode.env.onDidChangeTelemetryEnabled(() =>
           restartServicesForEnvironmentChange('IDE telemetry setting changed')
+        ),
+        // APPMAP_CUSTOMER_ID is part of the subprocess environment. Current CLI releases
+        // ignore it, so this changes nothing today; omitting it would make entitlement a
+        // "works only after a reload" feature once the CLI honors the variable.
+        onDidChangeEntitlement(() =>
+          restartServicesForEnvironmentChange('AppMap customer ID changed')
         ),
         vscode.commands.registerCommand('appmap.rpc.restart', async () => {
           await rpcService.restartServer();

--- a/src/lib/fireAndForget.ts
+++ b/src/lib/fireAndForget.ts
@@ -1,0 +1,10 @@
+/**
+ * Executes an async operation or accepts a Promise, suppressing all rejections.
+ */
+export default function fireAndForget(task: Promise<unknown> | (() => Promise<unknown>)): void {
+  const promise = typeof task === 'function' ? task() : task;
+
+  promise.catch((err) => {
+    console.warn('[fireAndForget] Suppressed error:', err);
+  });
+}

--- a/src/services/analysisManager.ts
+++ b/src/services/analysisManager.ts
@@ -5,6 +5,7 @@ import FindingsIndex from './findingsIndex';
 import openFinding from '../commands/openFinding';
 import { ResolvedFinding } from './resolvedFinding';
 import Environment from '../configuration/environment';
+import { isEntitled, onDidChangeEntitlement } from '../configuration/customerId';
 import { debuglog } from 'util';
 import Watcher from './watcher';
 
@@ -26,6 +27,7 @@ export default class AnalysisManager {
   private static readonly contextKeyUserAuthenticated = 'appmap.userAuthenticated';
 
   private static _isAnalysisEnabled?: boolean;
+  private static context?: vscode.ExtensionContext;
 
   public static get isAnalysisEnabled(): boolean {
     return Boolean(this._isAnalysisEnabled);
@@ -40,6 +42,8 @@ export default class AnalysisManager {
   }
 
   public static async register(context: vscode.ExtensionContext): Promise<void> {
+    this.context = context;
+
     void this.updateAnalysisState().catch((e) => {
       console.error('Error updating analysis state on register():', e);
     });
@@ -50,7 +54,8 @@ export default class AnalysisManager {
 
         // The API key won't be available immediately. Wait a tick.
         setTimeout(this.updateAnalysisState.bind(this), 0);
-      })
+      }),
+      onDidChangeEntitlement(() => setTimeout(this.updateAnalysisState.bind(this), 0))
     );
   }
 
@@ -82,6 +87,11 @@ export default class AnalysisManager {
 
   public static async isUserAuthenticated(): Promise<boolean> {
     if (Environment.isSystemTest) return true;
+
+    // Entitlement enables analysis just as a session does. The context is stashed at
+    // register() rather than passed in, because this is also called from the install-guide
+    // webview; before register() it reads as unentitled, which is the pre-existing behavior.
+    if (this.context && isEntitled(this.context)) return true;
 
     return !!(await getApiKey(false));
   }

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { ChildProcess, OutputStream, spawn, SpawnOptions } from './nodeDependencyProcess';
 import { getApiKey } from '../authentication';
-import { getCustomerId, isEntitled } from '../configuration/customerId';
+import isActivated from '../authentication/isActivated';
+import { getCustomerId } from '../configuration/customerId';
 import assert from 'assert';
 import { fileExists, sanitizeEnvironment } from '../util';
 import { join } from 'path';
@@ -169,9 +170,8 @@ export class ProcessWatcher implements vscode.Disposable {
       };
 
     // Entitlement stands in for a session here as it does everywhere else: an entitled
-    // installation is authenticated, so its indexer and scanner have to run. Checked first so
-    // that an entitled user never reaches getApiKey — this is polled once a second.
-    if (!isEntitled(this.context) && !(await accessToken()))
+    // installation is activated, so its indexer and scanner have to run.
+    if (!(await isActivated(this.context)))
       return { enabled: false, reason: 'User is not logged in to AppMap' };
 
     return { enabled: true };

--- a/src/services/processWatcher.ts
+++ b/src/services/processWatcher.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ChildProcess, OutputStream, spawn, SpawnOptions } from './nodeDependencyProcess';
 import { getApiKey } from '../authentication';
+import { getCustomerId, isEntitled } from '../configuration/customerId';
 import assert from 'assert';
 import { fileExists, sanitizeEnvironment } from '../util';
 import { join } from 'path';
@@ -50,9 +51,16 @@ async function accessToken(): Promise<string | undefined> {
 export async function loadEnvironment(
   context: vscode.ExtensionContext
 ): Promise<NodeJS.ProcessEnv> {
+  const apiKey = await accessToken();
+  const customerId = getCustomerId(context);
+
   const env: Record<string, string | undefined> = {
     APPMAP_API_URL: ExtensionSettings.apiUrl,
-    APPMAP_API_KEY: await accessToken(),
+    // Omitted rather than faked when there is no session: a customer ID is an entitlement,
+    // not a credential, and the CLI must not mistake one for the other. Both are passed when
+    // both exist — the API key wins for authentication, the customer ID is attribution-only.
+    ...(apiKey ? { APPMAP_API_KEY: apiKey } : undefined),
+    ...(customerId ? { APPMAP_CUSTOMER_ID: customerId } : undefined),
     ...(await getSecretEnv(context)),
     ...ExtensionSettings.appMapCommandLineEnvironment,
   };
@@ -160,7 +168,10 @@ export class ProcessWatcher implements vscode.Disposable {
         reason: `Project directory '${this.configFolder}' is not configured (does not have appmap.yml)`,
       };
 
-    if (!(await accessToken()))
+    // Entitlement stands in for a session here as it does everywhere else: an entitled
+    // installation is authenticated, so its indexer and scanner have to run. Checked first so
+    // that an entitled user never reaches getApiKey — this is polled once a second.
+    if (!isEntitled(this.context) && !(await accessToken()))
       return { enabled: false, reason: 'User is not logged in to AppMap' };
 
     return { enabled: true };

--- a/src/services/rpcProcessService.ts
+++ b/src/services/rpcProcessService.ts
@@ -15,6 +15,7 @@ import AssetService from '../assets/assetService';
 import { AssetIdentifier } from '../assets';
 import { setSecretEnvVars } from './navieConfigurationService';
 import ChatCompletion from './chatCompletion';
+import fireAndForget from '../lib/fireAndForget';
 
 export type RpcConnect = (port: number) => Client;
 
@@ -78,7 +79,9 @@ export default class RpcProcessService implements Disposable {
           NodeProcessService.outputChannel.appendLine(
             'Authentication changed. Restarting the RPC server'
           );
-          this.processWatcher.restart();
+          // Through restart() rather than the watcher directly, so that signing out stops the
+          // server rather than relaunching it unauthenticated.
+          fireAndForget(this.restart());
         }, 0);
       })
     );
@@ -110,10 +113,15 @@ export default class RpcProcessService implements Disposable {
   }
 
   public port(): number | undefined {
-    return this.rpcPort;
+    // Only while the process is actually running. The port of a server that has stopped —
+    // deliberately, or by crashing — points at a dead socket, and a caller that dials it hangs
+    // instead of failing, which is far harder to diagnose than having no port at all.
+    return this.available ? this.rpcPort : undefined;
   }
 
-  public restart(): Promise<void> {
+  public async restart(): Promise<void> {
+    if (!(await this.mayRun())) return;
+
     return this.processWatcher.restart();
   }
 
@@ -231,11 +239,29 @@ export default class RpcProcessService implements Disposable {
   }
 
   public async restartServer(): Promise<void> {
-    return this.processWatcher.restart();
+    return this.restart();
   }
 
-  protected waitForStartup(): Promise<void> {
-    if (this.processWatcher.running) return Promise.resolve();
+  /**
+   * Whether the RPC server may run, stopping it if it may not.
+   *
+   * Navie's backend only runs for an activated extension — signed in, or entitled by a
+   * customer ID. Every path that would start the process goes through here, so a user who has
+   * activated neither is never left with a server listening on their machine.
+   */
+  private async mayRun(): Promise<boolean> {
+    const { enabled, reason } = await this.processWatcher.canStart();
+    if (enabled) return true;
+
+    NodeProcessService.outputChannel.appendLine(`Not starting the RPC server: ${reason}`);
+    if (this.processWatcher.running) await this.processWatcher.stop(reason);
+
+    return false;
+  }
+
+  protected async waitForStartup(): Promise<void> {
+    if (this.processWatcher.running) return;
+    if (!(await this.mayRun())) return;
 
     return new Promise((resolve, reject) => {
       // Wait for the first port change event

--- a/src/services/signInManager.ts
+++ b/src/services/signInManager.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { AUTHN_PROVIDER_NAME, getApiKey } from '../authentication';
+import { isEntitled, onDidChangeEntitlement } from '../configuration/customerId';
 import ExtensionState from '../configuration/extensionState';
 import { DEBUG_EXCEPTION, Telemetry } from '../telemetry';
 import ErrorCode from '../telemetry/definitions/errorCodes';
@@ -10,8 +11,13 @@ export default class SignInManager {
   private static signedIn: boolean;
   private static firstInstalledVersion: semver.SemVer | null;
   private static versionCutOff = '0.66.2';
+  private static context: vscode.ExtensionContext | undefined;
 
-  public static async register(extensionState: ExtensionState): Promise<void> {
+  public static async register(
+    extensionState: ExtensionState,
+    context: vscode.ExtensionContext
+  ): Promise<void> {
+    this.context = context;
     this.firstInstalledVersion = semver.coerce(extensionState.firstVersionInstalled);
     void this.updateSignInState().catch((e) => {
       console.error('Error updating sign-in state on register():', e);
@@ -29,11 +35,14 @@ export default class SignInManager {
       extensionState.setSeenWalkthrough();
     }
 
-    vscode.authentication.onDidChangeSessions((e) => {
-      if (e.provider.id !== AUTHN_PROVIDER_NAME) return;
+    context.subscriptions.push(
+      vscode.authentication.onDidChangeSessions((e) => {
+        if (e.provider.id !== AUTHN_PROVIDER_NAME) return;
 
-      setTimeout(() => this.updateSignInState(), 0);
-    });
+        setTimeout(() => this.updateSignInState(), 0);
+      }),
+      onDidChangeEntitlement(() => setTimeout(() => this.updateSignInState(), 0))
+    );
   }
 
   public static async signIn(ssoTarget?: string): Promise<void> {
@@ -52,6 +61,11 @@ export default class SignInManager {
   }
 
   private static async isUserAuthenticated(): Promise<boolean> {
+    // A customer ID entitles the installation outright. Every sign-in affordance — five
+    // sidebar views and six walkthrough steps — hangs off the appMap.showSignIn context key
+    // this feeds, so entitlement suppresses all of them without any new `when` clauses.
+    if (this.context && isEntitled(this.context)) return true;
+
     return !!(await getApiKey(false));
   }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -7,6 +7,7 @@ import TelemetryResolver from './telemetryResolver';
 import TelemetryDataProvider from './telemetryDataProvider';
 import Event from './event';
 import SplunkTelemetryReporter from './splunkTelemetryReporter';
+import { getCustomerId } from '../configuration/customerId';
 import os from 'os';
 
 const EXTENSION_ID = `${publisher}.${name}`;
@@ -50,11 +51,17 @@ export class Telemetry {
   private static reporter: Reporter = NOOP_TELEMETRY;
   private static debugChannel?: vscode.OutputChannel;
   private static isSplunk = false;
+  // Narrowly a value accessor, not a property provider: this module owns the telemetry
+  // schema — the property names, the isSplunk gating, and what doc/telemetry.md discloses —
+  // while feature modules only supply values.
+  private static customerId: () => string | undefined = () => undefined;
 
   static register(context: vscode.ExtensionContext): void {
     if (process.env.APPMAP_TELEMETRY_DEBUG) {
       this.debugChannel = vscode.window.createOutputChannel('AppMap: Telemetry');
     }
+
+    this.customerId = () => getCustomerId(context);
 
     this.initializeReporter();
 
@@ -174,21 +181,54 @@ export class Telemetry {
       metrics = await telemetry.resolve(...(event.metrics as unknown as DataResolverArray<number>));
     }
 
+    this.send(event.name, properties, metrics);
+  }
+
+  /**
+   * Properties stamped onto every event, whatever the entry point.
+   *
+   * Resolved per event rather than at registration: activation ordering then cannot matter,
+   * and a customer ID that arrives later — from seeding or an organization-config update —
+   * is picked up without reinitializing the reporter.
+   */
+  private static commonProperties(): Record<string, string> {
+    const properties: Record<string, string> = {};
+
     if (!this.isSplunk) {
-      properties = {
-        ...properties,
-        // Add common properties when using Application Insights
-        // (others are added automatically by the AI SDK).
-        'common.ide': vscode.env.appName,
-        'common.ideversion': vscode.version,
-      };
+      // The Splunk reporter merges its own copy of these into every event. The Application
+      // Insights SDK supplies the rest of the common.* set but not these two, so add them
+      // here rather than hoisting the Splunk shim, which would override the SDK's own
+      // values (losing, for instance, its normalization of common.platformversion).
+      properties['common.ide'] = vscode.env.appName;
+      properties['common.ideversion'] = vscode.version;
     }
+
+    const customerId = this.customerId();
+    if (customerId) properties['common.customerid'] = customerId;
+
+    return properties;
+  }
+
+  /**
+   * The single point at which anything reaches the reporter. Keeping it that way is what
+   * makes the common-property stamp structural rather than a matter of discipline: a new
+   * entry point cannot omit it by accident. The debug channel is written here too, so
+   * APPMAP_TELEMETRY_DEBUG output is exactly what is transmitted.
+   */
+  private static send(
+    name: string,
+    properties?: Record<string, string>,
+    metrics?: Record<string, number>,
+    isError = false
+  ): void {
+    // Common properties first: an event that names one deliberately overrides it.
+    const allProperties = { ...this.commonProperties(), ...properties };
 
     this.debugChannel?.appendLine(
       JSON.stringify(
         {
-          event: `${EXTENSION_ID}/${event.name}`,
-          properties,
+          event: `${EXTENSION_ID}/${name}`,
+          properties: allProperties,
           metrics,
         },
         null,
@@ -196,22 +236,28 @@ export class Telemetry {
       )
     );
 
-    this.reporter.sendTelemetryEvent(event.name, properties, metrics);
+    if (isError) this.reporter.sendTelemetryErrorEvent(name, allProperties, metrics);
+    else this.reporter.sendTelemetryEvent(name, allProperties, metrics);
   }
 
   static reportAction(action: string, data?: Record<string, string>): void {
-    this.reporter.sendTelemetryEvent(action, data);
+    this.send(action, data);
   }
 
   static reportWebviewError(error: Record<string, string>): void {
-    this.reporter.sendTelemetryErrorEvent('webview_error', {
-      'appmap.webview.error.message': error.message,
-      'appmap.webview.error.stack': error.stack,
-    });
+    this.send(
+      'webview_error',
+      {
+        'appmap.webview.error.message': error.message,
+        'appmap.webview.error.stack': error.stack,
+      },
+      undefined,
+      true
+    );
   }
 
   static reportOpenUri(uri: vscode.Uri): void {
-    this.reporter.sendTelemetryEvent('open_uri', { uri: uri.toString() });
+    this.send('open_uri', { uri: uri.toString() });
   }
 
   /**

--- a/src/webviews/chatSearchWebview.ts
+++ b/src/webviews/chatSearchWebview.ts
@@ -6,6 +6,7 @@ import appmapMessageHandler from './appmapMessageHandler';
 import FilterStore, { SavedFilter } from './filterStore';
 import WebviewList from './WebviewList';
 import { getApiKey } from '../authentication';
+import isActivated from '../authentication/isActivated';
 import ExtensionSettings from '../configuration/extensionSettings';
 import { CodeSelection } from '../commands/quickSearch';
 import ExtensionState from '../configuration/extensionState';
@@ -132,6 +133,22 @@ export default class ChatSearchWebview {
   }: ExplainOpts = {}): Promise<ExplainResponse> {
     const appmapRpcPort = this.dataService.appmapRpcPort;
     if (!appmapRpcPort) {
+      // Navie's backend only runs for an activated extension, so for a signed-out user there
+      // is no port because there is nothing wrong — pointing them at an output log that says
+      // nothing about signing in would be a dead end.
+      if (!(await isActivated(this.context))) {
+        const optionSignIn = 'Sign In';
+        const res = await vscode.window.showInformationMessage(
+          'Navie is available once you activate AppMap. Sign in to get started.',
+          optionSignIn,
+          'Cancel'
+        );
+        if (res === optionSignIn) {
+          await vscode.commands.executeCommand('appmap.login');
+        }
+        return { status: ExplainResponseStatus.NoAppMapRpcPort };
+      }
+
       const optionViewLog = 'View output log';
       const res = await vscode.window.showErrorMessage(
         'The AppMap RPC server was unable to start. Please check the output log for more information.',

--- a/test/unit/configuration/customerId.test.ts
+++ b/test/unit/configuration/customerId.test.ts
@@ -1,0 +1,469 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import {
+  bundledCustomerId,
+  clearCustomerId,
+  getCustomerId,
+  getCustomerIdState,
+  isEntitled,
+  onDidChangeEntitlement,
+  registerCustomerIdOverrideWarning,
+  seedCustomerId,
+  setCustomerId,
+} from '../../../src/configuration/customerId';
+import MockExtensionContext from '../../mocks/mockExtensionContext';
+import { Configuration, resetConfigurations } from '../mock/vscode/workspace';
+
+const STATE_KEY = 'appmap.customerId';
+
+describe('customerId', () => {
+  let context: MockExtensionContext;
+
+  // The bundled default that build/bundleConfig.ps1 synthesizes into a repackaged VSIX.
+  function bundleDefault(value: string | undefined) {
+    (vscode.workspace.getConfiguration('appMap') as Configuration).setDefault('customerId', value);
+  }
+
+  beforeEach(() => {
+    context = new MockExtensionContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
+    resetConfigurations();
+    Sinon.restore();
+  });
+
+  describe('bundledCustomerId()', () => {
+    it('returns the setting default on a bundled build', () => {
+      bundleDefault('acme-corp');
+      expect(bundledCustomerId()).to.equal('acme-corp');
+    });
+
+    it('is undefined on a vanilla build', () => {
+      expect(bundledCustomerId()).to.be.undefined;
+    });
+
+    it('treats a blank default as absent', () => {
+      bundleDefault('   ');
+      expect(bundledCustomerId()).to.be.undefined;
+    });
+  });
+
+  describe('seedCustomerId()', () => {
+    it('seeds from the bundled default when globalState is empty', async () => {
+      bundleDefault('acme-corp');
+      await seedCustomerId(context);
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'acme-corp', source: 'bundled' });
+    });
+
+    it('trims the seeded value', async () => {
+      bundleDefault('  acme-corp  ');
+      await seedCustomerId(context);
+      expect(getCustomerId(context)).to.equal('acme-corp');
+    });
+
+    it('does not seed from a blank default', async () => {
+      bundleDefault('   ');
+      await seedCustomerId(context);
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+
+    it('does nothing on a vanilla build with empty globalState', async () => {
+      await seedCustomerId(context);
+      expect(context.globalState.get(STATE_KEY)).to.be.undefined;
+    });
+
+    it('re-seeds when the bundled default changes across a VSIX upgrade', async () => {
+      await context.globalState.update(STATE_KEY, { value: 'old-corp', source: 'bundled' });
+      bundleDefault('new-corp');
+
+      await seedCustomerId(context);
+
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'new-corp', source: 'bundled' });
+    });
+
+    it('leaves an unchanged bundled value alone', async () => {
+      bundleDefault('acme-corp');
+      await seedCustomerId(context);
+      await seedCustomerId(context);
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'acme-corp', source: 'bundled' });
+    });
+
+    it('clears a bundled value when a vanilla build is installed over a bundled one', async () => {
+      await context.globalState.update(STATE_KEY, { value: 'acme-corp', source: 'bundled' });
+
+      await seedCustomerId(context);
+
+      expect(getCustomerId(context)).to.be.undefined;
+      expect(context.globalState.get(STATE_KEY)).to.be.undefined;
+    });
+
+    it('does not clobber an orgConfig value with the bundled default', async () => {
+      await context.globalState.update(STATE_KEY, { value: 'from-url', source: 'orgConfig' });
+      bundleDefault('acme-corp');
+
+      await seedCustomerId(context);
+
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'from-url', source: 'orgConfig' });
+    });
+
+    it('keeps an orgConfig value on a vanilla build', async () => {
+      await context.globalState.update(STATE_KEY, { value: 'from-url', source: 'orgConfig' });
+
+      await seedCustomerId(context);
+
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'from-url', source: 'orgConfig' });
+    });
+
+    it('self-heals a corrupt entry by re-seeding', async () => {
+      await context.globalState.update(STATE_KEY, { value: 42, source: 'nonsense' });
+      bundleDefault('acme-corp');
+
+      await seedCustomerId(context);
+
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'acme-corp', source: 'bundled' });
+    });
+
+    it('discards a corrupt entry when there is no bundled default', async () => {
+      await context.globalState.update(STATE_KEY, 'not-an-object');
+
+      await seedCustomerId(context);
+
+      expect(context.globalState.get(STATE_KEY)).to.be.undefined;
+    });
+  });
+
+  describe('getCustomerId()', () => {
+    it('ignores a globalValue override of the setting', async () => {
+      await vscode.workspace
+        .getConfiguration('appMap')
+        .update('customerId', 'hand-written', vscode.ConfigurationTarget.Global);
+
+      await seedCustomerId(context);
+
+      expect(getCustomerId(context)).to.be.undefined;
+      expect(isEntitled(context)).to.be.false;
+    });
+
+    it('ignores a settings override even on a bundled build', async () => {
+      bundleDefault('acme-corp');
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await seedCustomerId(context);
+
+      expect(getCustomerId(context)).to.equal('acme-corp');
+    });
+
+    it('reports entitlement once a value is present', async () => {
+      expect(isEntitled(context)).to.be.false;
+      await setCustomerId(context, 'from-url', 'orgConfig');
+      expect(isEntitled(context)).to.be.true;
+    });
+  });
+
+  describe('setCustomerId()', () => {
+    it('records the value and its provenance', async () => {
+      const result = await setCustomerId(context, 'from-url', 'orgConfig');
+      expect(result).to.equal('from-url');
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'from-url', source: 'orgConfig' });
+    });
+
+    it('trims the value', async () => {
+      await setCustomerId(context, '  from-url\n', 'orgConfig');
+      expect(getCustomerId(context)).to.equal('from-url');
+    });
+
+    it('overrides a bundled value', async () => {
+      bundleDefault('acme-corp');
+      await seedCustomerId(context);
+
+      await setCustomerId(context, 'from-url', 'orgConfig');
+
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'from-url', source: 'orgConfig' });
+    });
+
+    it('treats a blank value as a clear', async () => {
+      await setCustomerId(context, 'from-url', 'orgConfig');
+
+      const result = await setCustomerId(context, '  ', 'orgConfig');
+
+      expect(result).to.be.undefined;
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+
+    it('reconverges on the bundled default when cleared by a blank value', async () => {
+      bundleDefault('acme-corp');
+      await setCustomerId(context, 'from-url', 'orgConfig');
+
+      const result = await setCustomerId(context, '', 'orgConfig');
+
+      expect(result).to.equal('acme-corp');
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'acme-corp', source: 'bundled' });
+    });
+  });
+
+  // globalState.update() fires nothing of its own, so entitlement gained or lost mid-session
+  // has to be announced or every consumer keeps stale state until reload.
+  describe('onDidChangeEntitlement', () => {
+    let fired: (string | undefined)[];
+    let subscription: vscode.Disposable;
+
+    beforeEach(() => {
+      fired = [];
+      subscription = onDidChangeEntitlement((value) => fired.push(value));
+    });
+
+    afterEach(() => subscription.dispose());
+
+    it('fires when entitlement is gained', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      expect(fired).to.deep.equal(['acme-corp']);
+    });
+
+    it('fires when the customer ID changes', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      await setCustomerId(context, 'other-corp', 'orgConfig');
+      expect(fired).to.deep.equal(['acme-corp', 'other-corp']);
+    });
+
+    it('fires when entitlement is lost', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      fired.length = 0;
+
+      await clearCustomerId(context);
+
+      expect(fired).to.deep.equal([undefined]);
+    });
+
+    it('does not fire when the same value is written again', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      fired.length = 0;
+
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+      expect(fired).to.be.empty;
+    });
+
+    it('does not fire when only the provenance changes', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      fired.length = 0;
+
+      await setCustomerId(context, 'acme-corp', 'bundled');
+
+      expect(fired).to.be.empty;
+      expect(getCustomerIdState(context)?.source).to.equal('bundled');
+    });
+
+    // Otherwise the clear command bounces the RPC server to announce a transition that
+    // did not happen.
+    it('does not fire when clearing reseeds a bundled build to the same ID', async () => {
+      bundleDefault('acme-corp');
+      await seedCustomerId(context);
+      fired.length = 0;
+
+      await clearCustomerId(context);
+
+      expect(fired).to.be.empty;
+      expect(getCustomerId(context)).to.equal('acme-corp');
+    });
+
+    it('fires when clearing an orgConfig value reveals a different bundled default', async () => {
+      bundleDefault('acme-corp');
+      await setCustomerId(context, 'other-corp', 'orgConfig');
+      fired.length = 0;
+
+      await clearCustomerId(context);
+
+      expect(fired).to.deep.equal(['acme-corp']);
+    });
+
+    // Activation-only, and always ahead of any subscriber.
+    it('does not fire from seedCustomerId', async () => {
+      bundleDefault('acme-corp');
+
+      await seedCustomerId(context);
+
+      expect(fired).to.be.empty;
+    });
+
+    it('fires once when a blank value collapses to a clear', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      fired.length = 0;
+
+      await setCustomerId(context, '   ', 'orgConfig');
+
+      expect(fired).to.deep.equal([undefined]);
+    });
+  });
+
+  // A hand-written appMap.customerId is inert, since only the setting's default is read.
+  // On a bundled build that is worth saying out loud; in a public build a notification
+  // explaining that the setting does nothing would advertise the feature to the one user
+  // poking at it.
+  describe('registerCustomerIdOverrideWarning()', () => {
+    let fireConfigChange: (section: string) => unknown;
+    let showWarningMessage: Sinon.SinonStub;
+    let subscription: vscode.Disposable | undefined;
+
+    beforeEach(() => {
+      let listener: ((e: vscode.ConfigurationChangeEvent) => unknown) | undefined;
+      Sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((cb) => {
+        listener = cb;
+        return { dispose: () => undefined };
+      });
+      fireConfigChange = (section: string) =>
+        listener?.({ affectsConfiguration: (s: string) => s === section });
+      showWarningMessage = Sinon.stub(vscode.window, 'showWarningMessage').resolves(undefined);
+      subscription = undefined;
+    });
+
+    afterEach(() => subscription?.dispose());
+
+    // The check at registration time is fire-and-forget, so let it settle.
+    async function register() {
+      subscription = registerCustomerIdOverrideWarning();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    // An override set before the window reloaded is just as inert, and just as confusing.
+    it('warns about an override that is already present at registration', async () => {
+      bundleDefault('acme-corp');
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await register();
+
+      expect(showWarningMessage.calledOnce).to.be.true;
+    });
+
+    it('stays silent at registration when there is no override', async () => {
+      bundleDefault('acme-corp');
+
+      await register();
+
+      expect(showWarningMessage.called).to.be.false;
+    });
+
+    it('does not warn twice when an override present at registration is then edited', async () => {
+      bundleDefault('acme-corp');
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await register();
+      await fireConfigChange('appMap.customerId');
+
+      expect(showWarningMessage.calledOnce).to.be.true;
+    });
+
+    it('stays silent in a public build, where the key is unregistered', async () => {
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+      await register();
+
+      await fireConfigChange('appMap.customerId');
+
+      expect(showWarningMessage.called).to.be.false;
+    });
+
+    it('stays silent on a bundled build with no override', async () => {
+      bundleDefault('acme-corp');
+      await register();
+
+      await fireConfigChange('appMap.customerId');
+
+      expect(showWarningMessage.called).to.be.false;
+    });
+
+    it('warns when a registered key is overridden mid-session', async () => {
+      bundleDefault('acme-corp');
+      await register();
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await fireConfigChange('appMap.customerId');
+
+      expect(showWarningMessage.calledOnce).to.be.true;
+      expect(String(showWarningMessage.firstCall.args[0])).to.include('appMap.customerId');
+    });
+
+    it('ignores changes to other settings', async () => {
+      bundleDefault('acme-corp');
+      await register();
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await fireConfigChange('appMap.configurationUrl');
+
+      expect(showWarningMessage.called).to.be.false;
+    });
+
+    // Editing settings.json fires several change events in a row.
+    it('warns at most once per session', async () => {
+      bundleDefault('acme-corp');
+      await register();
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+
+      await fireConfigChange('appMap.customerId');
+      await fireConfigChange('appMap.customerId');
+      await fireConfigChange('appMap.customerId');
+
+      expect(showWarningMessage.calledOnce).to.be.true;
+    });
+
+    it('removes the setting from every scope that defines it when asked', async () => {
+      const update = Sinon.stub().resolves();
+      Sinon.stub(vscode.workspace, 'getConfiguration').returns({
+        inspect: () => ({
+          key: 'appMap.customerId',
+          defaultValue: 'acme-corp',
+          globalValue: 'hand-written',
+          workspaceValue: 'also-hand-written',
+        }),
+        update,
+      } as unknown as vscode.WorkspaceConfiguration);
+      showWarningMessage.resolves('Remove setting');
+      await register();
+
+      await fireConfigChange('appMap.customerId');
+
+      expect(update.callCount).to.equal(2);
+      expect(update.calledWith('customerId', undefined, vscode.ConfigurationTarget.Global)).to.be
+        .true;
+      expect(update.calledWith('customerId', undefined, vscode.ConfigurationTarget.Workspace)).to.be
+        .true;
+    });
+
+    it('leaves the setting alone when the warning is dismissed', async () => {
+      bundleDefault('acme-corp');
+      await vscode.workspace.getConfiguration('appMap').update('customerId', 'hand-written');
+      await register();
+
+      await fireConfigChange('appMap.customerId');
+
+      expect(vscode.workspace.getConfiguration('appMap').get('customerId')).to.equal(
+        'hand-written'
+      );
+    });
+  });
+
+  describe('clearCustomerId()', () => {
+    it('clears fully on a vanilla build', async () => {
+      await setCustomerId(context, 'from-url', 'orgConfig');
+
+      const result = await clearCustomerId(context);
+
+      expect(result).to.be.undefined;
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+
+    it('re-seeds synchronously on a bundled build', async () => {
+      bundleDefault('acme-corp');
+      await setCustomerId(context, 'from-url', 'orgConfig');
+
+      const result = await clearCustomerId(context);
+
+      expect(result).to.equal('acme-corp');
+      expect(getCustomerIdState(context)).to.deep.equal({ value: 'acme-corp', source: 'bundled' });
+    });
+  });
+});

--- a/test/unit/mock/vscode/commands.ts
+++ b/test/unit/mock/vscode/commands.ts
@@ -1,6 +1,11 @@
+/* eslint @typescript-eslint/no-unused-vars: 0 */
+
+// Mirrors vscode.commands.executeCommand(command: string, ...rest: any[]): Thenable<T>.
+// The parameters are declared so that stubs of it carry a usable argument tuple, and callers
+// can assert on the command id and its arguments.
 export default {
-  executeCommand() {
-    return;
+  executeCommand(_command: string, ..._rest: unknown[]): Promise<unknown> {
+    return Promise.resolve(undefined);
   },
   registerCommand() {
     return {

--- a/test/unit/mock/vscode/env.ts
+++ b/test/unit/mock/vscode/env.ts
@@ -15,3 +15,6 @@ export async function asExternalUri(uri: Uri) {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const uriScheme = 'vscode-test';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const appName = 'Visual Studio Code';

--- a/test/unit/mock/vscode/index.ts
+++ b/test/unit/mock/vscode/index.ts
@@ -84,6 +84,7 @@ const MockVSCode = {
   commands,
   StatusBarAlignment,
   env,
+  version: '1.100.0',
   // Minimal stand-in for vscode.TreeItem: enough for TreeDataProvider unit tests to
   // read back the label/collapsible state and the fields providers commonly set.
   TreeItem: class {

--- a/test/unit/mock/vscode/workspace.ts
+++ b/test/unit/mock/vscode/workspace.ts
@@ -36,6 +36,15 @@ export const EVENTS = {
 };
 
 export class Configuration extends Map<string, unknown> {
+  // Defaults declared by a package.json `contributes.configuration` property. Values
+  // written through update() are the equivalent of `globalValue`.
+  private readonly defaults = new Map<string, unknown>();
+
+  setDefault(key: string, value: unknown): void {
+    if (value === undefined) this.defaults.delete(key);
+    else this.defaults.set(key, value);
+  }
+
   get(key: string, defaultValue?: unknown): unknown {
     let value = super.get(key);
 
@@ -53,7 +62,7 @@ export class Configuration extends Map<string, unknown> {
       value = current;
     }
 
-    value = value ?? defaultValue;
+    value = value ?? this.defaults.get(key) ?? defaultValue;
     // Simulate VS Code's proxy-backed configuration objects, which do not support
     // property deletion (attempting to do so throws a TypeError at runtime).
     if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
@@ -62,8 +71,13 @@ export class Configuration extends Map<string, unknown> {
     return value;
   }
 
-  inspect(key: string): { workspaceValue?: unknown } | undefined {
-    return {};
+  inspect(key: string): {
+    key: string;
+    defaultValue?: unknown;
+    globalValue?: unknown;
+    workspaceValue?: unknown;
+  } {
+    return { key, defaultValue: this.defaults.get(key), globalValue: super.get(key) };
   }
 
   update(key: string, value: unknown, target?: unknown): Promise<void> {

--- a/test/unit/remoteConfig.test.ts
+++ b/test/unit/remoteConfig.test.ts
@@ -10,9 +10,15 @@ import * as os from 'os';
 
 import RemoteConfig, { getConfigUrl } from '../../src/configuration/remoteConfig';
 import setConfigurationUrl from '../../src/commands/setConfigurationUrl';
+import {
+  getCustomerId,
+  getCustomerIdState,
+  seedCustomerId,
+  setCustomerId,
+} from '../../src/configuration/customerId';
 import MockExtensionContext from '../mocks/mockExtensionContext';
 import { getOutputChannelLines } from './mock/vscode/window';
-import { resetConfigurations } from './mock/vscode/workspace';
+import { Configuration, resetConfigurations } from './mock/vscode/workspace';
 
 describe('remoteConfig', () => {
   let context: MockExtensionContext;
@@ -323,6 +329,124 @@ describe('remoteConfig', () => {
     });
   });
 
+  // appMap.customerId arrives through the ordinary Config channel, but must not be written
+  // through getConfiguration().update() — the key is unregistered in public builds.
+  describe('apply() — customer ID', () => {
+    const url = 'https://example.com/config.json';
+
+    function bundleDefault(value: string | undefined) {
+      (vscode.workspace.getConfiguration('appMap') as Configuration).setDefault(
+        'customerId',
+        value
+      );
+    }
+
+    beforeEach(() => {
+      vscode.workspace.getConfiguration('appMap').update('configurationUrl', url);
+    });
+
+    it('diverts the key to globalState rather than to settings', async () => {
+      nock('https://example.com').get('/config.json').reply(200, {
+        'appMap.customerId': 'acme-corp',
+      });
+
+      await RemoteConfig.apply(context, channel);
+
+      expect(getCustomerIdState(context)).to.deep.equal({
+        value: 'acme-corp',
+        source: 'orgConfig',
+      });
+      expect(vscode.workspace.getConfiguration('appMap').get('customerId')).to.be.undefined;
+    });
+
+    it('logs the change', async () => {
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+
+      await RemoteConfig.apply(context, channel);
+
+      expect(lines.some((l) => l.includes('appMap.customerId') && l.includes('acme-corp'))).to.be
+        .true;
+    });
+
+    it('does not log a change when the value is unchanged', async () => {
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+      await RemoteConfig.apply(context, channel);
+
+      lines.length = 0;
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+      await RemoteConfig.apply(context, channel);
+
+      expect(lines.some((l) => l.includes('appMap.customerId'))).to.be.false;
+    });
+
+    it('treats a blank value as no entitlement', async () => {
+      nock('https://example.com').get('/config.json').reply(200, { 'appMap.customerId': '   ' });
+
+      await RemoteConfig.apply(context, channel);
+
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+
+    // Otherwise removing the key from the remote JSON silently leaves the org entitled.
+    it('clears the customer ID when the key disappears from the fetched config', async () => {
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+      await RemoteConfig.apply(context, channel);
+
+      nock('https://example.com').get('/config.json').reply(200, {});
+      await RemoteConfig.apply(context, channel);
+
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+
+    it('reseeds to the bundled default when the key disappears on a bundled build', async () => {
+      bundleDefault('bundled-corp');
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+      await RemoteConfig.apply(context, channel);
+
+      nock('https://example.com').get('/config.json').reply(200, {});
+      await RemoteConfig.apply(context, channel);
+
+      expect(getCustomerIdState(context)).to.deep.equal({
+        value: 'bundled-corp',
+        source: 'bundled',
+      });
+    });
+
+    // Deliberate: matches the existing fallback behavior and the offline-resilience goal.
+    it('re-establishes entitlement from the cached config when the URL is unreachable', async () => {
+      await context.globalState.update('remoteConfig', {
+        url,
+        config: { 'appMap.customerId': 'acme-corp' },
+      });
+      nock('https://example.com').get('/config.json').reply(500);
+
+      await RemoteConfig.apply(context, channel);
+
+      expect(getCustomerId(context)).to.equal('acme-corp');
+    });
+
+    it('is cleared by rollbackRemoteConfig', async () => {
+      nock('https://example.com')
+        .get('/config.json')
+        .reply(200, { 'appMap.customerId': 'acme-corp' });
+      await RemoteConfig.apply(context, channel);
+
+      await RemoteConfig.rollbackRemoteConfig(context, channel);
+
+      expect(getCustomerId(context)).to.be.undefined;
+    });
+  });
+
   describe('readAndParseLocalConfig()', () => {
     it('returns a sanitized Config when the file is valid JSON and a valid object', async () => {
       const tempFile = path.join(os.tmpdir(), 'valid-config.json');
@@ -501,6 +625,21 @@ describe('remoteConfig', () => {
           .to.be.true;
       });
 
+      it('diverts a customer ID in the file to globalState', async () => {
+        showOpenDialogStub.resolves([
+          { fsPath: '/path/to/config.json' },
+        ] as unknown as vscode.Uri[]);
+        readConfigStub.resolves({ 'appMap.customerId': 'acme-corp' });
+
+        await setConfigurationUrl(context, channel);
+
+        expect(getCustomerIdState(context)).to.deep.equal({
+          value: 'acme-corp',
+          source: 'orgConfig',
+        });
+        expect(vscode.workspace.getConfiguration('appMap').get('customerId')).to.be.undefined;
+      });
+
       it('rolls back active configuration URL and cached keys before applying', async () => {
         // First set up an active configuration URL and cache
         vscode.workspace
@@ -543,6 +682,159 @@ describe('remoteConfig', () => {
             'Successfully applied local organization configuration. These settings will persist until changed manually.'
           )
         ).to.be.true;
+      });
+    });
+
+    describe('Clear option', () => {
+      let showInformationMessageStub: Sinon.SinonStub;
+      let showWarningMessageStub: Sinon.SinonStub;
+
+      beforeEach(() => {
+        Sinon.stub(vscode.window, 'showQuickPick').resolves({
+          label: 'Clear',
+          key: 'clear',
+        } as unknown as vscode.QuickPickItem);
+        showInformationMessageStub = Sinon.stub(vscode.window, 'showInformationMessage');
+        showWarningMessageStub = Sinon.stub(vscode.window, 'showWarningMessage');
+      });
+
+      async function applyConfig(config: Record<string, unknown>) {
+        const url = 'https://example.com/config.json';
+        vscode.workspace.getConfiguration('appMap').update('configurationUrl', url);
+        nock('https://example.com').get('/config.json').reply(200, config);
+        await RemoteConfig.apply(context, channel);
+      }
+
+      it('reverts applied keys, drops the cache and clears the URL', async () => {
+        await applyConfig({ 'appMap.navie.rpcPort': 3000 });
+
+        await setConfigurationUrl(context, channel);
+
+        expect(vscode.workspace.getConfiguration('appMap').get('navie.rpcPort')).to.be.undefined;
+        expect(context.globalState.get('remoteConfig')).to.be.undefined;
+        expect(vscode.workspace.getConfiguration('appMap').get('configurationUrl')).to.be.undefined;
+      });
+
+      it('clears the customer ID', async () => {
+        await applyConfig({ 'appMap.customerId': 'acme-corp' });
+
+        await setConfigurationUrl(context, channel);
+
+        expect(getCustomerId(context)).to.be.undefined;
+      });
+
+      it('reports the reseeded customer ID on a bundled build', async () => {
+        (vscode.workspace.getConfiguration('appMap') as Configuration).setDefault(
+          'customerId',
+          'bundled-corp'
+        );
+        await applyConfig({ 'appMap.customerId': 'acme-corp' });
+
+        await setConfigurationUrl(context, channel);
+
+        expect(getCustomerIdState(context)).to.deep.equal({
+          value: 'bundled-corp',
+          source: 'bundled',
+        });
+        expect(
+          showInformationMessageStub
+            .getCalls()
+            .some((c) => String(c.args[0]).includes('bundled-corp'))
+        ).to.be.true;
+      });
+
+      // The extension cannot unset an environment variable for the next session.
+      it('warns when the URL comes from APPMAP_CONFIG_URL', async () => {
+        process.env.APPMAP_CONFIG_URL = 'https://env.example.com/config.json';
+        nock('https://env.example.com').get('/config.json').reply(200, {});
+        await RemoteConfig.apply(context, channel);
+
+        await setConfigurationUrl(context, channel);
+
+        expect(
+          showWarningMessageStub
+            .getCalls()
+            .some((c) => String(c.args[0]).includes('APPMAP_CONFIG_URL'))
+        ).to.be.true;
+      });
+
+      // Two toasts at once for one action reads as a malfunction.
+      it('reports the outcome in a single notification', async () => {
+        process.env.APPMAP_CONFIG_URL = 'https://env.example.com/config.json';
+        nock('https://env.example.com')
+          .get('/config.json')
+          .reply(200, { 'appMap.customerId': 'acme-corp' });
+        await RemoteConfig.apply(context, channel);
+
+        await setConfigurationUrl(context, channel);
+
+        expect(showWarningMessageStub.callCount).to.equal(1);
+        expect(showInformationMessageStub.called).to.be.false;
+        expect(String(showWarningMessageStub.firstCall.args[0])).to.include('cleared');
+      });
+
+      it('does not warn when the URL comes from the setting', async () => {
+        await applyConfig({});
+
+        await setConfigurationUrl(context, channel);
+
+        expect(showWarningMessageStub.called).to.be.false;
+      });
+    });
+
+    describe('Status option', () => {
+      beforeEach(() => {
+        Sinon.stub(vscode.window, 'showQuickPick').resolves({
+          label: 'Status',
+          key: 'status',
+        } as unknown as vscode.QuickPickItem);
+      });
+
+      function reportedStatus(): string {
+        return lines.join('\n');
+      }
+
+      it('reports that the installation is not entitled', async () => {
+        await setConfigurationUrl(context, channel);
+        expect(reportedStatus()).to.include('not entitled');
+      });
+
+      it('reports entitlement via organization config, with the ID', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        await setConfigurationUrl(context, channel);
+
+        expect(reportedStatus()).to.include('organization config');
+        expect(reportedStatus()).to.include('acme-corp');
+      });
+
+      it('reports entitlement via the bundled installation', async () => {
+        (vscode.workspace.getConfiguration('appMap') as Configuration).setDefault(
+          'customerId',
+          'bundled-corp'
+        );
+        await seedCustomerId(context);
+
+        await setConfigurationUrl(context, channel);
+
+        expect(reportedStatus()).to.include('bundled installation');
+        expect(reportedStatus()).to.include('bundled-corp');
+      });
+
+      it('reports the configuration URL and its source', async () => {
+        vscode.workspace
+          .getConfiguration('appMap')
+          .update('configurationUrl', 'https://example.com/config.json');
+
+        await setConfigurationUrl(context, channel);
+
+        expect(reportedStatus()).to.include('https://example.com/config.json');
+        expect(reportedStatus()).to.include('setting');
+      });
+
+      it('reports when no configuration URL is set', async () => {
+        await setConfigurationUrl(context, channel);
+        expect(reportedStatus()).to.match(/no organization configuration url/i);
       });
     });
   });

--- a/test/unit/remoteConfig.test.ts
+++ b/test/unit/remoteConfig.test.ts
@@ -97,6 +97,20 @@ describe('remoteConfig', () => {
       await RemoteConfig.apply(context, channel);
       expect(context.globalState.get('remoteConfig')).to.be.undefined;
     });
+
+    // The keys stay applied, so the record of what was applied has to stay too — it is the
+    // only thing the Clear command has to work from.
+    it('retains the cached config for later rollback', async () => {
+      const cached = {
+        url: 'https://example.com/old.json',
+        config: { 'appMap.navie.rpcPort': 3000 },
+      };
+      await context.globalState.update('remoteConfig', cached);
+
+      await RemoteConfig.apply(context, channel);
+
+      expect(context.globalState.get('remoteConfig')).to.deep.equal(cached);
+    });
   });
 
   describe('apply() — successful fetch via HTTP', () => {
@@ -717,6 +731,78 @@ describe('remoteConfig', () => {
 
       it('clears the customer ID', async () => {
         await applyConfig({ 'appMap.customerId': 'acme-corp' });
+
+        await setConfigurationUrl(context, channel);
+
+        expect(getCustomerId(context)).to.be.undefined;
+      });
+
+      it('clears the applied marker so the sign-in prompt returns', async () => {
+        await applyConfig({ 'appMap.navie.rpcPort': 3000 });
+        expect(RemoteConfig.isApplied(context)).to.be.true;
+
+        await setConfigurationUrl(context, channel);
+
+        expect(RemoteConfig.isApplied(context)).to.be.false;
+      });
+
+      // A key the user has since edited is theirs, not ours to revert.
+      it('leaves a key whose value changed after it was applied', async () => {
+        await applyConfig({ 'appMap.navie.rpcPort': 3000, 'appMap.useAnimation': true });
+        await vscode.workspace.getConfiguration('appMap').update('navie.rpcPort', 9999);
+
+        await setConfigurationUrl(context, channel);
+
+        expect(vscode.workspace.getConfiguration('appMap').get('navie.rpcPort')).to.equal(9999);
+        expect(vscode.workspace.getConfiguration('appMap').get('useAnimation')).to.be.undefined;
+      });
+
+      // Removing the URL leaves the settings applied (single-shot mode), so the record of what
+      // was applied has to survive for Clear to have anything to revert.
+      describe('after the URL has been removed', () => {
+        async function removeUrl() {
+          await vscode.workspace
+            .getConfiguration('appMap')
+            .update('configurationUrl', undefined, vscode.ConfigurationTarget.Global);
+          // The configuration-change listener re-runs apply() when the URL setting changes.
+          await RemoteConfig.apply(context, channel);
+        }
+
+        it('still reverts the applied keys', async () => {
+          await applyConfig({ 'appMap.navie.rpcPort': 3000 });
+          await removeUrl();
+          expect(vscode.workspace.getConfiguration('appMap').get('navie.rpcPort')).to.equal(3000);
+
+          await setConfigurationUrl(context, channel);
+
+          expect(vscode.workspace.getConfiguration('appMap').get('navie.rpcPort')).to.be.undefined;
+        });
+
+        it('still clears the customer ID', async () => {
+          await applyConfig({ 'appMap.customerId': 'acme-corp' });
+          await removeUrl();
+          expect(getCustomerId(context)).to.equal('acme-corp');
+
+          await setConfigurationUrl(context, channel);
+
+          expect(getCustomerId(context)).to.be.undefined;
+        });
+
+        it('still clears the applied marker', async () => {
+          await applyConfig({ 'appMap.navie.rpcPort': 3000 });
+          await removeUrl();
+
+          await setConfigurationUrl(context, channel);
+
+          expect(RemoteConfig.isApplied(context)).to.be.false;
+        });
+      });
+
+      // Entitlement has no other recovery path: the setting is inert and globalState is not
+      // user-editable, so Clear must de-entitle even with no cached configuration to walk.
+      it('clears the customer ID even when no cached configuration remains', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+        expect(context.globalState.get('remoteConfig')).to.be.undefined;
 
         await setConfigurationUrl(context, channel);
 

--- a/test/unit/services/analysisManager.test.ts
+++ b/test/unit/services/analysisManager.test.ts
@@ -1,0 +1,98 @@
+import '../mock/vscode';
+
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import * as auth from '../../../src/authentication';
+import AnalysisManager, { AnalysisToggleEvent } from '../../../src/services/analysisManager';
+import Environment from '../../../src/configuration/environment';
+import { clearCustomerId, setCustomerId } from '../../../src/configuration/customerId';
+import MockExtensionContext from '../../mocks/mockExtensionContext';
+import { waitFor } from '../../waitFor';
+
+describe('AnalysisManager', () => {
+  let context: MockExtensionContext;
+  let getApiKey: Sinon.SinonStub;
+
+  beforeEach(async () => {
+    context = new MockExtensionContext();
+    // Otherwise this short-circuits to true before entitlement is ever consulted.
+    Sinon.stub(Environment, 'isSystemTest').value(false);
+    getApiKey = Sinon.stub(auth, 'getApiKey').resolves(undefined);
+    await AnalysisManager.register(context);
+  });
+
+  afterEach(async () => {
+    context.dispose();
+    await clearCustomerId(context);
+    Sinon.restore();
+  });
+
+  describe('isUserAuthenticated', () => {
+    it('is false without a session and without a customer ID', async () => {
+      expect(await AnalysisManager.isUserAuthenticated()).to.be.false;
+    });
+
+    it('is true with a session', async () => {
+      getApiKey.resolves('fake api key');
+      expect(await AnalysisManager.isUserAuthenticated()).to.be.true;
+    });
+
+    it('is true with a customer ID and no session', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      // register() already resolved the state once, while still unentitled.
+      getApiKey.resetHistory();
+
+      expect(await AnalysisManager.isUserAuthenticated()).to.be.true;
+      expect(getApiKey.notCalled).to.be.true;
+    });
+
+    it('is false again once entitlement is cleared', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      await clearCustomerId(context);
+      expect(await AnalysisManager.isUserAuthenticated()).to.be.false;
+    });
+  });
+
+  describe('when entitlement changes mid-session', () => {
+    let toggles: AnalysisToggleEvent[];
+    let subscription: { dispose(): unknown };
+
+    beforeEach(() => {
+      // Enabling analysis builds a findings index, diagnostics provider and file-system
+      // watcher, none of which the vscode mock supports; the integration suite covers them.
+      // What matters here is that the entitlement event drives the state transition at all.
+      const internals = AnalysisManager as unknown as {
+        onAnalysisEnabled(): void;
+        onAnalysisDisabled(): void;
+      };
+      Sinon.stub(internals, 'onAnalysisEnabled');
+      Sinon.stub(internals, 'onAnalysisDisabled');
+
+      toggles = [];
+      subscription = AnalysisManager.onAnalysisToggled((e) => toggles.push(e));
+    });
+
+    afterEach(() => subscription.dispose());
+
+    it('enables analysis when a customer ID arrives', async () => {
+      expect(AnalysisManager.isAnalysisEnabled).to.be.false;
+
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+      await waitFor('analysis to be enabled', () => AnalysisManager.isAnalysisEnabled);
+      expect(toggles).to.deep.equal([{ enabled: true, userAuthenticated: true }]);
+    });
+
+    it('disables analysis when entitlement is withdrawn', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+      await waitFor('analysis to be enabled', () => AnalysisManager.isAnalysisEnabled);
+      toggles.length = 0;
+
+      await clearCustomerId(context);
+
+      await waitFor('analysis to be disabled', () => !AnalysisManager.isAnalysisEnabled);
+      expect(toggles).to.deep.equal([{ enabled: false, userAuthenticated: false }]);
+    });
+  });
+});

--- a/test/unit/services/processWatcher.test.ts
+++ b/test/unit/services/processWatcher.test.ts
@@ -14,6 +14,7 @@ import type vscode from 'vscode';
 import * as processWatcher from '../../../src/services/processWatcher';
 import { setSecretEnvVars } from '../../../src/services/navieConfigurationService';
 import * as authentication from '../../../src/authentication';
+import { clearCustomerId, setCustomerId } from '../../../src/configuration/customerId';
 
 // To be tested
 import {
@@ -24,9 +25,12 @@ import {
 
 const testModule = join(__dirname, 'support', 'simpleProcess.mjs');
 
-function makeWatcher(opts: Partial<ProcessWatcherOptions> = {}) {
+function makeWatcher(
+  opts: Partial<ProcessWatcherOptions> = {},
+  context: vscode.ExtensionContext = new MockExtensionContext()
+) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new ProcessWatcher(new MockExtensionContext(), {
+  return new ProcessWatcher(context, {
     id: 'test process' as unknown as ProcessId,
     modulePath: testModule,
     binPath: 'unused',
@@ -108,15 +112,66 @@ describe('ProcessWatcher', () => {
     });
   });
 
+  // The indexer and scanner are started and stopped by polling canStart() once a second, so
+  // an entitled installation that is not signed in must report enabled here or those services
+  // never run at all.
+  describe('canStart', () => {
+    const configuredDir = join(__dirname, '..', '..', 'fixtures', 'workspaces', 'project-base');
+
+    let context: MockExtensionContext;
+
+    beforeEach(() => {
+      context = new MockExtensionContext();
+    });
+
+    afterEach(() => clearCustomerId(context));
+
+    function watcher() {
+      return makeWatcher({ cwd: configuredDir }, context);
+    }
+
+    it('is enabled with a session', async () => {
+      expect(await watcher().canStart()).to.deep.equal({ enabled: true });
+    });
+
+    it('is disabled without a session and without a customer ID', async () => {
+      (authentication.getApiKey as Sinon.SinonStub).resolves(undefined);
+
+      expect(await watcher().canStart()).to.deep.equal({
+        enabled: false,
+        reason: 'User is not logged in to AppMap',
+      });
+    });
+
+    it('is enabled when entitled without a session', async () => {
+      (authentication.getApiKey as Sinon.SinonStub).resolves(undefined);
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+      expect(await watcher().canStart()).to.deep.equal({ enabled: true });
+    });
+
+    it('is still disabled when the directory is not configured, entitled or not', async () => {
+      await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+      const { enabled, reason } = await makeWatcher({ cwd: __dirname }, context).canStart();
+
+      expect(enabled).to.be.false;
+      expect(reason).to.include('is not configured');
+    });
+  });
+
   describe('loadEnvironment', () => {
     let context: vscode.ExtensionContext;
     beforeEach(() => {
       context = new MockExtensionContext();
     });
 
+    afterEach(() => clearCustomerId(context));
+
     describe('without OpenAI API key', () => {
       it('propagates the APPMAP_API_KEY', async () => {
         const env = await processWatcher.loadEnvironment(context);
+        expect(env).to.have.property('APPMAP_API_KEY', 'the-appmap-key');
         expect(env).to.not.have.property('OPENAI_API_KEY');
       });
     });
@@ -127,6 +182,41 @@ describe('ProcessWatcher', () => {
       it('propagates the OPENAI_API_KEY', async () => {
         const env = await processWatcher.loadEnvironment(context);
         expect(env).to.have.property('OPENAI_API_KEY', 'the-openai-key');
+      });
+    });
+
+    describe('without a session', () => {
+      beforeEach(() => (authentication.getApiKey as Sinon.SinonStub).resolves(undefined));
+
+      it('omits the APPMAP_API_KEY rather than passing an empty one', async () => {
+        const env = await processWatcher.loadEnvironment(context);
+        expect(env).to.not.have.property('APPMAP_API_KEY');
+      });
+
+      it('passes the customer ID in place of it when entitled', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        const env = await processWatcher.loadEnvironment(context);
+
+        expect(env).to.have.property('APPMAP_CUSTOMER_ID', 'acme-corp');
+        expect(env).to.not.have.property('APPMAP_API_KEY');
+      });
+    });
+
+    describe('with a session', () => {
+      it('omits the customer ID when there is none', async () => {
+        const env = await processWatcher.loadEnvironment(context);
+        expect(env).to.not.have.property('APPMAP_CUSTOMER_ID');
+      });
+
+      // The API key wins for authentication; the customer ID is attribution-only.
+      it('passes both when a customer ID is also set', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        const env = await processWatcher.loadEnvironment(context);
+
+        expect(env).to.have.property('APPMAP_API_KEY', 'the-appmap-key');
+        expect(env).to.have.property('APPMAP_CUSTOMER_ID', 'acme-corp');
       });
     });
   });

--- a/test/unit/services/rpcProcessService.test.ts
+++ b/test/unit/services/rpcProcessService.test.ts
@@ -15,6 +15,7 @@ import { waitFor } from '../../waitFor';
 import vscode from '../mock/vscode';
 import { Configuration } from '../mock/vscode/workspace';
 import { getSecretEnv } from '../../../src/services/navieConfigurationService';
+import { setCustomerId } from '../../../src/configuration/customerId';
 
 chai.use(chaiAsPromised);
 
@@ -197,6 +198,74 @@ describe('RpcProcessService', () => {
       rpcService.scheduleRestart();
 
       await waitFor(`Expecting debounced restart`, () => restartSpy.calledOnce);
+    });
+  });
+
+  // Navie's backend should only run for an activated extension. Anything else leaves a server
+  // listening for a user who has not signed in and is not entitled.
+  describe('when the extension is neither signed in nor entitled', () => {
+    beforeEach(() => {
+      stubRpcConfiguration();
+      delete process.env.APPMAP_TEST_API_KEY;
+    });
+
+    it('does not start the RPC server', async () => {
+      await rpcServiceState.waitForStartup();
+
+      expect(rpcService.available).to.be.false;
+      expect(rpcService.port()).to.be.undefined;
+    });
+
+    it('does not start it on restart either', async () => {
+      await rpcService.restart();
+
+      expect(rpcService.available).to.be.false;
+    });
+
+    it('starts once a customer ID entitles the installation', async () => {
+      await rpcServiceState.waitForStartup();
+      expect(rpcService.available).to.be.false;
+
+      await setCustomerId(extensionContext, 'acme-corp', 'orgConfig');
+      await rpcService.restart();
+
+      await waitFor('RPC server to become available', () => rpcService.available);
+    });
+
+    it('starts once the user signs in', async () => {
+      await rpcServiceState.waitForStartup();
+      expect(rpcService.available).to.be.false;
+
+      process.env.APPMAP_TEST_API_KEY = 'test-key';
+      await rpcService.restart();
+
+      await waitFor('RPC server to become available', () => rpcService.available);
+    });
+  });
+
+  describe('when authentication is lost while running', () => {
+    beforeEach(async () => {
+      stubRpcConfiguration();
+      await rpcServiceState.waitForStartup();
+      await waitFor('RPC server to become available', () => rpcService.available);
+    });
+
+    it('stops the RPC server', async () => {
+      delete process.env.APPMAP_TEST_API_KEY;
+
+      await rpcService.restart();
+
+      expect(rpcService.available).to.be.false;
+    });
+
+    // A stale port sends callers to a dead socket, where they hang instead of failing.
+    it('reports no port once the server has stopped', async () => {
+      expect(rpcService.port()).to.be.greaterThan(0);
+      delete process.env.APPMAP_TEST_API_KEY;
+
+      await rpcService.restart();
+
+      expect(rpcService.port()).to.be.undefined;
     });
   });
 

--- a/test/unit/sidebarSignIn.test.ts
+++ b/test/unit/sidebarSignIn.test.ts
@@ -12,7 +12,7 @@ import { waitFor } from '../waitFor';
 
 describe('Sidebar sign-in', () => {
   let sandbox: sinon.SinonSandbox;
-  let stubbedExecuteCommand: sinon.SinonStub<[], void>;
+  let stubbedExecuteCommand: sinon.SinonStub;
   let getApiKeyStub: sinon.SinonStub<
     [createIfNone: boolean, ssoTarget?: string],
     Promise<string | undefined>

--- a/test/unit/sidebarSignIn.test.ts
+++ b/test/unit/sidebarSignIn.test.ts
@@ -6,6 +6,7 @@ import * as auth from '../../src/authentication';
 import SignInManager from '../../src/services/signInManager';
 import MockExtensionContext from '../mocks/mockExtensionContext';
 import ExtensionState from '../../src/configuration/extensionState';
+import { clearCustomerId, setCustomerId } from '../../src/configuration/customerId';
 
 import { waitFor } from '../waitFor';
 
@@ -29,15 +30,20 @@ describe('Sidebar sign-in', () => {
     getApiKeyStub = sandbox.stub(auth, 'getApiKey');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // register() subscribes to entitlement changes; without this the listeners accumulate
+    // across cases, since SignInManager keeps its state statically and the context is shared.
+    context.subscriptions.forEach((subscription) => subscription.dispose());
+    context.subscriptions.length = 0;
     sandbox.restore();
+    await clearCustomerId(context);
   });
 
   it('is not shown for an existing user who is logged in and then logs out', async () => {
     getApiKeyStub.returns(Promise.resolve(fakeApiKey));
     sandbox.stub(extensionState, 'firstVersionInstalled').value(existingUserVersion);
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register(extensionState, context);
     await expectShowSignIn(false);
 
     // user logs out
@@ -50,7 +56,7 @@ describe('Sidebar sign-in', () => {
     getApiKeyStub.returns(Promise.resolve(fakeApiKey));
     sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register(extensionState, context);
     await expectShowSignIn(false);
 
     // user logs out
@@ -63,7 +69,7 @@ describe('Sidebar sign-in', () => {
     getApiKeyStub.returns(Promise.resolve(noApiKey));
     sandbox.stub(extensionState, 'firstVersionInstalled').value(existingUserVersion);
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register(extensionState, context);
     await expectShowSignIn(false);
 
     // user logs in
@@ -76,13 +82,75 @@ describe('Sidebar sign-in', () => {
     getApiKeyStub.returns(Promise.resolve(noApiKey));
     sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
 
-    await SignInManager.register(extensionState);
+    await SignInManager.register(extensionState, context);
     await expectShowSignIn(true);
 
     // user logs in
     getApiKeyStub.returns(Promise.resolve(fakeApiKey));
     await SignInManager.updateSignInState();
     await expectShowSignIn(false);
+  });
+
+  it('is not shown for a new user with no API key when a customer ID entitles the installation', async () => {
+    getApiKeyStub.returns(Promise.resolve(noApiKey));
+    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
+    await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+    await SignInManager.register(extensionState, context);
+
+    await expectShowSignIn(false);
+  });
+
+  it('does not consult the API key at all when entitled', async () => {
+    getApiKeyStub.returns(Promise.resolve(noApiKey));
+    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
+    await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+    await SignInManager.register(extensionState, context);
+    await expectShowSignIn(false);
+
+    assert(getApiKeyStub.notCalled);
+  });
+
+  it('is shown again once entitlement is cleared', async () => {
+    getApiKeyStub.returns(Promise.resolve(noApiKey));
+    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
+    await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+    await SignInManager.register(extensionState, context);
+    await expectShowSignIn(false);
+
+    await clearCustomerId(context);
+    await SignInManager.updateSignInState();
+
+    await expectShowSignIn(true);
+  });
+
+  // globalState fires no change event of its own, so an entitlement that arrives mid-session
+  // has to be announced or the sign-in view stays up until the window reloads.
+  it('hides itself when a customer ID arrives mid-session', async () => {
+    getApiKeyStub.returns(Promise.resolve(noApiKey));
+    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
+
+    await SignInManager.register(extensionState, context);
+    await expectShowSignIn(true);
+
+    await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+    await expectShowSignIn(false);
+  });
+
+  it('reappears when entitlement is withdrawn mid-session', async () => {
+    getApiKeyStub.returns(Promise.resolve(noApiKey));
+    sandbox.stub(extensionState, 'firstVersionInstalled').value(newUserVersion);
+    await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+    await SignInManager.register(extensionState, context);
+    await expectShowSignIn(false);
+
+    await clearCustomerId(context);
+
+    await expectShowSignIn(true);
   });
 
   async function expectShowSignIn(value: boolean): Promise<void> {

--- a/test/unit/telemetry/index.test.ts
+++ b/test/unit/telemetry/index.test.ts
@@ -8,6 +8,7 @@ import TelemetryReporter from 'vscode-extension-telemetry';
 import ExtensionSettings from '../../../src/configuration/extensionSettings';
 import { Telemetry } from '../../../src/telemetry';
 import SplunkTelemetryReporter from '../../../src/telemetry/splunkTelemetryReporter';
+import { clearCustomerId, setCustomerId } from '../../../src/configuration/customerId';
 
 import MockExtensionContext from '../../mocks/mockExtensionContext';
 
@@ -96,5 +97,134 @@ describe('Telemetry', () => {
 
     expect(disposeSpy.called).to.be.false;
     expect(Telemetry.getReporter()).to.equal(initialReporter);
+  });
+
+  // Every entry point funnels through Telemetry.send, so the common-property stamp cannot be
+  // omitted by accident. The shared cases drive all four.
+  describe('common properties', () => {
+    let sendEvent: Sinon.SinonStub;
+    let sendErrorEvent: Sinon.SinonStub;
+
+    function registerWith(telemetryConfig: Record<string, unknown>) {
+      Sinon.stub(ExtensionSettings, 'telemetryConfiguration').get(() => telemetryConfig);
+      Telemetry.register(context);
+      sendEvent = Sinon.stub(Telemetry.getReporter(), 'sendTelemetryEvent');
+      sendErrorEvent = Sinon.stub(Telemetry.getReporter(), 'sendTelemetryErrorEvent');
+    }
+
+    // Sends one event through each of the four entry points and returns the properties each
+    // one actually handed to the reporter.
+    async function propertiesFromEveryEntryPoint(): Promise<Record<string, string>[]> {
+      await Telemetry.sendEvent({ name: 'test_event' });
+      Telemetry.reportAction('test_action', { 'appmap.some.property': 'value' });
+      Telemetry.reportWebviewError({ message: 'boom', stack: 'stack' });
+      Telemetry.reportOpenUri(vscode.Uri.parse('file:///tmp/x.appmap.json'));
+
+      expect(sendEvent.callCount).to.equal(3);
+      expect(sendErrorEvent.callCount).to.equal(1);
+
+      return [...sendEvent.getCalls(), ...sendErrorEvent.getCalls()].map(
+        (call) => call.args[1] as Record<string, string>
+      );
+    }
+
+    afterEach(() => clearCustomerId(context));
+
+    // Behavior that must hold whichever backend is configured.
+    function itStampsTheCustomerId() {
+      it('omits common.customerid when no customer ID is set', async () => {
+        for (const properties of await propertiesFromEveryEntryPoint()) {
+          expect(properties).to.not.have.property('common.customerid');
+        }
+      });
+
+      it('stamps common.customerid on every entry point', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        for (const properties of await propertiesFromEveryEntryPoint()) {
+          expect(properties).to.have.property('common.customerid', 'acme-corp');
+        }
+      });
+
+      it('reads the customer ID per event rather than at registration', async () => {
+        Telemetry.reportAction('before');
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+        Telemetry.reportAction('after');
+
+        expect(sendEvent.firstCall.args[1]).to.not.have.property('common.customerid');
+        expect(sendEvent.secondCall.args[1]).to.have.property('common.customerid', 'acme-corp');
+      });
+
+      it('preserves the properties of the event itself', async () => {
+        Telemetry.reportAction('test_action', { 'appmap.some.property': 'value' });
+
+        expect(sendEvent.firstCall.args[1]).to.have.property('appmap.some.property', 'value');
+      });
+
+      it('lets an event property override a common one', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        Telemetry.reportAction('test_action', { 'common.customerid': 'overridden' });
+
+        expect(sendEvent.firstCall.args[1]).to.have.property('common.customerid', 'overridden');
+      });
+    }
+
+    describe('on the Application Insights backend', () => {
+      beforeEach(() => registerWith({}));
+
+      itStampsTheCustomerId();
+
+      // The SDK supplies the rest of the common.* set, but not these two.
+      it('adds common.ide and common.ideversion', async () => {
+        for (const properties of await propertiesFromEveryEntryPoint()) {
+          expect(properties).to.have.property('common.ide', vscode.env.appName);
+          expect(properties).to.have.property('common.ideversion', vscode.version);
+        }
+      });
+    });
+
+    describe('on the Splunk backend', () => {
+      beforeEach(() => registerWith(SPLUNK_CONFIG));
+
+      itStampsTheCustomerId();
+
+      it('leaves common.ide and common.ideversion to the reporter', async () => {
+        for (const properties of await propertiesFromEveryEntryPoint()) {
+          expect(properties).to.not.have.property('common.ide');
+          expect(properties).to.not.have.property('common.ideversion');
+        }
+      });
+    });
+
+    describe('with APPMAP_TELEMETRY_DEBUG set', () => {
+      let channel: { lines: string[]; clear(): void };
+
+      beforeEach(() => {
+        process.env.APPMAP_TELEMETRY_DEBUG = 'true';
+        const createOutputChannel = Sinon.spy(vscode.window, 'createOutputChannel');
+
+        registerWith({});
+
+        channel = createOutputChannel.returnValues[0] as unknown as typeof channel;
+        channel.clear(); // drop the reporter-selection line register() writes
+      });
+
+      afterEach(() => {
+        delete process.env.APPMAP_TELEMETRY_DEBUG;
+        // The debug channel is static and register() never clears it.
+        (Telemetry as unknown as { debugChannel?: vscode.OutputChannel }).debugChannel = undefined;
+      });
+
+      it('logs exactly what it hands to the reporter', async () => {
+        await setCustomerId(context, 'acme-corp', 'orgConfig');
+
+        Telemetry.reportOpenUri(vscode.Uri.parse('file:///tmp/x.appmap.json'));
+
+        const logged = JSON.parse(channel.lines.join('\n'));
+        expect(logged.event).to.match(/\/open_uri$/);
+        expect(logged.properties).to.deep.equal(sendEvent.firstCall.args[1]);
+      });
+    });
   });
 });

--- a/test/unit/webviews/chatSearchWebview.test.ts
+++ b/test/unit/webviews/chatSearchWebview.test.ts
@@ -3,10 +3,13 @@ import '../mock/vscode';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import vscode from '../mock/vscode';
+
+import * as isActivatedModule from '../../../src/authentication/isActivated';
 import CommandRegistry from '../../../src/commands/commandRegistry';
 import ExtensionState from '../../../src/configuration/extensionState';
 import RpcProcessService from '../../../src/services/rpcProcessService';
-import ChatSearchWebview from '../../../src/webviews/chatSearchWebview';
+import ChatSearchWebview, { ExplainResponseStatus } from '../../../src/webviews/chatSearchWebview';
 
 import MockAppMapCollection from '../../mocks/mockAppMapCollection';
 import MockExtensionContext from '../../mocks/mockExtensionContext';
@@ -56,6 +59,46 @@ describe('ChatSearchWebview', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  // The RPC server only runs for an activated extension, so "no port" is the normal state for
+  // a signed-out user, not a failure. Reporting it as one sends them to an output log that
+  // explains nothing.
+  describe('when the RPC server is not running', () => {
+    beforeEach(() => rpcService.port.returns(undefined));
+
+    it('offers to sign in when the extension is not activated', async () => {
+      sandbox.stub(isActivatedModule, 'default').resolves(false);
+      const showInformationMessage = sandbox
+        .stub(vscode.window, 'showInformationMessage')
+        .resolves(undefined);
+
+      const result = await chatSearchWebview.explain();
+
+      expect(WebviewPanels).to.be.empty;
+      expect(result.status).to.equal(ExplainResponseStatus.NoAppMapRpcPort);
+      expect(String(showInformationMessage.firstCall.args[0])).to.match(/sign in/i);
+    });
+
+    it('runs the sign-in command when the user accepts', async () => {
+      sandbox.stub(isActivatedModule, 'default').resolves(false);
+      sandbox.stub(vscode.window, 'showInformationMessage').resolves('Sign In' as never);
+      const executeCommand = sandbox.stub(vscode.commands, 'executeCommand');
+
+      await chatSearchWebview.explain();
+
+      expect(executeCommand.calledWith('appmap.login')).to.be.true;
+    });
+
+    it('still reports a genuine startup failure when the extension is activated', async () => {
+      sandbox.stub(isActivatedModule, 'default').resolves(true);
+      const showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+
+      const result = await chatSearchWebview.explain();
+
+      expect(result.status).to.equal(ExplainResponseStatus.NoAppMapRpcPort);
+      expect(String(showErrorMessage.firstCall.args[0])).to.include('unable to start');
+    });
   });
 
   it('should process change-model-config for non-secret env variables', async () => {


### PR DESCRIPTION
Adds the unverified `appMap.customerId` field to support managed B2B
deployments. When present, it transitions the extension into an entitled
state without requiring authentication, passing `APPMAP_CUSTOMER_ID` to
subprocesses while omitting the `APPMAP_API_KEY`.

Includes telemetry event stamping, remote configuration integration,
synchronous re-seeding on clearing, override warnings, and comprehensive
unit test coverage.